### PR TITLE
tables and attr_list compatibility

### DIFF
--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -121,6 +121,8 @@ class AttrListTreeprocessor(Treeprocessor):
                 elif elem.text:
                     # no children. Get from text.
                     m = RE.search(elem.text)
+                    if not m and elem.tag == 'td':
+                        m = re.search(self.BASE_RE, elem.text)
                     if m:
                         self.assign_attrs(elem, m.group(1))
                         elem.text = elem.text[:m.start()]

--- a/tests/extensions/extra/tables_and_attr_list.html
+++ b/tests/extensions/extra/tables_and_attr_list.html
@@ -1,0 +1,18 @@
+<table>
+<thead>
+<tr>
+<th>First Header</th>
+<th>Second Header</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="foo bar" title="Some title!">Content Cell</td>
+<td>Content Cell</td>
+</tr>
+<tr>
+<td>Content Cell</td>
+<td class="foo bar" title="Some title!">Content Cell</td>
+</tr>
+</tbody>
+</table>

--- a/tests/extensions/extra/tables_and_attr_list.txt
+++ b/tests/extensions/extra/tables_and_attr_list.txt
@@ -1,0 +1,4 @@
+First Header                                           | Second Header
+------------------------------------------------------ | -------------
+Content Cell{: class="foo bar" title="Some title!" }   | Content Cell
+Content Cell                                           | Content Cell{: class="foo bar" title="Some title!" }

--- a/tests/extensions/extra/test.cfg
+++ b/tests/extensions/extra/test.cfg
@@ -15,3 +15,6 @@ extensions=footnotes
 
 [tables]
 extensions=tables
+
+[tables_and_attr_list]
+extensions=tables,attr_list


### PR DESCRIPTION
Treats `<td>` as an inline element even though it's a block element. As far as I know, there's no way to have multi-line cells with the tables extension, and simply using an html `<td>` gets wrapped in an additional `<td>`, so I think there's a case for an exception. [This deficiency has practical consequences.](http://stackoverflow.com/questions/18901540/how-do-i-add-attributes-to-tables-in-python-markdown/19615075#19615075)

Example:

```
import markdown


example = """\
First Header                                           | Second Header
------------------------------------------------------ | -------------
Content Cell{: class="foo bar" title="Some title!" }   | Content Cell
Content Cell                                           | Content Cell{: class="foo bar" title="Some title!" }
"""

output = markdown.markdown(example, extensions=['extra'])
print """-----------------------------------------------
EXAMPLE OUTPUT:
    %s
-------------------------------------------------""" % output
```

Output Before:

```
-----------------------------------------------
EXAMPLE OUTPUT:
    <table>
<thead>
<tr>
<th>First Header</th>
<th>Second Header</th>
</tr>
</thead>
<tbody>
<tr>
<td>Content Cell{: class="foo bar" title="Some title!" }</td>
<td>Content Cell</td>
</tr>
<tr>
<td>Content Cell</td>
<td>Content Cell{: class="foo bar" title="Some title!" }</td>
</tr>
</tbody>
</table>
-------------------------------------------------
```

Output After:

```
-----------------------------------------------
EXAMPLE OUTPUT:
    <table>
<thead>
<tr>
<th>First Header</th>
<th>Second Header</th>
</tr>
</thead>
<tbody>
<tr>
<td class="foo bar" title="Some title!">Content Cell/n</td>
<td>Content Cell</td>
</tr>
<tr>
<td>Content Cell</td>
<td class="foo bar" title="Some title!">Content Cell</td>
</tr>
</tbody>
</table>
-------------------------------------------------
```
