### PR TITLE
Support org-table syntax in tables extension

### DIFF
--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 from . import Extension
 from ..blockprocessors import BlockProcessor
 from ..util import etree
+import re
 
 class TableProcessor(BlockProcessor):
     """ Process Tables. """
@@ -41,7 +42,7 @@ class TableProcessor(BlockProcessor):
             border = True
         # Get alignment of columns
         align = []
-        for c in self._split_row(seperator, border):
+        for c in self._split_separator(seperator, border):
             if c.startswith(':') and c.endswith(':'):
                 align.append('center')
             elif c.startswith(':'):
@@ -76,13 +77,24 @@ class TableProcessor(BlockProcessor):
             if a:
                 c.set('align', a)
 
+    def _strip_border(self, row):
+        """ remove leading/trailing border indicators. """
+        if row.startswith('|'):
+            row = row[1:]
+        if row.endswith('|'):
+            row = row[:-1]
+        return row
+
+    def _split_separator(self, row, border):
+        """ split a separator row into list of cells. """
+        if border:
+            row = self._strip_border(row)
+        return re.split('[|+]', row)
+
     def _split_row(self, row, border):
         """ split a row of text into list of cells. """
         if border:
-            if row.startswith('|'):
-                row = row[1:]
-            if row.endswith('|'):
-                row = row[:-1]
+            row = self._strip_border(row)
         return row.split('|')
 
 

--- a/tests/extensions/extra/org_tables.html
+++ b/tests/extensions/extra/org_tables.html
@@ -1,0 +1,18 @@
+<table>
+<thead>
+<tr>
+<th>First Header</th>
+<th>Second Header</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Content Cell</td>
+<td>Content Cell</td>
+</tr>
+<tr>
+<td>Content Cell</td>
+<td>Content Cell</td>
+</tr>
+</tbody>
+</table>

--- a/tests/extensions/extra/org_tables.txt
+++ b/tests/extensions/extra/org_tables.txt
@@ -1,0 +1,4 @@
+| First Header | Second Header |
+|--------------+---------------|
+| Content Cell | Content Cell  |
+| Content Cell | Content Cell  |


### PR DESCRIPTION
Emacs org-table uses a `+` instead of a `|` when drawing header dashes. It would be nice if the tables parser would support this syntax.

```
| Column A | Column B | Column C |
|----------+----------+----------|
| Cell A1  | Cell B1  | Cell C1  |
| Cell A2  | Cell B2  | Cell C2  |
| Cell A3  | Cell B3  | Cell C3  |
```

org-tables will always include `|` on left and right side of table and only the internal `|`'s are replaced with `+`.

Currently the tables extension will detect the table but throw out all columns but the first. This patch will cause simple org-tables to be parsed correctly.
