### PR TITLE
smarty: add support for angled quotes

### DIFF
--- a/docs/extensions/smarty.txt
+++ b/docs/extensions/smarty.txt
@@ -15,11 +15,12 @@ their HTML entity equivalents.
 
 ASCII symbol | Replacements    | HTML Entities
 ------------ | --------------- | -------------------
-&#39;        | &lsquo; &rsquo; | `&lsquo;` `&rsquo;`
-&quot;       | &ldquo; &rdquo; | `&ldquo;` `&rdquo;`
-\...         | &hellip;        | `&hellip;`
-\--          | &ndash;         | `&ndash;`
--\--         | &mdash;         | `&mdash;`
+`'`          | &lsquo; &rsquo; | `&lsquo;` `&rsquo;`
+`"`          | &ldquo; &rdquo; | `&ldquo;` `&rdquo;`
+`<< >>`      | &laquo; &raquo; | `&laquo;` `&raquo;`
+`...`        | &hellip;        | `&hellip;`
+`--`         | &ndash;         | `&ndash;`
+`---`        | &mdash;         | `&mdash;`
 
 !!! note
     This extension reimplements the Python [SmartyPants] 
@@ -42,13 +43,14 @@ as the name of the extension.
 See the [Library Reference](../reference.html#extensions) for information about
 configuring extensions.
 
-The following options are provided to configure the output (all three are set to `True` by default):
+The following options are provided to configure the output:
 
-Option           | Description
-------           | -----------
-`smart_dashes`   | whether to convert dashes
-`smart_quotes`   | whether to convert quotes
-`smart_ellipses` | whether to convert ellipses
+Option                | Default value | Description
+------                | ------------- | -----------
+`smart_dashes`        | enabled       | whether to convert dashes
+`smart_quotes`        | enabled       | whether to convert straight quotes
+`smart_angled_quotes` | disabled      | whether to convert angled quotes
+`smart_ellipses`      | enabled       | whether to convert ellipses
 
 Further reading
 ---------------

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -137,6 +137,7 @@ class SmartyExtension(Extension):
     def __init__(self, configs):
         self.config = {
             'smart_quotes': [True, 'Educate quotes'],
+            'smart_angled_quotes': [False, 'Educate angled quotes'],
             'smart_dashes': [True, 'Educate dashes'],
             'smart_ellipses': [True, 'Educate ellipses']
         }
@@ -162,6 +163,14 @@ class SmartyExtension(Extension):
         ellipsesPattern = SubstituteTextPattern(r'(?<!\.)\.{3}(?!\.)', ('&hellip;',), md)
         self.inlinePatterns.add('smarty-ellipses', ellipsesPattern, '_begin')
 
+    def educateAngledQuotes(self, md):
+        leftAngledQuotePattern = SubstituteTextPattern(r'\<\<', ('&laquo;',), md)
+        rightAngledQuotePattern = SubstituteTextPattern(r'\>\>', ('&raquo;',), md)
+        self.inlinePatterns.add('smarty-left-angle-quotes',
+                                leftAngledQuotePattern, '_begin')
+        self.inlinePatterns.add('smarty-right-angle-quotes',
+                                rightAngledQuotePattern, '>smarty-left-angle-quotes')
+
     def educateQuotes(self, md):
         patterns = (
             (singleQuoteStartRe, (rsquo,)),
@@ -186,6 +195,8 @@ class SmartyExtension(Extension):
             self.educateEllipses(md)
         if configs['smart_quotes']:
             self.educateQuotes(md)
+        if configs['smart_angled_quotes']:
+            self.educateAngledQuotes(md)
         if configs['smart_dashes']:
             self.educateDashes(md)
         inlineProcessor = InlineProcessor(md)

--- a/tests/extensions/smarty.html
+++ b/tests/extensions/smarty.html
@@ -14,6 +14,8 @@ one two &lsquo;60s<br />
 em-dashes (&mdash;) and ellipes (&hellip;)<br />
 &ldquo;<a href="http://example.com">Link</a>&rdquo; &mdash; she said.</p>
 <p>&ldquo;Ellipsis within quotes&hellip;&rdquo;</p>
+<p>Кавычки-&laquo;ёлочки&raquo;<br />
+Anführungszeichen-&raquo;Chevrons&laquo;</p>
 <hr />
 <p>Escaped -- ndash<br />
 'Escaped' "quotes"<br />

--- a/tests/extensions/smarty.txt
+++ b/tests/extensions/smarty.txt
@@ -17,6 +17,9 @@ em-dashes (---) and ellipes (...)
 
 "Ellipsis within quotes..."
 
+Кавычки-<<ёлочки>>  
+Anführungszeichen->>Chevrons<<
+
 --- -- ---
 
 Escaped \-- ndash  

--- a/tests/extensions/test.cfg
+++ b/tests/extensions/test.cfg
@@ -40,4 +40,4 @@ extensions=nl2br,attr_list
 extensions=admonition
 
 [smarty]
-extensions=smarty
+extensions=smarty(smart_angled_quotes=1)


### PR DESCRIPTION
Such quotes are used in French, Russian/Ukrainian/Belorussian, German and many other languages. See http://en.wikipedia.org/wiki/Guillemet for details.

Now smartypants will convert `<<` to `«` and `>>` to `»` if the corresponding option is set (disabled by default).
