### PR TITLE
Add failing unit test for smarty

### DIFF
--- a/tests/extensions/smarty.html
+++ b/tests/extensions/smarty.html
@@ -13,6 +13,7 @@ one two &lsquo;60s<br />
 &lsquo;quoted&rsquo; text and <strong>bold &lsquo;quoted&rsquo; text</strong><br />
 em-dashes (&mdash;) and ellipes (&hellip;)<br />
 &ldquo;<a href="http://example.com">Link</a>&rdquo; &mdash; she said.</p>
+<p>&ldquo;Ellipsis within quotes&hellip;&rdquo;</p>
 <hr />
 <p>Escaped -- ndash<br />
 'Escaped' "quotes"<br />

--- a/tests/extensions/smarty.txt
+++ b/tests/extensions/smarty.txt
@@ -15,6 +15,8 @@ It's fun. What's fun?
 em-dashes (---) and ellipes (...)  
 "[Link](http://example.com)" --- she said.
 
+"Ellipsis within quotes..."
+
 --- -- ---
 
 Escaped \-- ndash  


### PR DESCRIPTION
Added this failing test:

```
"Ellipsis within quotes..."
```

The second double quotes should be rdquo, but smarty makes ldquo. I tried to figure out where the bug might be, but I couldn't narrow down the bug because all of these cases succeed:

```
"One period."
"Two periods.."
"Semicolon;"
```

There must be something about the order of regexp evaluation I'm not understanding.
