### PR TITLE
Fix unicode problem in headerid extension

### DIFF
--- a/markdown/extensions/headerid.py
+++ b/markdown/extensions/headerid.py
@@ -137,7 +137,7 @@ class HeaderIdTreeprocessor(markdown.treeprocessors.Treeprocessor):
                     if "id" in elem.attrib:
                         id = elem.id
                     else:
-                        id = slugify(''.join(itertext(elem)), sep)
+                        id = slugify(u''.join(itertext(elem)), sep)
                     elem.set('id', unique(id, self.IDs))
                 if start_level:
                     level = int(elem.tag[-1]) + start_level


### PR DESCRIPTION
slugify() requires unicode, not a str instance. This causes the extension to
crash:

File "/home/erik/virtualenv/bb/local/lib/python2.7/site-packages/markdown/**init**.py" in markdown
1.     return md.convert(text)
   File "/home/erik/virtualenv/bb/local/lib/python2.7/site-packages/markdown/**init**.py" in convert
2.             newRoot = treeprocessor.run(root)
   File "/home/erik/virtualenv/bb/local/lib/python2.7/site-packages/markdown/extensions/headerid.py" in run
3.                         id = slugify(''.join(itertext(elem)), sep)
   File "/home/erik/virtualenv/bb/local/lib/python2.7/site-packages/markdown/extensions/headerid.py" in slugify
4.     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')

TypeError: must be unicode, not str
