### PR TITLE
Adding support for MySQL style tables to table extension

### DIFF
--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -23,14 +23,24 @@ class TableProcessor(markdown.blockprocessors.BlockProcessor):
 
     def test(self, parent, block):
         rows = block.split('\n')
-        return (len(rows) > 2 and '|' in rows[0] and 
-                '|' in rows[1] and '-' in rows[1] and 
-                rows[1].strip()[0] in ['|', ':', '-'])
+        # PHP extra format
+        if (len(rows) > 2 and '|' in rows[0] and
+            '|' in rows[1] and '-' in rows[1] and
+            rows[1].strip()[0] in ['|', ':', '-']):
+            return True
+        # MySQL format
+        if (len(rows) > 4 and '+' in rows[0] and
+            '|' in rows[1] and '-' in rows[2] and
+            rows[2].strip()[0] == '+'):
+            return True
 
     def run(self, parent, blocks):
         """ Parse a table block and build table. """
         block = blocks.pop(0).split('\n')
         header = block[0].strip()
+        if header.startswith('+'):
+            block = block[1:-1]
+            header = block[0].strip()
         seperator = block[1].strip()
         rows = block[2:]
         # Get format type (bordered by pipes or not)
@@ -76,12 +86,16 @@ class TableProcessor(markdown.blockprocessors.BlockProcessor):
 
     def _split_row(self, row, border):
         """ split a row of text into list of cells. """
+        sep = '|'
         if border:
             if row.startswith('|'):
                 row = row[1:]
-            if row.endswith('|'):
+            elif row.startswith('+'):
+                sep = '+'
+                row = row[1:]
+            if row.endswith(sep):
                 row = row[:-1]
-        return row.split('|')
+        return row.split(sep)
 
 
 class TableExtension(markdown.Extension):

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -117,6 +117,27 @@
 </tr>
 </tbody>
 </table>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Null</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>username</td>
+<td>varchar(255)</td>
+<td>NO</td>
+</tr>
+<tr>
+<td>password</td>
+<td>varchar(255)</td>
+<td>NO</td>
+</tr>
+</tbody>
+</table>
 <p>Three spaces in front of a table:</p>
 <table>
 <thead>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -32,6 +32,13 @@ foo|bar|baz
    | Q |
  W |   | W
 
++------------+--------------+------+
+| Field      | Type         | Null |
++------------+--------------+------+
+| username   | varchar(255) | NO   |
+| password   | varchar(255) | NO   |
++------------+--------------+------+
+
 Three spaces in front of a table:
 
    First Header | Second Header


### PR DESCRIPTION
Adding support for tables that look like this:

```
+------------+--------------+------+
| Field      | Type         | Null |
+------------+--------------+------+
| username   | varchar(255) | NO   |
| password   | varchar(255) | NO   |
+------------+--------------+------+
```

The differences from the currently support format are the addition of the top and bottom lines, and the use of the `+` on borders. This would be an extension of the format supported by PHP Markdown extra, but I think it's worthwhile and the implementation is simple.
