### PR TITLE
patched extensions/codehilite.py to allow global line number override

### DIFF
--- a/css/code.css
+++ b/css/code.css
@@ -1,0 +1,62 @@
+.codehilite .hll { background-color: #ffffcc }
+.codehilite  { background: #f8f8f8; }
+.codehilite .c { color: #408080; font-style: italic } /* Comment */
+.codehilite .err { border: 1px solid #FF0000 } /* Error */
+.codehilite .k { color: #008000; font-weight: bold } /* Keyword */
+.codehilite .o { color: #666666 } /* Operator */
+.codehilite .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.codehilite .cp { color: #BC7A00 } /* Comment.Preproc */
+.codehilite .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.codehilite .cs { color: #408080; font-style: italic } /* Comment.Special */
+.codehilite .gd { color: #A00000 } /* Generic.Deleted */
+.codehilite .ge { font-style: italic } /* Generic.Emph */
+.codehilite .gr { color: #FF0000 } /* Generic.Error */
+.codehilite .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.codehilite .gi { color: #00A000 } /* Generic.Inserted */
+.codehilite .go { color: #808080 } /* Generic.Output */
+.codehilite .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.codehilite .gs { font-weight: bold } /* Generic.Strong */
+.codehilite .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.codehilite .gt { color: #0040D0 } /* Generic.Traceback */
+.codehilite .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.codehilite .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.codehilite .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.codehilite .kp { color: #008000 } /* Keyword.Pseudo */
+.codehilite .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.codehilite .kt { color: #B00040 } /* Keyword.Type */
+.codehilite .m { color: #666666 } /* Literal.Number */
+.codehilite .s { color: #BA2121 } /* Literal.String */
+.codehilite .na { color: #7D9029 } /* Name.Attribute */
+.codehilite .nb { color: #008000 } /* Name.Builtin */
+.codehilite .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.codehilite .no { color: #880000 } /* Name.Constant */
+.codehilite .nd { color: #AA22FF } /* Name.Decorator */
+.codehilite .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.codehilite .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.codehilite .nf { color: #0000FF } /* Name.Function */
+.codehilite .nl { color: #A0A000 } /* Name.Label */
+.codehilite .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.codehilite .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.codehilite .nv { color: #19177C } /* Name.Variable */
+.codehilite .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.codehilite .w { color: #bbbbbb } /* Text.Whitespace */
+.codehilite .mf { color: #666666 } /* Literal.Number.Float */
+.codehilite .mh { color: #666666 } /* Literal.Number.Hex */
+.codehilite .mi { color: #666666 } /* Literal.Number.Integer */
+.codehilite .mo { color: #666666 } /* Literal.Number.Oct */
+.codehilite .sb { color: #BA2121 } /* Literal.String.Backtick */
+.codehilite .sc { color: #BA2121 } /* Literal.String.Char */
+.codehilite .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.codehilite .s2 { color: #BA2121 } /* Literal.String.Double */
+.codehilite .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.codehilite .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.codehilite .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.codehilite .sx { color: #008000 } /* Literal.String.Other */
+.codehilite .sr { color: #BB6688 } /* Literal.String.Regex */
+.codehilite .s1 { color: #BA2121 } /* Literal.String.Single */
+.codehilite .ss { color: #19177C } /* Literal.String.Symbol */
+.codehilite .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.codehilite .vc { color: #19177C } /* Name.Variable.Class */
+.codehilite .vg { color: #19177C } /* Name.Variable.Global */
+.codehilite .vi { color: #19177C } /* Name.Variable.Instance */
+.codehilite .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/test_patch/original_output.html
+++ b/test_patch/original_output.html
@@ -1,0 +1,104 @@
+<link rel='stylesheet' href='css/code.css'/>
+<h1>Original <code>codehilite</code> output</h1>
+<pre>
+************************************************************************
+
+shebang 1 `codehilite`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite`
+<div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+************************************************************************
+
+shebang 1 `codehilite(force_linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite(force_linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite(force_linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+************************************************************************
+
+shebang 1 `codehilite(force_linenos=False)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite(force_linenos=False)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite(force_linenos=False)`
+<div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</pre>

--- a/test_patch/output.html
+++ b/test_patch/output.html
@@ -1,0 +1,163 @@
+<link rel='stylesheet' href='css/code.css'/>
+<h1>New <code>codehilite(linenos)</code> output</h1>
+<pre>
+************************************************************************
+
+shebang 1 `codehilite`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite`
+<div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+************************************************************************
+
+shebang 1 `codehilite(force_linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite(force_linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite(force_linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+************************************************************************
+
+shebang 1 `codehilite(force_linenos=False)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite(force_linenos=False)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite(force_linenos=False)`
+<div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+************************************************************************
+
+shebang 1 `codehilite(linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4
+5</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+shebang 2 `codehilite(linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+
+colons `codehilite(linenos=True)`
+<table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
+2
+3
+4</pre></div></td><td class="code"><div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</td></tr></table>
+************************************************************************
+
+shebang 1 `codehilite(linenos=False)`
+<div class="codehilite"><pre><span class="c">#!/usr/bin/env python</span>
+<span class="c"># full shebanag first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+
+shebang 2 `codehilite(linenos=False)`
+<div class="codehilite"><pre><span class="c"># mock shebang first line</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+
+colons `codehilite(linenos=False)`
+<div class="codehilite"><pre><span class="c"># colons first line example</span>
+<span class="k">print</span><span class="p">(</span><span class="s">&quot;Hello, world!&quot;</span><span class="p">)</span>
+<span class="k">while</span> <span class="bp">True</span><span class="p">:</span>
+    <span class="n">awesome</span><span class="p">()</span>
+</pre></div>
+</pre>

--- a/test_patch/test.py
+++ b/test_patch/test.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+# python-markdown Codehilite line numbers override
+#
+# © 2012 Noah K. Tilton <noahktilton@gmail.com>
+# BSD License
+
+# The following tests can be used to compare the new and old
+# functionality side by side.
+
+sys.path.insert(0, './test_patch/usr/lib/python3.2/site-packages')
+
+import markdown
+
+shebang1_code = """
+    #!/usr/bin/env python
+    # full shebanag first line
+    print("Hello, world!")
+    while True:
+        awesome()
+"""
+
+shebang2_code = """
+    #!python
+    # mock shebang first line
+    print("Hello, world!")
+    while True:
+        awesome()
+"""
+
+colons_code = """
+    ::python
+    # colons first line example
+    print("Hello, world!")
+    while True:
+        awesome()
+"""
+
+with open("original_output.html", "w+b") as f:
+#with open("output.html", "w+b") as f:
+
+    w = lambda s: f.write(bytes("%s\n" % s, 'utf-8'))
+    w("<link rel='stylesheet' href='css/code.css'/>")
+    w("<h1>New <code>codehilite(linenos)</code> output</h1>")
+
+    argtypes = [
+            "codehilite",
+            "codehilite(force_linenos=True)",
+            "codehilite(force_linenos=False)",
+            #"codehilite(linenos=True)",
+            #"codehilite(linenos=False)",
+    ]
+    w("<pre>")
+    for arg in argtypes:
+        w(("*" * 72))
+        w("")
+        w("shebang 1 `%s`" % arg)
+        w(markdown.markdown(shebang1_code, [arg]))
+        w("")
+        w("shebang 2 `%s`" % arg)
+        w(markdown.markdown(shebang2_code, [arg]))
+        w("")
+        w("colons `%s`" % arg)
+        w(markdown.markdown(colons_code, [arg]))
+    w("</pre>")


### PR DESCRIPTION
Waylan,

I took the time to add this functionality while leaving the existing functionality intact for backwards compatibility.  Please take a look at `output.html` and `original_output.html` (generated by `test_patch/test.py`).

If you have any questions about what I did or why I did it, let me know.

Cheers,
noah
