### PR TITLE
Remove `<del>` and `<ins>` from block-level elements list

### DIFF
--- a/markdown/util.py
+++ b/markdown/util.py
@@ -17,7 +17,7 @@ Constants you might want to modify
 
 BLOCK_LEVEL_ELEMENTS = re.compile("^(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul"
                                   "|script|noscript|form|fieldset|iframe|math"
-                                  "|ins|del|hr|hr/|style|li|dt|dd|thead|tbody"
+                                  "|hr|hr/|style|li|dt|dd|thead|tbody"
                                   "|tr|th|td|section|footer|header|group|figure"
                                   "|figcaption|aside|article|canvas|output"
                                   "|progress|video)$")


### PR DESCRIPTION
They are span elements. `<del>` is explicitly mentioned as such in the [markdown syntax document](http://daringfireball.net/projects/markdown/syntax)

This fixes #92 and does not cause any tests to fail.
