### PR TITLE
A tiny edit that allows "+" and "|" in the table separator row

### DIFF
--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -81,6 +81,7 @@ class TableProcessor(markdown.blockprocessors.BlockProcessor):
                 row = row[1:]
             if row.endswith('|'):
                 row = row[:-1]
+            row = row.replace('+', '|') 
         return row.split('|')
 
 


### PR DESCRIPTION
A tiny edit that allows both "+" and of "|" in the separator row of a table. 

This is useful (to me) because it allows me to use org-mode in emacs to edit tables.

Uncertain if this break compliance with markdown - I could not find an official definition for table syntax.
