### PR TITLE
Fixed typo in docs: 'md.treepreprocessor' for 'md.treeprocessor'. 

### DIFF
--- a/docs/extensions/api.txt
+++ b/docs/extensions/api.txt
@@ -388,7 +388,7 @@ accepts two arguments:
     * ``md.preprocessors``
     * ``md.inlinePatterns``
     * ``md.parser.blockprocessors``
-    * ``md.treepreprocessors``
+    * ``md.treeprocessors``
     * ``md.postprocessors``
 
     Some other things you may want to access in the markdown instance are:


### PR DESCRIPTION
Spent some extra time debugging my code because of this typo...
