### PR TITLE
New footnotes configuration option: BACKLINK_TEXT (second try)

### DIFF
--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -290,8 +290,8 @@ class FootnotePostprocessor(markdown.postprocessors.Postprocessor):
         self.footnotes = footnotes
 
     def run(self, text):
-        text = text.replace(FN_BACKLINK_TEXT, "&#8617;")
-        return text.replace(NBSP_PLACEHOLDER, self.footnotes.getConfig("BACKLINK_TEXT"))
+        text = text.replace(FN_BACKLINK_TEXT, self.footnotes.getConfig("BACKLINK_TEXT"))
+        return text.replace(NBSP_PLACEHOLDER, "&#160;")
 
 def makeExtension(configs=[]):
     """ Return an instance of the FootnoteExtension """

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -43,7 +43,11 @@ class FootnoteExtension(markdown.Extension):
                        'UNIQUE_IDS':
                        [False,
                         "Avoid name collisions across "
-                        "multiple calls to reset()."]}
+                        "multiple calls to reset()."],
+                       "BACKLINK_TEXT":
+                       ["&#8617;",
+                        "The text string that links from the footnote to the reader's place."]
+                       }
 
         for key, value in configs:
             self.config[key][0] = value
@@ -282,10 +286,12 @@ class FootnoteTreeprocessor(markdown.treeprocessors.Treeprocessor):
 
 class FootnotePostprocessor(markdown.postprocessors.Postprocessor):
     """ Replace placeholders with html entities. """
+    def __init__(self, footnotes):
+        self.footnotes = footnotes
 
     def run(self, text):
         text = text.replace(FN_BACKLINK_TEXT, "&#8617;")
-        return text.replace(NBSP_PLACEHOLDER, "&#160;")
+        return text.replace(NBSP_PLACEHOLDER, self.footnotes.getConfig("BACKLINK_TEXT"))
 
 def makeExtension(configs=[]):
     """ Return an instance of the FootnoteExtension """


### PR DESCRIPTION
> BACKLINK_TEXT specifies the text that's used in the link at the end of
> the footnote to link back up to the reader's place. It still defaults to "&#8617;".

Since I'm apparently awful at pull requests, I realized the best way to do this was to close the original and start with a clean commit in a new branch. So here's that. Sorry for the confusion and for being confused, and I hope this is helpful.

Here's the [original pull request](https://github.com/waylan/Python-Markdown/pull/62), for future reference.
