### PR TITLE
Fixed UnicodeEncodeError when output from markdown_py is piped

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -373,7 +373,8 @@ class Markdown:
                 output_file.write(html)
                 # Don't close here. User may want to write more.
         else:
-            sys.stdout.write(html)
+            stdout = codecs.getwriter(encoding)(sys.stdout, errors="xmlcharrefreplace")
+            stdout.write(html)
 
         return self
 


### PR DESCRIPTION
When output is piped into another program, UnicodeEncodeError because Python 2.x can't determine system encoding.

To check this bug, try: `cat some.txt | markdown_py | cat'. 

To fix the bug result have to be encoded into the output encoding explicitly, because sys.stdout.encoding is None, when piping data.
