### PR TITLE
Have the HeaderId extension preserve periods when generating ids from headings

### DIFF
--- a/markdown/extensions/headerid.py
+++ b/markdown/extensions/headerid.py
@@ -73,7 +73,7 @@ import logging
 
 logger = logging.getLogger('MARKDOWN')
 
-ID_CHARS = ascii_lowercase + digits + '-_'
+ID_CHARS = ascii_lowercase + digits + '-_.'
 IDCOUNT_RE = re.compile(r'^(.*)_([0-9]+)$')
 
 


### PR DESCRIPTION
I'm about to publish some documentation. At the moment I have…

```
#### `document.author` #### {#document.author}
```

and dozens of similar occurrences. This strikes me as unnecessary repetition. Without declaring the ids explicitly, though, the periods are omitted from the generated ids.

If accepted, this patch will result in automatically generated ids changing in a small proportion of cases. The upside is significant, though, so I believe it's worth the cost.

For the sake of consistency, I suggest that colons be preserved too, so that the four punctuation characters that may be included in explicit ids are also preserved when ids are inferred.

Preserving colons is more contentious than preserving periods, though. While one likely wishes to preserve the colons in "Hash::set", one may not want the colon in "Approach 3: JavaScript trickery" to be preserved. Since headings should not end in a period, any periods present are likely to be significant, as in the case in the first example.

I thought it wise to leave the colon out for now. Apparently I'm a one character per pull request kinda guy. :)
