### PR TITLE
Orgtbl compat

### DIFF
--- a/docs/extensions/tables.txt
+++ b/docs/extensions/tables.txt
@@ -49,6 +49,14 @@ will be rendered as:
       </tbody>
     </table>
 
+Alternatively, as a convenience for [org-mode](http://orgmode.org/) users the
+following text will yield the same html:
+
+    | First Header | Second Header |
+    |--------------+---------------|
+    | Content Cell | Content Cell  |
+    | Content Cell | Content Cell  |
+
 Usage
 -----
 

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -26,7 +26,7 @@ class TableProcessor(BlockProcessor):
     def test(self, parent, block):
         rows = block.split('\n')
         return (len(rows) > 2 and '|' in rows[0] and 
-                '|' in rows[1] and '-' in rows[1] and 
+                '-' in rows[1] and ('|' in rows[1] or '+' in rows[1]) and
                 rows[1].strip()[0] in ['|', ':', '-'])
 
     def run(self, parent, blocks):
@@ -41,7 +41,7 @@ class TableProcessor(BlockProcessor):
             border = True
         # Get alignment of columns
         align = []
-        for c in self._split_row(seperator, border):
+        for c in self._split_header_row(seperator, border):
             if c.startswith(':') and c.endswith(':'):
                 align.append('center')
             elif c.startswith(':'):
@@ -75,6 +75,13 @@ class TableProcessor(BlockProcessor):
                 c.text = ""
             if a:
                 c.set('align', a)
+
+    def _split_header_row(self, row, border):
+        """ split a header row into list of cells. """
+        cells = []
+        for c in self._split_row(row, border):
+            cells.extend(c.split('+'))
+        return cells
 
     def _split_row(self, row, border):
         """ split a row of text into list of cells. """

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -25,7 +25,7 @@ class TableProcessor(BlockProcessor):
 
     def test(self, parent, block):
         rows = block.split('\n')
-        return (len(rows) > 2 and '|' in rows[0] and 
+        return (len(rows) > 2 and '|' in rows[0] and
                 '-' in rows[1] and ('|' in rows[1] or '+' in rows[1]) and
                 rows[1].strip()[0] in ['|', ':', '-'])
 
@@ -65,7 +65,7 @@ class TableProcessor(BlockProcessor):
         if parent.tag == 'thead':
             tag = 'th'
         cells = self._split_row(row, border)
-        # We use align here rather than cells to ensure every row 
+        # We use align here rather than cells to ensure every row
         # contains the same number of columns.
         for i, a in enumerate(align):
             c = etree.SubElement(tr, tag)
@@ -98,7 +98,7 @@ class TableExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
         """ Add an instance of TableProcessor to BlockParser. """
-        md.parser.blockprocessors.add('table', 
+        md.parser.blockprocessors.add('table',
                                       TableProcessor(md.parser),
                                       '<hashheader')
 

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -117,6 +117,125 @@
 </tr>
 </tbody>
 </table>
+<p>Cross section with +:</p>
+<table>
+<thead>
+<tr>
+<th>First Header</th>
+<th>Second Header</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Content Cell</td>
+<td>Content Cell</td>
+</tr>
+<tr>
+<td>Content Cell</td>
+<td>Content Cell</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>First Header</th>
+<th>Second Header</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Content Cell</td>
+<td>Content Cell</td>
+</tr>
+<tr>
+<td>Content Cell</td>
+<td>Content Cell</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Item</th>
+<th align="right">Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Computer</td>
+<td align="right">$1600</td>
+</tr>
+<tr>
+<td>Phone</td>
+<td align="right">$12</td>
+</tr>
+<tr>
+<td>Pipe</td>
+<td align="right">$1</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Function name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>help()</code></td>
+<td>Display the help window.</td>
+</tr>
+<tr>
+<td><code>destroy()</code></td>
+<td><strong>Destroy your computer!</strong></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th align="left">foo</th>
+<th align="center">bar</th>
+<th align="right">baz</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left"></td>
+<td align="center">Q</td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="left">W</td>
+<td align="center"></td>
+<td align="right">W</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+<th>baz</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+<td>Q</td>
+<td></td>
+</tr>
+<tr>
+<td>W</td>
+<td></td>
+<td>W</td>
+</tr>
+</tbody>
+</table>
 <p>Three spaces in front of a table:</p>
 <table>
 <thead>

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -236,6 +236,49 @@
 </tr>
 </tbody>
 </table>
+<p>Mixed cross section:</p>
+<table>
+<thead>
+<tr>
+<th align="left">foo</th>
+<th align="center">bar</th>
+<th align="right">baz</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left"></td>
+<td align="center">Q</td>
+<td align="right"></td>
+</tr>
+<tr>
+<td align="left">W</td>
+<td align="center"></td>
+<td align="right">W</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+<th>baz</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+<td>Q</td>
+<td></td>
+</tr>
+<tr>
+<td>W</td>
+<td></td>
+<td>W</td>
+</tr>
+</tbody>
+</table>
 <p>Three spaces in front of a table:</p>
 <table>
 <thead>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -90,7 +90,7 @@ Three spaces in front of a table:
    | Content Cell | Content Cell  |
 
 Four spaces is a code block:
-   
+
     First Header | Second Header
     ------------ | -------------
     Content Cell | Content Cell

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -32,6 +32,39 @@ foo|bar|baz
    | Q |
  W |   | W
 
+Cross section with +:
+
+First Header | Second Header
+-------------+--------------
+Content Cell | Content Cell
+Content Cell | Content Cell
+
+| First Header  | Second Header |
+| --------------+-------------- |
+| Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  |
+
+| Item      | Value |
+| :---------+------:|
+| Computer  | $1600 |
+| Phone     |   $12 |
+| Pipe      |    $1 |
+
+| Function name | Description                    |
+| --------------+------------------------------- |
+| `help()`      | Display the help window.       |
+| `destroy()`   | **Destroy your computer!**     |
+
+|foo|bar|baz|
+|:--+:-:+--:|
+|   | Q |   |
+|W  |   |  W|
+
+foo|bar|baz
+---+---+---
+   | Q |
+ W |   | W
+
 Three spaces in front of a table:
 
    First Header | Second Header

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -65,6 +65,18 @@ foo|bar|baz
    | Q |
  W |   | W
 
+Mixed cross section:
+
+|foo|bar|baz|
+|:--|:-:+--:|
+|   | Q |   |
+|W  |   |  W|
+
+foo|bar|baz
+---+---|---
+   | Q |
+ W |   | W
+
 Three spaces in front of a table:
 
    First Header | Second Header


### PR DESCRIPTION
This branch adds additional syntax to the table extension such that the `+` character can be used as a cross-section character in header separators. This is particularly convenient for emacs org-mode users as it has tools based on this syntax. e.g.:

```
| First Header | Second Header |
|--------------+---------------|
| Content Cell | Content Cell  |
| Content Cell | Content Cell  |
```

This addition is backwards compatible and does not affect existing functionality.

Tests (all passing) and docs updates are included.
