### PR TITLE
Add range support for HL in codehilite

### DIFF
--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -35,16 +35,32 @@ except ImportError:
 def parse_hl_lines(expr):
     """Support our syntax for emphasizing certain lines of code.
 
-    expr should be like '1 2' to emphasize lines 1 and 2 of a code block.
+    expr should be like '1 2' to emphasize lines 1 and 2 of a code block
+    or contains lines ranges like '1 3-5' to emplasize lines 1 and 3 to
+    5 included.
     Returns a list of ints, the line numbers to emphasize.
     """
     if not expr:
         return []
 
-    try:
-        return map(int, expr.split())
-    except ValueError:
-        return []
+    listsHL = []
+    for exp in expr.split():
+        lex = exp.split("-")
+        if len(lex) == 1:
+            try:
+                val = int(lex[0])
+                listsHL.append(val)
+            except ValueError:
+                pass
+        elif len(lex) ==2:
+            try:
+                valMin = int(lex[0])
+                valMax = int(lex[1])
+                for val in range(valMin, valMax+1):
+                    listsHL.append(val)
+            except ValueError:
+                pass
+    return listsHL
 
 
 # ------------------ The Main CodeHilite Class ----------------------
@@ -65,7 +81,8 @@ class CodeHilite(object):
 
     * css_class: Set class name of wrapper div ('codehilite' by default).
 
-    * hl_lines: (List of integers) Lines to emphasize, 1-indexed.
+    * hl_lines: (List of integers) Lines to emphasize, 1-indexed. Can also containts elements
+    range.
 
     Low Level Usage:
         >>> code = CodeHilite()
@@ -153,7 +170,7 @@ class CodeHilite(object):
 
         Also parses optional list of highlight lines, like:
 
-            :::python hl_lines="1 3"
+            :::python hl_lines="1 3 6-8"
         """
 
         import re

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -62,15 +62,23 @@ Optionally backticks instead of tildes as per how github's code block markdown i
 If the codehighlite extension and Pygments are installed, lines can be highlighted:
 
     >>> text = '''
-    ... ```hl_lines="1 3"
+    ... ```hl_lines="1 3 5-7"
     ... line 1
     ... line 2
     ... line 3
+    ... line 4
+    ... line 5
+    ... line 6
+    ... line 7
     ... ```'''
     >>> print markdown.markdown(text, extensions=['codehilite', 'fenced_code'])
     <pre><code><span class="hilight">line 1</span>
     line 2
     <span class="hilight">line 3</span>
+    line 4
+    <span class="hilight">line 5</span>
+    <span class="hilight">line 6</span>
+    <span class="hilight">line 7</span>
     </code></pre>
 
 Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/).


### PR DESCRIPTION
Because a recent PR add feature for emphasizing some lines in a code block, I propose to add range support too : 

``````
```python hl_lines="2 4-6"
def Test():
    # I am highlighted
    print "not me"
    print """I am highlighted
               me too
               and me"""
    # Not me !
```
``````
