### PR TITLE
More expressive ValueError description

### DIFF
--- a/markdown/odict.py
+++ b/markdown/odict.py
@@ -117,7 +117,11 @@ class OrderedDict(dict):
 
     def index(self, key):
         """ Return the index of a given key. """
-        return self.keyOrder.index(key)
+        try:
+            return self.keyOrder.index(key)
+        except ValueError, e:
+            raise KeyError("Element '%s' was not found in OrderedDict")
+            
 
     def index_for_location(self, location):
         """ Return index or None for a given location. """

--- a/markdown/odict.py
+++ b/markdown/odict.py
@@ -117,7 +117,11 @@ class OrderedDict(dict):
 
     def index(self, key):
         """ Return the index of a given key. """
-        return self.keyOrder.index(key)
+        try:
+            return self.keyOrder.index(key)
+        except ValueError, e:
+            raise KeyError("Element '%s' was not found in OrderedDict" % key)
+            
 
     def index_for_location(self, location):
         """ Return index or None for a given location. """


### PR DESCRIPTION
More expressive ValueError description on adding before or after nonexistent middleware ('location' parameter of add method of processor). 

Old error message: 
ValueError: list.index(x): x not in list

New error message:
ValueError: Element 'extension' was not found in OrderedDict

Sorry for mess with commits... Had a typo there. ;)
