### PR TITLE
allow language guessing to be disabled by passing a setting to CodeHilite

### DIFF
--- a/docs/extensions/CodeHilite.txt
+++ b/docs/extensions/CodeHilite.txt
@@ -111,3 +111,10 @@ to do so.
     >>> html = markdown.markdown(text, 
     ...     ['codehilite(force_linenos=True)']
     ... )
+
+If you want to prevent Pygments from guessing the language, only highlighting
+blocks when you explicitly request it, set the `guess_lang` setting to 'False'.
+
+    >>> html = markdown.markdown(text,
+    ...     ['codehilite(guess_lang=True)']
+    ... )

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -117,6 +117,7 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
                 if self.codehilite_conf:
                     highliter = CodeHilite(m.group('code'),
                             linenos=self.codehilite_conf['force_linenos'],
+                            guess_lang=self.codehilite_conf['guess_lang'],
                             css_class=self.codehilite_conf['css_class'],
                             style=self.codehilite_conf['pygments_style'],
                             lang=(m.group('lang') or None),


### PR DESCRIPTION
This allows a user to turn off guessing in CodeHilite with `codehilite(guess_lang=False)`. Let me know if I’ve overlooked anything that needs to be changed.
#### Some changes that require explanation
1. I added some checks for certain string values and converted them to booleans. This allows `guess_lang=False` to function correctly. Without the change, you’d have the _string_ ‘False’, which is non-empty and evaluates to the boolean True. (This will also prevent some unexpected behavior with the `force_linenos` setting. Prior to the change, both `force_linenos=True` and `force_linenos=False` would turn the setting on.) I tried to solve this in a more general way by checking values in `extensios/__init__.py`, but that doesn’t seem to get used for the CodeHilite extension so I left it alone. I’ll let you decide whether or not similar conversions should be done there.
2. I noticed a line with `== None` and changed it to `is None` instead. I just did [something](https://github.com/skurfer/Python-Markdown/pull/new/noGuessing#L1R210) recently that checked for `None`, and then happened to read PEP8 right after, so it stood out in my mind. I’m not that picky, nor do I have PEP8 memorized. :)
