### PR TITLE
toc extension: Add a 'id="toc"' attribute in toc div 

### DIFF
--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -27,6 +27,7 @@ class TocTreeprocessor(markdown.treeprocessors.Treeprocessor):
 
         div = etree.Element("div")
         div.attrib["class"] = "toc"
+        div.attrib["id"] = "toc"
         last_li = None
 
         # Add title to the div

--- a/tests/extensions/toc.html
+++ b/tests/extensions/toc.html
@@ -1,4 +1,4 @@
-<div class="toc">
+<div class="toc" id="toc">
 <ul>
 <li><a href="#overview">Overview</a><ul>
 <li><a href="#philosophy">Philosophy</a></li>

--- a/tests/extensions/toc_nested.html
+++ b/tests/extensions/toc_nested.html
@@ -2,7 +2,7 @@
 <h2 id="header-1">Header 1</h2>
 <h3 id="header-i">Header i</h3>
 <h1 id="header-b">Header B</h1>
-<div class="toc">
+<div class="toc" id="toc">
 <ul>
 <li><a href="#header-a">Header A</a><ul>
 <li><a href="#header-1">Header 1</a><ul>

--- a/tests/extensions/toc_nested2.html
+++ b/tests/extensions/toc_nested2.html
@@ -1,4 +1,4 @@
-<div class="toc">
+<div class="toc" id="toc">
 <ul>
 <li><a href="#start-with-header-other-than-one">Start with header other than one.</a></li>
 <li><a href="#header-3">Header 3</a><ul>


### PR DESCRIPTION
Hi,

I need to access to the toc DIV, to hide and show the Table of Contents. I suggest to add an id attribute with a value of 'toc'. 

So the Table of Content DIV become:  

```
<div class="toc" id="toc"\>
...
</div\>
```

I've also added this change in the test sources.

Thanks,

-- BidiX
http://notewiki.bidix.info
