### PR TITLE
New HTML5 block elements

### DIFF
--- a/markdown/util.py
+++ b/markdown/util.py
@@ -18,7 +18,9 @@ Constants you might want to modify
 BLOCK_LEVEL_ELEMENTS = re.compile("p|div|h[1-6]|blockquote|pre|table|dl|ol|ul"
                                   "|script|noscript|form|fieldset|iframe|math"
                                   "|ins|del|hr|hr/|style|li|dt|dd|thead|tbody"
-                                  "|tr|th|td")
+                                  "|tr|th|td|section|footer|header|group|figure"
+                                  "|figcaption|aside|article|canvas|output"
+                                  "|progress|video")
 # Placeholders
 STX = u'\u0002'  # Use STX ("Start of text") for start-of-placeholder
 ETX = u'\u0003'  # Use ETX ("End of text") for end-of-placeholder

--- a/tests/misc/block_html5.html
+++ b/tests/misc/block_html5.html
@@ -1,0 +1,16 @@
+<section>
+    <header>
+        <hgroup>
+            <h1>Hello :-)</h1>
+        </hgroup>
+    </header>
+    <figure>
+        <img src="image.png" alt="" />
+        <figcaption>Caption</figcaption>
+    </figure>
+    <footer>
+        <p>Some footer</p>
+    </footer>
+</section>
+
+<figure></figure>

--- a/tests/misc/block_html5.txt
+++ b/tests/misc/block_html5.txt
@@ -1,0 +1,14 @@
+<section>
+    <header>
+        <hgroup>
+            <h1>Hello :-)</h1>
+        </hgroup>
+    </header>
+    <figure>
+        <img src="image.png" alt="" />
+        <figcaption>Caption</figcaption>
+    </figure>
+    <footer>
+        <p>Some footer</p>
+    </footer>
+</section><figure></figure>


### PR DESCRIPTION
Currently markdown tries to wrap all the new HTML5 block-level elements with paragraph. This patch should solve this :-)
