### PR TITLE
Misc typos.

### DIFF
--- a/docs/extensions/api.txt
+++ b/docs/extensions/api.txt
@@ -103,7 +103,7 @@ that example pattern is not very DRY. A pattern for `**strong**` text would
 be almost identical, with the exception that it would create a 'strong' element.
 Therefore, Markdown provides a number of generic pattern classes that can 
 provide some common functionality. For example, both emphasis and strong are
-implemented with separate instances of the ``SimpleTagPettern`` listed below. 
+implemented with separate instances of the ``SimpleTagPattern`` listed below.
 Feel free to use or extend any of the Pattern classes found at `markdown.inlinepatterns`.
 
 **Generic Pattern Classes**
@@ -358,7 +358,7 @@ Integrating Your Code Into Markdown {: #integrating_into_markdown }
 
 Once you have the various pieces of your extension built, you need to tell 
 Markdown about them and ensure that they are run in the proper sequence. 
-Markdown accepts a ``Extension`` instance for each extension. Therefore, you
+Markdown accepts an ``Extension`` instance for each extension. Therefore, you
 will need to define a class that extends ``markdown.extensions.Extension`` and 
 over-rides the ``extendMarkdown`` method. Within this class you will manage 
 configuration options for your extension and attach the various processors and 

--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -61,7 +61,7 @@ The following options are available on the `markdown.markdown` function:
     the [extension documentation](extensions/index.html) for a list of 
     available extensions.
 
-    The list of extensions may contain instances of extensions or stings of
+    The list of extensions may contain instances of extensions or strings of
     extension names. If an extension name is provided as a string, the
     extension must be importable as a python module either within the 
     `markdown.extensions` package or on your PYTHONPATH with a name starting 
@@ -234,7 +234,7 @@ string must be passed to one of two instance methods:
         md.reset()
         html2 = md.convert(text2)
     
-    You can also change calls to `reset` togeather:
+    You can also change calls to `reset` together:
     
         html3 = md.reset().convert(text3)
 

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -107,7 +107,7 @@ class Markdown:
 
         """
 
-        # For backward compatability, loop through old positional args
+        # For backward compatibility, loop through old positional args
         pos = ['extensions', 'extension_configs', 'safe_mode', 'output_format']
         c = 0
         for arg in args:

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -235,7 +235,7 @@ class SimpleTagPattern(Pattern):
 
 
 class SubstituteTagPattern(SimpleTagPattern):
-    """ Return a eLement of type `tag` with no children. """
+    """ Return an element of type `tag` with no children. """
     def handleMatch (self, m):
         return util.etree.Element(self.tag)
 


### PR DESCRIPTION
In the docs and the .py files. See the diff.
