### PR TITLE
Fixed pyflakes warnings

### DIFF
--- a/docs/change_log.txt
+++ b/docs/change_log.txt
@@ -9,7 +9,7 @@ Python-Markdown Changelog
 
 Nov 4, 2012: Released version 2.2.1 ([Notes](release-2.2.1.html)).
 
-Jul 5, 2012: Released version 2.2.0 (Notes](release-2.2.0.html)).
+Jul 5, 2012: Released version 2.2.0 ([Notes](release-2.2.0.html)).
 
 Jan 22, 2012: Released version 2.1.1 ([Notes](release-2.1.1.html)).
 

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -37,7 +37,6 @@ import re
 import codecs
 import sys
 import logging
-import warnings
 import util
 from preprocessors import build_preprocessors
 from blockprocessors import build_block_parser

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -485,7 +485,7 @@ class HRProcessor(BlockProcessor):
             # Recursively parse lines before hr so they get parsed first.
             self.parser.parseBlocks(parent, [prelines])
         # create hr
-        hr = util.etree.SubElement(parent, 'hr')
+        util.etree.SubElement(parent, 'hr')
         # check for lines in block after hr.
         postlines = block[self.match.end():].lstrip('\n')
         if postlines:

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -125,7 +125,7 @@ class FootnoteExtension(markdown.Extension):
 
         div = etree.Element("div")
         div.set('class', 'footnote')
-        hr = etree.SubElement(div, "hr")
+        etree.SubElement(div, "hr")
         ol = etree.SubElement(div, "ol")
 
         for id in self.footnotes.keys():

--- a/markdown/extensions/headerid.py
+++ b/markdown/extensions/headerid.py
@@ -77,9 +77,7 @@ Dependencies:
 """
 
 import markdown
-from markdown.util import etree
 import re
-from string import ascii_lowercase, digits, punctuation
 import logging
 import unicodedata
 

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -22,7 +22,6 @@ Copyright 2011
 
 '''
 
-import re
 import markdown
 from markdown.inlinepatterns import SimpleTagPattern
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -45,7 +45,6 @@ import util
 import odict
 import re
 from urlparse import urlparse, urlunparse
-import sys
 # If you see an ImportError for htmlentitydefs after using 2to3 to convert for 
 # use by Python3, then you are probably using the buggy version from Python 3.0.
 # We recomend using the tool from Python 3.1 even if you will be running the 

--- a/markdown/odict.py
+++ b/markdown/odict.py
@@ -119,7 +119,7 @@ class OrderedDict(dict):
         """ Return the index of a given key. """
         try:
             return self.keyOrder.index(key)
-        except ValueError, e:
+        except ValueError:
             raise ValueError("Element '%s' was not found in OrderedDict" % key)
 
     def index_for_location(self, location):

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -1,4 +1,3 @@
-import re
 import inlinepatterns
 import util
 import odict

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import re
-from logging import CRITICAL
-
 import etree_loader
 
 


### PR DESCRIPTION
Pyflakes emits these warnings:

```
unused-import usr/share/pyshared/markdown/__init__.py:40: warnings
unused-variable usr/share/pyshared/markdown/blockprocessors.py:488: hr
redefined-while-unused usr/share/pyshared/markdown/etree_loader.py:14: etree_in_c line 7
redefined-while-unused usr/share/pyshared/markdown/etree_loader.py:15: Comment line 8
redefined-while-unused usr/share/pyshared/markdown/etree_loader.py:18: etree line 11
unused-variable usr/share/pyshared/markdown/extensions/footnotes.py:128: hr
unused-import usr/share/pyshared/markdown/extensions/headerid.py:80: etree
unused-import usr/share/pyshared/markdown/extensions/headerid.py:82: ascii_lowercase
unused-import usr/share/pyshared/markdown/extensions/headerid.py:82: digits
unused-import usr/share/pyshared/markdown/extensions/headerid.py:82: punctuation
redefined-while-unused usr/share/pyshared/markdown/extensions/html_tidy.py:35: tidy line 33
unused-import usr/share/pyshared/markdown/extensions/smart_strong.py:25: re
unused-import usr/share/pyshared/markdown/inlinepatterns.py:48: sys
unused-variable usr/share/pyshared/markdown/odict.py:122: e
unused-import usr/share/pyshared/markdown/treeprocessors.py:1: re
unused-import usr/share/pyshared/markdown/util.py:3: CRITICAL
```

This pull request fixes all `unused-import` and `unused-variable` warnings (but not `redefined-while-used` ones which are false positives).
