### PR TITLE
markdown="1" | "Default to Span Mode"

### DIFF
--- a/markdown/extensions/extra.py
+++ b/markdown/extensions/extra.py
@@ -6,22 +6,22 @@ A compilation of various Python-Markdown extensions that imitates
 [PHP Markdown Extra](http://michelf.com/projects/php-markdown/extra/).
 
 Note that each of the individual extensions still need to be available
-on your PYTHONPATH. This extension simply wraps them all up as a 
+on your PYTHONPATH. This extension simply wraps them all up as a
 convenience so that only one extension needs to be listed when
 initiating Markdown. See the documentation for each individual
 extension for specifics about that extension.
 
-In the event that one or more of the supported extensions are not 
-available for import, Markdown will issue a warning and simply continue 
-without that extension. 
+In the event that one or more of the supported extensions are not
+available for import, Markdown will issue a warning and simply continue
+without that extension.
 
-There may be additional extensions that are distributed with 
+There may be additional extensions that are distributed with
 Python-Markdown that are not included here in Extra. Those extensions
 are not part of PHP Markdown Extra, and therefore, not part of
 Python-Markdown Extra. If you really would like Extra to include
 additional extensions, we suggest creating your own clone of Extra
-under a differant name. You could also edit the `extensions` global 
-variable defined below, but be aware that such changes may be lost 
+under a differant name. You could also edit the `extensions` global
+variable defined below, but be aware that such changes may be lost
 when you upgrade to any future version of Python-Markdown.
 
 """
@@ -29,6 +29,8 @@ when you upgrade to any future version of Python-Markdown.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
+from ..blockprocessors import BlockProcessor
+from .. import util
 
 extensions = ['smart_strong',
               'fenced_code',
@@ -38,7 +40,7 @@ extensions = ['smart_strong',
               'tables',
               'abbr',
               ]
-              
+
 
 class ExtraExtension(Extension):
     """ Add various extensions to Markdown class."""
@@ -49,6 +51,36 @@ class ExtraExtension(Extension):
         if not md.safeMode:
             # Turn on processing of markdown text within raw html
             md.preprocessors['html_block'].markdown_in_raw = True
+            start_spanmode_placeholder = "xx7882146723658911jj"
+            end_spanmode_placeholder = "jj3912235655514745xx"
+            md.preprocessors['html_block'].start_spanmode_placeholder = \
+                start_spanmode_placeholder
+            md.preprocessors['html_block'].end_spanmode_placeholder = \
+                end_spanmode_placeholder
+            md.parser.blockprocessors.add('html_block',
+                                          HtmlBlockProcessor(md.parser),
+                                          '_begin')
+            md.parser.blockprocessors.start_spanmode_placeholder = \
+                start_spanmode_placeholder
+            md.parser.blockprocessors.end_spanmode_placeholder = \
+                end_spanmode_placeholder
+
+
+class HtmlBlockProcessor(BlockProcessor):
+    """ Process Markdown Inside HTML Blocks. """
+
+    def test(self, parent, block):
+        return block == self.parser.blockprocessors.start_spanmode_placeholder
+
+    def run(self, parent, blocks):
+        del blocks[0]
+        line = blocks.pop(0)
+        block = ""
+        while line != self.parser.blockprocessors.end_spanmode_placeholder:
+            block += line
+            line = blocks.pop(0)
+        parent.append(util.etree.fromstring(block))
+
 
 def makeExtension(configs={}):
     return ExtraExtension(configs=dict(configs))

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -40,6 +40,7 @@ INLINE_PLACEHOLDER_RE = re.compile(INLINE_PLACEHOLDER % r'([0-9]{4})')
 AMP_SUBSTITUTE = STX+"amp"+ETX
 HTML_PLACEHOLDER = STX + "wzxhzdk:%s" + ETX
 HTML_PLACEHOLDER_RE = re.compile(HTML_PLACEHOLDER % r'([0-9]+)')
+TAG_PLACEHOLDER = STX + "hzzhzkh:%s" + ETX
 
 
 """
@@ -119,10 +120,12 @@ class HtmlStash(object):
     in the beginning and replace with place-holders.
     """
 
-    def __init__ (self):
+    def __init__(self):
         """ Create a HtmlStash. """
-        self.html_counter = 0 # for counting inline html segments
-        self.rawHtmlBlocks=[]
+        self.html_counter = 0  # for counting inline html segments
+        self.rawHtmlBlocks = []
+        self.tag_counter = 0
+        self.tag_data = []
 
     def store(self, html, safe=False):
         """
@@ -150,3 +153,13 @@ class HtmlStash(object):
     def get_placeholder(self, key):
         return HTML_PLACEHOLDER % key
 
+    def store_tag(self, tag, attrs, left_tag_index, right_tag_index):
+        """
+        Store tag data in an Element Tree object and generate placeholder.
+        """
+        self.tag_data.append({'tag': tag, 'attrs': attrs,
+                              'left_tag_index': left_tag_index,
+                              'right_tag_index': right_tag_index})
+        placeholder = TAG_PLACEHOLDER % str(self.tag_counter)
+        self.tag_counter += 1
+        return placeholder

--- a/tests/extensions/extra/raw-html.html
+++ b/tests/extensions/extra/raw-html.html
@@ -12,9 +12,3 @@
 
 <p><em>blah</em></p>
 </div>
-
-<p>
-    This is not a code block since Markdown parses paragraph
-    content as span.
-</p>
-<p><em>Hello</em> <em>world</em></p>

--- a/tests/extensions/extra/raw-html.html
+++ b/tests/extensions/extra/raw-html.html
@@ -12,3 +12,9 @@
 
 <p><em>blah</em></p>
 </div>
+
+<p>
+    This is not a code block since Markdown parses paragraph
+    content as span.
+</p>
+<p><em>Hello</em> <em>world</em></p>

--- a/tests/extensions/extra/raw-html.txt
+++ b/tests/extensions/extra/raw-html.txt
@@ -9,10 +9,3 @@ _bar_
 _blah_
 
 </div>
-
-<p markdown="1">
-    This is not a code block since Markdown parses paragraph
-    content as span.
-</p>
-
-<p markdown="1">_Hello_ _world_</p>

--- a/tests/extensions/extra/raw-html.txt
+++ b/tests/extensions/extra/raw-html.txt
@@ -10,3 +10,9 @@ _blah_
 
 </div>
 
+<p markdown="1">
+    This is not a code block since Markdown parses paragraph
+    content as span.
+</p>
+
+<p markdown="1">_Hello_ _world_</p>

--- a/tests/extensions/extra/test.cfg
+++ b/tests/extensions/extra/test.cfg
@@ -15,3 +15,6 @@ extensions=footnotes
 
 [tables]
 extensions=tables
+
+[raw-html]
+normalize=1


### PR DESCRIPTION
Implements a 'default span mode' in those blocks with the `markdown="1"` attribute that should never have block elements within them. Nothing here fixes the deficiencies mentioned in issue #52, but it does fall under the category of 'better support for markdown="1"'.

The regex in `contain_span_tags` comes directly from php-markdown:

```
# Tags where markdown="1" default to span mode:
protected $contain_span_tags_re = 'p|h[1-6]|li|dd|dt|td|th|legend|address';
```

Spanmode tests:
Input (with 'extra' enabled):

```
<p markdown="1">
    This is not a code block since Markdown parses paragraph
    content as span.
</p>

<p markdown="1">_Hello_ _world_</p>
```

Output Before:

```
<p>

<pre><code>This is not a code block since Markdown parses paragraph
content as span.
</code></pre>
</p>

<p>

<p><em>Hello</em> <em>world</em></p>
</p>
```

Output After:

```
<p>
    This is not a code block since Markdown parses paragraph
    content as span.
</p>
<p><em>Hello</em> <em>world</em></p>
```
