### PR TITLE
Don't replace spaces for %20 in URLs

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -344,7 +344,6 @@ class LinkPattern(Pattern):
         `username:password@host:port`.
 
         """
-        url = url.replace(' ', '%20')
         if not self.markdown.safeMode:
             # Return immediately bipassing parsing.
             return url


### PR DESCRIPTION
The markdown parser from John Gruber doesn't do this, and there is no mention of this in the specification.

This is a broken implementation because it doesn't encode everything. Ie, there may already be a `%20` in the URL and a space. The original `%20` should become `%2520` and the space would already be turned into `%20`. If this should be percent encoding the URL's then it should use `urllib.quote` so it handles these cases and also encodes every other character.
