### PR TITLE
Some minor code cleanups

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -33,7 +33,6 @@ License: BSD (see LICENSE for details).
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from .__version__ import version, version_info
-import re
 import codecs
 import sys
 import logging

--- a/markdown/odict.py
+++ b/markdown/odict.py
@@ -4,11 +4,6 @@ from . import util
 
 from copy import deepcopy
 
-def iteritems_compat(d):
-    """Return an iterator over the (key, value) pairs of a dictionary.
-    Copied from `six` module."""
-    return iter(getattr(d, _iteritems)())
-
 class OrderedDict(dict):
     """
     A dictionary that keeps its keys in the order in which they're inserted.
@@ -106,8 +101,8 @@ class OrderedDict(dict):
             return [self[k] for k in self.keyOrder]
 
     def update(self, dict_):
-        for k, v in iteritems_compat(dict_):
-            self[k] = v
+        for k in dict_:
+            self[k] = dict_[k]
 
     def setdefault(self, key, default):
         if key not in self:
@@ -138,7 +133,7 @@ class OrderedDict(dict):
         Replaces the normal dict.__repr__ with a version that returns the keys
         in their Ordered order.
         """
-        return '{%s}' % ', '.join(['%r: %r' % (k, v) for k, v in iteritems_compat(self)])
+        return '{%s}' % ', '.join(['%r: %r' % (k, v) for k, v in self._iteritems()])
 
     def clear(self):
         super(OrderedDict, self).clear()

--- a/run-tests.py
+++ b/run-tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import tests
-import os, sys, getopt
+import os, sys
 
 if len(sys.argv) > 1 and sys.argv[1] == "update":
     if len(sys.argv) > 2:

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -9,7 +9,6 @@ Tests of the various APIs with the python markdown lib.
 
 from __future__ import unicode_literals
 import unittest
-import os
 import sys
 import types
 import markdown


### PR DESCRIPTION
This removes some unused imports and fixes a bug introduced by me in #201 (I don't know a way to reproduce it, maybe that code is unused at all).

commit 299bb08bfe203dff0843b9ec9b9c565a63be1c4c:

```
Remove some unused imports
```

commit c10dfac9909282b54a48be6261f76ba11d9da6d0:

```
odict.py: remove usage of iteritems_compat which was not working

I've added iteritems_compat function in one of my previous pull
requests, which was failing with:

    ./markdown/odict.py:106: undefined name 'iteritems_compat'

This commit drops usage of that function.
```
