### PR TITLE
fix: def_list.py raises exception for unintended : in list element.

### DIFF
--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -48,7 +48,9 @@ class DefListProcessor(markdown.blockprocessors.BlockProcessor):
         else:
             d = m.group(2)
         sibling = self.lastChild(parent)
-        if not terms and sibling.tag == 'p':
+        if not terms and sibling==None:
+            state = 'list'
+        elif not terms and sibling.tag == 'p':
             # The previous paragraph contains the terms
             state = 'looselist'
             terms = sibling.text.split('\n')


### PR DESCRIPTION
Markdown source

```

- hoge
-    :    hogehoge

```

will raise exception like this:

 File "env/lib/python2.7/site-packages/markdown/extensions/def_list.py", line 51, in run
    if not terms and sibling.tag == 'p':

  'NoneType' object has no attribute 'tag'
