### PR TITLE
Allow for html_class to be determined dynamically based on the wikilink's label.

### DIFF
--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -125,6 +125,8 @@ class WikiLinks(markdown.inlinepatterns.Pattern):
             a.text = label 
             a.set('href', url)
             if html_class:
+                if callable(html_class):
+                    html_class = html_class(label)
                 a.set('class', html_class)
         else:
             a = ''


### PR DESCRIPTION
In some cases it's desirable that the class applied to a wikilink be dynamic based on context; e.g. if you want to style wikilinks to pages that already exist differently from pages that don't yet exist. This change allows for that.
