### PR TITLE
Fixed not working "index" link in extensions documentation

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -11,7 +11,7 @@
   <h3>Navigation</h3>
   <ul>
     <li class="right" style="margin-right: 10px">
-      <a href="siteindex.html" title="General Index">index</a></li>
+      <a href="%(base)ssiteindex.html" title="General Index">index</a></li>
     <li class="right">
       <a href="%(next_url)s" title="%(next_title)s"
          accesskey="N">next</a> |</li>


### PR DESCRIPTION
To reproduce:
- Go to http://packages.python.org/Markdown/extensions/header_id.html
- Click "index" link in the top-right corner

It points to `http://packages.python.org/Markdown/extensions/siteindex.html`, but should point to `http://packages.python.org/Markdown/siteindex.html`. This commit fixes it.
