### PR TITLE
Simpler extension mechanism

### DIFF
--- a/docs/extensions/api.txt
+++ b/docs/extensions/api.txt
@@ -594,6 +594,25 @@ For example:
 This is useful if you need to implement a large number of extensions with more
 than one residing in a module.
 
+### Named extensions
+
+If you don't want to ship your custom extension as a ``mdx_`` module,
+the third option is to name your extension class and move
+``makeExtension`` to your class as a static method:
+
+    class FootnoteExtension(markdown.Extension):
+        name = "footnotes"
+        
+        @staticmethod
+        def makeExtension(configs=None):
+            return FootnoteExtension(configs=configs)
+
+This will allow you to ship custom Markdown extensions as part of your
+package. Under the hood, :attr:`markdown.Extension` subclasses are
+registered with a meta class that keeps track of all
+`markdown.Extension` sub classes if they have a ``name`` attribute. 
+
+
 [Preprocessors]: #preprocessors
 [InlinePatterns]: #inlinepatterns
 [Treeprocessors]: #treeprocessors

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -41,7 +41,7 @@ from blockprocessors import build_block_parser
 from treeprocessors import build_treeprocessors
 from inlinepatterns import build_inlinepatterns
 from postprocessors import build_postprocessors
-from extensions import Extension
+from extensions import Extension, registry
 from serializers import to_html_string, to_xhtml_string
 
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
@@ -179,6 +179,14 @@ class Markdown:
 
         # Parse extensions config params (ignore the order)
         configs = dict(configs)
+
+        # Check if the extension was created through the meta class
+        if ext_name in registry:
+            cls = registry[ext_name]
+            assert hasattr(cls, 'makeExtension'), "'%s' requires a static method 'makeExtension'" % repr(cls)
+            return cls.makeExtension(configs.items())
+            
+
         pos = ext_name.find("(") # find the first "("
         if pos > 0:
             ext_args = ext_name[pos+1:-1]

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -3,8 +3,21 @@ Extensions
 -----------------------------------------------------------------------------
 """
 
+registry = {}
+
+class ExtensionMetaClass(type):
+    def __new__(cls, name, bases, attrs):
+        Extension =  super(ExtensionMetaClass, cls).__new__(cls, name, bases, attrs)
+
+        if hasattr(Extension, 'name'):
+            registry[Extension.name] = Extension
+
+        return Extension
+
+
 class Extension:
     """ Base class for extensions to subclass. """
+    __metaclass__ = ExtensionMetaClass
     def __init__(self, configs = {}):
         """Create an instance of an Extention.
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -11,6 +11,39 @@ from __future__ import unicode_literals
 import unittest
 import markdown
 
+class SmilieProcessor(markdown.preprocessors.Preprocessor):
+    def run(self, lines):
+        for line in lines:
+            yield line.replace(':(', ':)')
+
+class Smilies(markdown.Extension):
+    name = "smilies"
+    def extendMarkdown(self, md, md_globals):
+        md.preprocessors.add("smilie-processor", SmilieProcessor(), "_begin")
+
+    @staticmethod
+    def makeExtension(config):
+        return Smilies()
+
+class BrokenSmilies(markdown.Extension):
+    name = "broken-smilies"
+
+
+class TestMetaClassLoading(unittest.TestCase):
+    """ Test loading extensions that got registered by meta classes """
+
+    def test_meta_class_loading(self):
+        md = markdown.Markdown(extensions = ['smilies'])
+        text = md.convert(':(')
+        self.assertEqual('<p>:)</p>', text)
+
+    def test_static_method_assertion(self):
+        def md():
+            return markdown.Markdown(extensions = ['broken-smilies'])
+
+        self.assertRaises(AssertionError, md)
+        
+
 class TestAbbr(unittest.TestCase):
     """ Test abbr extension. """
 


### PR DESCRIPTION
Hi

This is somewhat of an unsolicited pull request, but hey that's what GitHub is about. :)

I've added some code to get rid of the current ugliness of extension creation. It's backwards compatible. 

The branch registers "named" extensions, which can be placed anywhere in your code. Documentation and the tests should describe pretty well what it does. The reasoning was that it's pretty ugly to distribute root-level `mdx_*` modules. 

Anyhow. I've got another branch with a `tox.ini` file to test against different Python versions too if you're interested. 

Cheers, 
# !A
