### PR TITLE
Allow tables to have leading whitespace

### DIFF
--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -22,7 +22,7 @@ class TableProcessor(markdown.blockprocessors.BlockProcessor):
     """ Process Tables. """
 
     def test(self, parent, block):
-        rows = block.split('\n')
+        rows = [r.strip() for r in block.split('\n')]
         return (len(rows) > 2 and '|' in rows[0] and 
                 '|' in rows[1] and '-' in rows[1] and 
                 rows[1][0] in ['|', ':', '-'])

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -76,10 +76,7 @@ class TableProcessor(markdown.blockprocessors.BlockProcessor):
     def _split_row(self, row, border):
         """ split a row of text into list of cells. """
         if border:
-            if row.startswith('|'):
-                row = row[1:]
-            if row.endswith('|'):
-                row = row[:-1]
+            row = row.strip('|')
         return row.split('|')
 
 


### PR DESCRIPTION
This change allows tables to be preceded with 0-3 spaces (which PHP Markdown Extra also allows). As we all know very well, there’s no standard for tables, but since the Python implementation claims to support the PHP syntax, they might as well be consistent, right?

(Translation: I have a bunch of documents with tables indented two spaces because I was using PHP and they fall apart in Python-Markdown, which I use more and more. I don’t want to go back and edit everything, plus I think the text is easier to parse visually that way.)

In the other commit, I just replaced all the testing and array slicing with a simple call to `strip()`. Technically, this is a slight change in behavior since `strip()` will get multiple occurrences of the character, but in my testing, two pipes are already being stripped somehow (and PHP Markdown Extra won’t even recognize it as a table), so I feel like the change is safe.
