### PR TITLE
tox.ini: install pytidylib from PyPI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,6 @@ envlist = py26, py27, py31, py32, py33, py34
 downloadcache = {toxworkdir}/cache
 deps = nose
        coverage
-       git+https://github.com/waylan/pytidylib.git#egg=PyTidyLib
+       pytidylib
 commands = coverage run --source=markdown {toxinidir}/run-tests.py {posargs}
            coverage report --show-missing


### PR DESCRIPTION
PyTidyLib Python 3 issues have been fixed in 0.2.3 release
