### PR TITLE
Fixed parsing of brackets within inline image titles

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -107,7 +107,7 @@ LINK_RE = NOIMG + BRK + \
 r'''\(\s*(<.*?>|((?:(?:\(.*?\))|[^\(\)]))*?)\s*((['"])(.*?)\12\s*)?\)'''
 # [text](url) or [text](<url>) or [text](url "title")
 
-IMAGE_LINK_RE = r'\!' + BRK + r'\s*\((<.*?>|([^\)]*))\)'
+IMAGE_LINK_RE = r'\!' + BRK + r'\s*\((<.*?>|([^")]+"[^"]*"|[^\)]*))\)'
 # ![alttxt](http://x.com/) or ![alttxt](<http://x.com/>)
 REFERENCE_RE = NOIMG + BRK+ r'\s?\[([^\]]*)\]'           # [Google][3]
 SHORT_REF_RE = NOIMG + r'\[([^\]]+)\]'                   # [Google]

--- a/tests/misc/brackets-in-img-title.html
+++ b/tests/misc/brackets-in-img-title.html
@@ -1,0 +1,9 @@
+<p><img alt="alt" src="local-img.jpg" />
+<img alt="alt" src="local-img.jpg" title="" />
+<img alt="alt" src="local-img.jpg" title="normal title" /></p>
+<p><img alt="alt" src="local-img.jpg" title="(just title in brackets)" />
+<img alt="alt" src="local-img.jpg" title="title with brackets (I think)" /></p>
+<p><img alt="alt" src="local-img.jpg" title="(" />
+<img alt="alt" src="local-img.jpg" title="(open only" />
+<img alt="alt" src="local-img.jpg" title=")" />
+<img alt="alt" src="local-img.jpg" title="close only)" /></p>

--- a/tests/misc/brackets-in-img-title.txt
+++ b/tests/misc/brackets-in-img-title.txt
@@ -1,0 +1,12 @@
+![alt](local-img.jpg)
+![alt](local-img.jpg "")
+![alt](local-img.jpg "normal title")
+
+![alt](local-img.jpg "(just title in brackets)")
+![alt](local-img.jpg "title with brackets (I think)")
+
+![alt](local-img.jpg "(")
+![alt](local-img.jpg "(open only")
+![alt](local-img.jpg ")")
+![alt](local-img.jpg "close only)")
+


### PR DESCRIPTION
Fix incorrect parsing of inline image title when it contains a close bracket.

`![alt](img.jpg "example (wrong)"]` translates into `<img ... title="&quot;example (wrong" />")`

The regex matches the close bracket within the quotes, breaking the tag into `"example (wrong` and `")`

This fix adds a match for quoted titles, as well as test cases.
