### PR TITLE
makefile: fix building docs.zip, and rename the target to docs-zip

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,11 +13,9 @@ build:
 build-win:
 	python setup.py bdist_wininst
 
-docs:
+docs-zip:
 	python setup.py build_docs --force
-	cd build/docs
-	zip -r ../docs.zip .
-	cd ../../ 
+	cd build/docs && zip -r ../docs.zip .
 
 test:
 	tox


### PR DESCRIPTION
Makefile's docs target is currently broken in several ways:
- Make refuses to run that target when `docs` directory exists (it does).
- Every line is executed in its own shell session, so `cd` statements have no effect and the whole tree is zipped.

This PR fixes that. You may also consider adding `makefile` and `tox.in` to `MANIFEST.in`.
