### PR TITLE
Fix wrong 'linenos' argument for CodeHilite(), in fenced_code.py

### DIFF
--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -131,7 +131,7 @@ class FencedBlockPreprocessor(Preprocessor):
                 # is enabled, so we call it to highlite the code
                 if self.codehilite_conf:
                     highliter = CodeHilite(m.group('code'),
-                            linenos=self.codehilite_conf['force_linenos'][0],
+                            linenums=self.codehilite_conf['linenums'][0],
                             guess_lang=self.codehilite_conf['guess_lang'][0],
                             css_class=self.codehilite_conf['css_class'][0],
                             style=self.codehilite_conf['pygments_style'][0],


### PR DESCRIPTION
CodeHilite: linenos is replaced by linenums
