### PR TITLE
Add `long_description` attribute to `data` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,6 @@ though there are a few known issues. See Features_ for information
 on what exactly is supported and what is not. Additional features are 
 supported by the `Available Extensions`_.
 
-.. _Python-Markdown: http://packages.python.org/Markdown/
 .. _Markdown: http://daringfireball.net/projects/markdown/
 .. _Features: http://packages.python.org/Markdown/index.html#Features
 .. _`Available Extensions`: http://packages.python.org/Markdown/extensions/index.html

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,27 @@ class md_build(build):
 
     sub_commands = build.sub_commands + [('build_docs', has_docs)]
 
+long_description = \
+'''This is a Python implementation of John Gruber's Markdown_. 
+It is almost completely compliant with the reference implementation,
+though there are a few known issues. See Features_ for information 
+on what exactly is supported and what is not. Additional features are 
+supported by the `Available Extensions`_.
+
+.. _Python-Markdown: http://packages.python.org/Markdown/
+.. _Markdown: http://daringfireball.net/projects/markdown/
+.. _Features: http://packages.python.org/Markdown/index.html#Features
+.. _`Available Extensions`: http://packages.python.org/Markdown/extensions/index.html
+
+Support
+=======
+
+You may ask for help and discuss various other issues on the
+`mailing list`_ and report bugs on the `bug tracker`_.
+
+.. _`mailing list`: http://lists.sourceforge.net/lists/listinfo/python-markdown-discuss
+.. _`bug tracker`: http://github.com/waylan/Python-Markdown/issues
+'''
 
 data = dict(
     name =          'Markdown',
@@ -172,6 +193,7 @@ data = dict(
     url =           'http://packages.python.org/Markdown/',
     download_url =  'http://pypi.python.org/packages/source/M/Markdown/Markdown-%s.tar.gz' % version,
     description =   'Python implementation of Markdown.',
+    long_description = long_description,
     author =        'Manfred Stienstra, Yuri takhteyev and Waylan limberg',
     author_email =  'markdown [at] freewisdom.org',
     maintainer =    'Waylan Limberg',


### PR DESCRIPTION
Currently, text on http://pypi.python.org/pypi/Markdown/ is unreadable because PyPI accepts only reStructuredText, but our README file is in Markdown.

I've found out that PyPI prefers `long_description` string in `setup.py` to README files, so adding such a string (in reStructuredText) will fix this issue.

This commit adds such a string. The text is taken from README, but I've removed the "Documentation" section because PyPI already has a "Package Documentation" link on the top of the page.
