### PR TITLE
Fix issue when second value of captured group is None

### DIFF
--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -150,7 +150,7 @@ def _serialize_html(write, elem, qnames, namespaces, format):
                 _serialize_html(write, e, qnames, None, format)
         else:
             write("<" + tag)
-            items = elem.items()
+            items = [item for item in elem.items() if item[1] != None]
             if items or namespaces:
                 items.sort() # lexical order
                 for k, v in items:


### PR DESCRIPTION
It is possible to create a regexp with named groups which evaluates some groups values to `None` like in following example:

```
import re

rx_pattern = r'([^(]|^)(http|https)://(?:www.|)vimeo\.com/(?P<vimeoid>\d+)(?:\[(?P<width>\d+|),\s*,\s*(?P<height>\d+|)\]|)\S*'
test_str = "http://vimeo.com/45678967234"

rx = re.compile(rx_pattern)
matches = rx.search(test_str)
print matches.groups()   # >>> ('', 'http', '45678967234', None, None)
```

In this case serializator failed when trying to find something inside string which is `None`
