### PR TITLE
New configuration option for footnote extension: BACKLINK_TEXT

### DIFF
--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -118,12 +118,12 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
                 # is enabled, so we call it to highlite the code
                 if self.codehilite_conf:
                     highliter = CodeHilite(m.group('code'),
-                            linenos=self.codehilite_conf['force_linenos'],
-                            guess_lang=self.codehilite_conf['guess_lang'],
-                            css_class=self.codehilite_conf['css_class'],
-                            style=self.codehilite_conf['pygments_style'],
+                            linenos=self.codehilite_conf['force_linenos'][0],
+                            guess_lang=self.codehilite_conf['guess_lang'][0],
+                            css_class=self.codehilite_conf['css_class'][0],
+                            style=self.codehilite_conf['pygments_style'][0],
                             lang=(m.group('lang') or None),
-                            noclasses=self.codehilite_conf['noclasses'])
+                            noclasses=self.codehilite_conf['noclasses'][0])
 
                     code = highliter.hilite()
                 else:

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -74,9 +74,8 @@ class FootnoteExtension(markdown.Extension):
         md.treeprocessors.add("footnote", FootnoteTreeprocessor(self),
                                  "<inline")
         # Insert a postprocessor after amp_substitute oricessor
-        # (pass BACKLINK_TEXT config value to it because the Postprocessor can't get it otherwise.)
-        md.postprocessors.add("footnote", FootnotePostprocessor(
-            self.getConfig("BACKLINK_TEXT"), self), ">amp_substitute")
+        md.postprocessors.add("footnote", FootnotePostprocessor(self),
+                ">amp_substitute")
 
     def reset(self):
         """ Clear the footnotes on reset, and prepare for a distinct document. """
@@ -287,12 +286,11 @@ class FootnoteTreeprocessor(markdown.treeprocessors.Treeprocessor):
 
 class FootnotePostprocessor(markdown.postprocessors.Postprocessor):
     """ Replace placeholders with html entities. """
-    def __init__(self, backlink, *args):
-        self.backlink = backlink
-        markdown.postprocessors.Postprocessor.__init__(self, *args)
+    def __init__(self, footnotes):
+        self.footnotes = footnotes
 
     def run(self, text):
-        text = text.replace(FN_BACKLINK_TEXT, self.backlink)
+        text = text.replace(FN_BACKLINK_TEXT, self.footnotes.getConfig("BACKLINK_TEXT"))
         return text.replace(NBSP_PLACEHOLDER, "&#160;")
 
 def makeExtension(configs=[]):


### PR DESCRIPTION
> BACKLINK_TEXT specifies the text that's used in the link at the end of
> the footnote to link back up to the reader's place. It still defaults to
> "&#8617;".

I thought this might be useful.
