### PR TITLE
Prevent javascript:// URLs

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -364,6 +364,9 @@ class LinkPattern(Pattern):
                 # Not a safe url
                 return ''
 
+        if scheme == 'javascript':
+            return ''
+
         # Url passes all tests. Return url as-is.
         return urlunparse(url)
 

--- a/tests/safe_mode/link-targets.html
+++ b/tests/safe_mode/link-targets.html
@@ -1,0 +1,2 @@
+<p><a href="">XSS</a>
+See http://security.stackexchange.com/q/30330/1261 for details.</p>

--- a/tests/safe_mode/link-targets.txt
+++ b/tests/safe_mode/link-targets.txt
@@ -1,0 +1,3 @@
+[XSS](javascript://%0Aalert%28'XSS'%29;)
+See http://security.stackexchange.com/q/30330/1261 for details.
+


### PR DESCRIPTION
This pull request prevents JavaScript URLs and fixes an [XSS attack](http://en.wikipedia.org/wiki/Cross-site_scripting)  that worked even when safe_mode was set.

In the long term, I think it would be certainly a great idea to allow users to lock down the allowed schemes, and default to something sensible, like `http`, `https`, `mailto`, `news` and maybe `tel`.
