### PR TITLE
Input file not existing error reporting.

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -36,6 +36,7 @@ version_info = (2,2,1, "final")
 import re
 import codecs
 import sys
+import os
 import logging
 import util
 from preprocessors import build_preprocessors
@@ -349,6 +350,10 @@ class Markdown:
         # Read the source
         if input:
             if isinstance(input, str):
+                if not os.path.exists(input) or not os.path.isfile(input):
+                  print ("Input file: " + input + " does not exist.")
+                  print ("Cannot continue, exiting.")
+                  sys.exit(1)
                 input_file = codecs.open(input, mode="r", encoding=encoding)
             else:
                 input_file = codecs.getreader(encoding)(input)


### PR DESCRIPTION
I have been using Python-Markdown recently and occasionally type in the incorrect input file name, resulting in:

```
Traceback (most recent call last):
  File "markdown/__main__.py", line 87, in <module>
    run()
  File "markdown/__main__.py", line 81, in run
     markdown.markdownFromFile(**options)
  File "/afs/inf.ed.ac.uk/user/a/aclark6/Python/Python-Markdown/markdown/__init__.py", line 452, in       markdownFromFile
    kwargs.get('encoding', None))
  File "/afs/inf.ed.ac.uk/user/a/aclark6/Python/Python-Markdown/markdown/__init__.py", line 357, in convertFile
    input_file = codecs.open(input, mode="r", encoding=encoding)
  File "/usr/lib64/python2.6/codecs.py", line 881, in open
    file = __builtin__.open(filename, mode, buffering)
IOError: [Errno 2] No such file or directory: 'laskdjf'
```

This is a very simple fix which will result in the slightly friendlier:

```
Input file: laskdjf does not exist.
Cannot continue, exiting.
```
