### PR TITLE
Fix issue308 and fix (unrelated) failure to break out of nest loop.

### DIFF
--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -143,7 +143,7 @@ class HtmlBlockPreprocessor(Preprocessor):
         """
         Same effect as concatenating the strings in items,
         finding the character to which stringindex refers in that string,
-        and returning the item in which that character resides.
+        and returning the index of the item in which that character resides.
         """
         items.append('dummy')
         i, count = 0, 0
@@ -175,8 +175,8 @@ class HtmlBlockPreprocessor(Preprocessor):
                     if len(items) - right_listindex <= 1:  # last element
                         right_listindex -= 1
                     placeholder = self.markdown.htmlStash.store('\n\n'.join(
-                        items[i:right_listindex]))
-                    del items[i:right_listindex]
+                        items[i:right_listindex + 1]))
+                    del items[i:right_listindex + 1]
                     items.insert(i, placeholder)
         return items
 

--- a/tests/extensions/extra/raw-html.html
+++ b/tests/extensions/extra/raw-html.html
@@ -27,5 +27,11 @@ Note: Subelements are not required to have tail text.</div>
 Raw html blocks may also be nested.
 </div>
 
+
+
 </div>
 <p>This text is after the markdown in html.</p>
+<div name="issue308">
+<p><span>1</span>
+<span>2</span></p>
+</div>

--- a/tests/extensions/extra/raw-html.txt
+++ b/tests/extensions/extra/raw-html.txt
@@ -44,3 +44,10 @@ Raw html blocks may also be nested.
 </div>
 
 This text is after the markdown in html.
+
+<div markdown="1" name="issue308">
+
+<span>1</span>
+<span>2</span>
+
+</div>


### PR DESCRIPTION
- fix [issue 308](https://github.com/waylan/Python-Markdown/issues/308) (preprocessors.py lines 178-179)
- fix unending `while` loop (extra.py line 78/79)
- test issue 308
- cleaner `MarkdownInHtmlProcessor` class

I included both bug fixes in one pull request because I couldn't test the first without fixing the second.
