### PR TITLE
Fix some pyflakes-undefined-name warnings

### DIFF
--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -95,7 +95,7 @@ class DefListIndentProcessor(ListIndentProcessor):
 
     def create_item(self, parent, block):
         """ Create a new dd and parse the block with it as the parent. """
-        dd = markdown.etree.SubElement(parent, 'dd')
+        dd = etree.SubElement(parent, 'dd')
         self.parser.parseBlocks(dd, [block])
  
 

--- a/markdown/odict.py
+++ b/markdown/odict.py
@@ -2,6 +2,13 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from . import util
 
+from copy import deepcopy
+
+def iteritems_compat(d):
+    """Return an iterator over the (key, value) pairs of a dictionary.
+    Copied from `six` module."""
+    return iter(getattr(d, _iteritems)())
+
 class OrderedDict(dict):
     """
     A dictionary that keeps its keys in the order in which they're inserted.
@@ -30,7 +37,7 @@ class OrderedDict(dict):
                 super_set(key, value)
 
     def __deepcopy__(self, memo):
-        return self.__class__([(key, copy.deepcopy(value, memo))
+        return self.__class__([(key, deepcopy(value, memo))
                                for key, value in self.items()])
 
     def __copy__(self):
@@ -99,7 +106,7 @@ class OrderedDict(dict):
             return [self[k] for k in self.keyOrder]
 
     def update(self, dict_):
-        for k, v in six.iteritems(dict_):
+        for k, v in iteritems_compat(dict_):
             self[k] = v
 
     def setdefault(self, key, default):
@@ -131,7 +138,7 @@ class OrderedDict(dict):
         Replaces the normal dict.__repr__ with a version that returns the keys
         in their Ordered order.
         """
-        return '{%s}' % ', '.join(['%r: %r' % (k, v) for k, v in six.iteritems(self)])
+        return '{%s}' % ', '.join(['%r: %r' % (k, v) for k, v in iteritems_compat(self)])
 
     def clear(self):
         super(OrderedDict, self).clear()


### PR DESCRIPTION
Currently pyflakes reports this:

```
e: python-markdown: pyflakes-undefined-name usr/share/pyshared/markdown/extensions/def_list.py:98: markdown
e: python-markdown: pyflakes-undefined-name usr/share/pyshared/markdown/odict.py:33: copy
e: python-markdown: pyflakes-undefined-name usr/share/pyshared/markdown/odict.py:102: six
e: python-markdown: pyflakes-undefined-name usr/share/pyshared/markdown/odict.py:134: six
```

This PR fixes that. Instead of importing `six`, I copied implementation of `iteritems()` and used that instead.
