### PR TITLE
Test for headerid extension

### DIFF
--- a/tests/extensions/headerid.html
+++ b/tests/extensions/headerid.html
@@ -1,0 +1,8 @@
+<h1 id="header-1">Header 1</h1>
+<h2 id="header-2">Header 2</h2>
+<h3 id="header-3">Header 3</h3>
+<h4 id="header-4">Header 4</h4>
+<h5 id="header-5">Header 5</h5>
+<h6 id="header-6">Header 6</h6>
+<h1 id="custom-id">Markdown plus h2 with a custom ID</h1>
+<p><a href="#id-goes-here">Link back to H2</a></p>

--- a/tests/extensions/headerid.txt
+++ b/tests/extensions/headerid.txt
@@ -1,0 +1,10 @@
+# Header 1 #
+## Header 2 ##
+### Header 3 ###
+#### Header 4 ####
+##### Header 5 #####
+###### Header 6 ######
+ 
+Markdown plus h2 with a custom ID {#custom-id}
+==============================================
+[Link back to H2](#id-goes-here)

--- a/tests/extensions/test.cfg
+++ b/tests/extensions/test.cfg
@@ -38,3 +38,6 @@ extensions=nl2br,attr_list
 
 [admonition]
 extensions=admonition
+
+[headerid]
+extensions=attr_list,headerid


### PR DESCRIPTION
Thought it'd be nice to have this test, ie. there was a bug recently due to `elem.id` instead of `elem.get(id)` - this should now be caught.

Have a nice day :)
