### PR TITLE
Fix tabs being converted to spaces in the resulting HTML

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -286,8 +286,8 @@ class Markdown:
 
         source = source.replace(util.STX, "").replace(util.ETX, "")
         source = source.replace("\r\n", "\n").replace("\r", "\n") + "\n\n"
+        #TODO: retain indented blank lines in code
         source = re.sub(r'\n\s+\n', '\n\n', source)
-        source = source.expandtabs(self.tab_length)
 
         # Split into lines and run the line preprocessors.
         self.lines = source.split("\n")

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -261,8 +261,10 @@ class CodeBlockProcessor(BlockProcessor):
 
 
 class BlockQuoteProcessor(BlockProcessor):
-
-    RE = re.compile(r'(^|\n)[ ]{0,%s}>\s?(.*)' % (self.tab_length-1))
+    
+    def __init__(self, *args):
+        BlockProcessor.__init__(self, *args)
+        self.RE = re.compile(r'(^|\n)[ ]{0,%s}>\s?(.*)' % (self.tab_length-1))
 
     def test(self, parent, block):
         return bool(self.RE.search(block))
@@ -302,15 +304,8 @@ class BlockQuoteProcessor(BlockProcessor):
 
 class OListProcessor(BlockProcessor):
     """ Process ordered list blocks. """
-
+    
     TAG = 'ol'
-    # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-    RE = re.compile(r'^[ ]{0,%s}\d+\.\s+(.*)' % (self.tab_length-1))
-    # Detect items on secondary lines. they can be of either list type.
-    CHILD_RE = re.compile(r'^[ ]{0,%s}((\d+\.)|[*+-])\s+(.*)' % (self.tab_length-1))
-    # Detect indented (nested) items of either type
-    INDENT_RE = re.compile(r'^(?:[ ]{%s}|\t)[ ]{0,%s}((\d+\.)|[*+-])\s+.*'
-        % (self.tab_length, self.tab_length-1))
     # The integer (python string) with which the lists starts (default=1)
     # Eg: If list is intialized as)
     #   3. Item
@@ -318,6 +313,16 @@ class OListProcessor(BlockProcessor):
     STARTSWITH = '1'
     # List of allowed sibling tags. 
     SIBLING_TAGS = ['ol', 'ul']
+    
+    def __init__(self, *args):
+        BlockProcessor.__init__(self, *args)
+        # Detect an item (``1. item``). ``group(1)`` contains contents of item.
+        self.RE = re.compile(r'^[ ]{0,%s}\d+\.\s+(.*)' % (self.tab_length-1))
+        # Detect items on secondary lines. they can be of either list type.
+        self.CHILD_RE = re.compile(r'^[ ]{0,%s}((\d+\.)|[*+-])\s+(.*)' % (self.tab_length-1))
+        # Detect indented (nested) items of either type
+        self.INDENT_RE = re.compile(r'^(?:[ ]{%s}|\t)[ ]{0,%s}((\d+\.)|[*+-])\s+.*'
+            % (self.tab_length, self.tab_length-1))
 
     def test(self, parent, block):
         return bool(self.RE.match(block))
@@ -410,9 +415,12 @@ class OListProcessor(BlockProcessor):
 
 class UListProcessor(OListProcessor):
     """ Process unordered list blocks. """
-
+    
     TAG = 'ul'
-    RE = re.compile(r'^(?:[ ]{0,%s}|\t)[*+-]\s+(.*)' % (self.tab_length-1))
+    
+    def __init__(self, *args):
+        OListProcessor.__init__(self, *args)
+        self.RE = re.compile(r'^(?:[ ]{0,%s}|\t)[*+-]\s+(.*)' % (self.tab_length-1))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -262,7 +262,7 @@ class CodeBlockProcessor(BlockProcessor):
 
 class BlockQuoteProcessor(BlockProcessor):
 
-    RE = re.compile(r'(^|\n)[ ]{0,3}>\s?(.*)')
+    RE = re.compile(r'(^|\n)[ ]{0,%s}>\s?(.*)' % (self.tab_length-1))
 
     def test(self, parent, block):
         return bool(self.RE.search(block))
@@ -305,11 +305,12 @@ class OListProcessor(BlockProcessor):
 
     TAG = 'ol'
     # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-    RE = re.compile(r'^[ ]{0,3}\d+\.\s+(.*)')
+    RE = re.compile(r'^[ ]{0,%s}\d+\.\s+(.*)' % (self.tab_length-1))
     # Detect items on secondary lines. they can be of either list type.
-    CHILD_RE = re.compile(r'^[ ]{0,3}((\d+\.)|[*+-])\s+(.*)')
+    CHILD_RE = re.compile(r'^[ ]{0,%s}((\d+\.)|[*+-])\s+(.*)' % (self.tab_length-1))
     # Detect indented (nested) items of either type
-    INDENT_RE = re.compile(r'^(?:[ ]{4}|\t)[ ]{0,3}((\d+\.)|[*+-])\s+.*')
+    INDENT_RE = re.compile(r'^(?:[ ]{%s}|\t)[ ]{0,%s}((\d+\.)|[*+-])\s+.*'
+        % (self.tab_length, self.tab_length-1))
     # The integer (python string) with which the lists starts (default=1)
     # Eg: If list is intialized as)
     #   3. Item
@@ -411,7 +412,7 @@ class UListProcessor(OListProcessor):
     """ Process unordered list blocks. """
 
     TAG = 'ul'
-    RE = re.compile(r'^(?:[ ]{0,3}|\t)[*+-]\s+(.*)')
+    RE = re.compile(r'^(?:[ ]{0,%s}|\t)[*+-]\s+(.*)' % (self.tab_length-1))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -25,14 +25,18 @@ import markdown
 
 class SaneOListProcessor(markdown.blockprocessors.OListProcessor):
     
-    CHILD_RE = re.compile(r'^[ ]{0,3}((\d+\.))[ ]+(.*)')
-    SIBLING_TAGS = ['ol']
+    def __init__(self, *args):
+        markdown.blockprocessors.OListProcessor.__init__(self, *args)
+        self.CHILD_RE = re.compile(r'^[ ]{0,%s}((\d+\.))\s+(.*)' % (self.tab_length-1))
+        self.SIBLING_TAGS = ['ol']
 
 
 class SaneUListProcessor(markdown.blockprocessors.UListProcessor):
     
-    CHILD_RE = re.compile(r'^[ ]{0,3}(([*+-]))[ ]+(.*)')
-    SIBLING_TAGS = ['ul']
+    def __init__(self, *args):
+        markdown.blockprocessors.UListProcessor.__init__(self, *args)
+        self.CHILD_RE = re.compile(r'^[ ]{0,%s}(([*+-]))\s+(.*)' % (self.tab_length-1))
+        self.SIBLING_TAGS = ['ul']
 
 
 class SaneListExtension(markdown.Extension):

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -25,18 +25,20 @@ import markdown
 
 class SaneOListProcessor(markdown.blockprocessors.OListProcessor):
     
+    SIBLING_TAGS = ['ol']
+    
     def __init__(self, *args):
         markdown.blockprocessors.OListProcessor.__init__(self, *args)
         self.CHILD_RE = re.compile(r'^[ ]{0,%s}((\d+\.))\s+(.*)' % (self.tab_length-1))
-        self.SIBLING_TAGS = ['ol']
 
 
 class SaneUListProcessor(markdown.blockprocessors.UListProcessor):
     
+    SIBLING_TAGS = ['ul']
+    
     def __init__(self, *args):
         markdown.blockprocessors.UListProcessor.__init__(self, *args)
         self.CHILD_RE = re.compile(r'^[ ]{0,%s}(([*+-]))\s+(.*)' % (self.tab_length-1))
-        self.SIBLING_TAGS = ['ul']
 
 
 class SaneListExtension(markdown.Extension):

--- a/tests/basic/inline-html-comments.html
+++ b/tests/basic/inline-html-comments.html
@@ -2,7 +2,7 @@
 <!-- This is a simple comment -->
 
 <!--
-    This is another comment.
+	This is another comment.
 -->
 
 <p>Paragraph two.</p>

--- a/tests/basic/inline-html-simple.html
+++ b/tests/basic/inline-html-simple.html
@@ -1,11 +1,11 @@
 <p>Here's a simple block:</p>
 <div>
-    foo
+	foo
 </div>
 
 <p>This should be a code block, though:</p>
 <pre><code>&lt;div&gt;
-    foo
+	foo
 &lt;/div&gt;
 </code></pre>
 <p>As should this:</p>
@@ -13,11 +13,11 @@
 </code></pre>
 <p>Now, nested:</p>
 <div>
-    <div>
-        <div>
-            foo
-        </div>
-    </div>
+	<div>
+		<div>
+			foo
+		</div>
+	</div>
 </div>
 
 <p>This should just be an HTML comment:</p>

--- a/tests/basic/markdown-syntax.html
+++ b/tests/basic/markdown-syntax.html
@@ -721,8 +721,8 @@ _   underscore
 []  square brackets
 ()  parentheses
 #   hash mark
-+   plus sign
--   minus sign (hyphen)
++	plus sign
+-	minus sign (hyphen)
 .   dot
 !   exclamation mark
 </code></pre>

--- a/tests/basic/tabs.html
+++ b/tests/basic/tabs.html
@@ -1,7 +1,7 @@
 <ul>
 <li>
 <p>this is a list item
-    indented with tabs</p>
+	indented with tabs</p>
 </li>
 <li>
 <p>this is a list item
@@ -12,11 +12,11 @@
 <pre><code>this code block is indented by one tab
 </code></pre>
 <p>And:</p>
-<pre><code>    this code block is indented by two tabs
+<pre><code>	this code block is indented by two tabs
 </code></pre>
 <p>And:</p>
-<pre><code>+   this is an example list item
-    indented with tabs
+<pre><code>+	this is an example list item
+	indented with tabs
 
 +   this is an example list item
     indented with spaces

--- a/tests/extensions/extra/markdown-syntax.html
+++ b/tests/extensions/extra/markdown-syntax.html
@@ -721,8 +721,8 @@ _   underscore
 []  square brackets
 ()  parentheses
 #   hash mark
-+   plus sign
--   minus sign (hyphen)
++	plus sign
+-	minus sign (hyphen)
 .   dot
 !   exclamation mark
 </code></pre>

--- a/tests/extensions/toc.html
+++ b/tests/extensions/toc.html
@@ -692,8 +692,8 @@ _   underscore
 []  square brackets
 ()  parentheses
 #   hash mark
-+   plus sign
--   minus sign (hyphen)
++	plus sign
+-	minus sign (hyphen)
 .   dot
 !   exclamation mark
 </code></pre>

--- a/tests/safe_mode/inline-html-comments.html
+++ b/tests/safe_mode/inline-html-comments.html
@@ -1,7 +1,7 @@
 <p>Paragraph one.</p>
 <p>&lt;!-- This is a simple comment --&gt;</p>
 <p>&lt;!--
-    This is another comment.
+	This is another comment.
 --&gt;</p>
 <p>Paragraph two.</p>
 <p>&lt;!-- one comment block -- -- with two comments --&gt;</p>

--- a/tests/safe_mode/inline-html-simple.html
+++ b/tests/safe_mode/inline-html-simple.html
@@ -1,10 +1,10 @@
 <p>Here's a simple block:</p>
 <p>&lt;div&gt;
-    foo
+	foo
 &lt;/div&gt;</p>
 <p>This should be a code block, though:</p>
 <pre><code>&lt;div&gt;
-    foo
+	foo
 &lt;/div&gt;
 </code></pre>
 <p>As should this:</p>
@@ -12,11 +12,11 @@
 </code></pre>
 <p>Now, nested:</p>
 <p>&lt;div&gt;
-    &lt;div&gt;
-        &lt;div&gt;
-            foo
-        &lt;/div&gt;
-    &lt;/div&gt;
+	&lt;div&gt;
+		&lt;div&gt;
+			foo
+		&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/div&gt;</p>
 <p>This should just be an HTML comment:</p>
 <p>&lt;!-- Comment --&gt;</p>

--- a/tests/safe_mode/remove.html
+++ b/tests/safe_mode/remove.html
@@ -2,7 +2,7 @@
 <p></p>
 <p>This should be a code block, though:</p>
 <pre><code>&lt;div&gt;
-    foo
+	foo
 &lt;/div&gt;
 </code></pre>
 <p>As should this:</p>

--- a/tests/safe_mode/replace.html
+++ b/tests/safe_mode/replace.html
@@ -2,7 +2,7 @@
 <p>[HTML_REMOVED]</p>
 <p>This should be a code block, though:</p>
 <pre><code>&lt;div&gt;
-    foo
+	foo
 &lt;/div&gt;
 </code></pre>
 <p>As should this:</p>


### PR DESCRIPTION
does not alter behavior in any other way than that tabs are preserved, which you can see by [viewing the changes to the tests ignoring whitespace](https://github.com/flying-sheep/Python-Markdown/commit/21a5505d46cd48f97065b65134c5288db0acdbf2?w=1).

fixes #36
