### PR TITLE
Fix including MANIFEST.in (fixes tox from sdist)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,4 @@ include makefile
 include LICENSE.md
 include README.md
 include INSTALL.md
-include MANIFEST
+include MANIFEST.in


### PR DESCRIPTION
Currently (without MANIFEST.in in the sdist), running tox results in the following error:

```
running build_docs
error: [Errno 2] No such file or directory: 'docs/_template.html'
```

Fetching the raw MANIFEST.in from the github repository correctly allows the relevant files (recursive-include docs *, in this case) to be included in the virtualenv that is created by tox.

I'm assuming that the addition of "MANIFEST" in MANIFEST.in" was a typo, and that MANIFEST.in was intended instead. If this is not the case, feel free to reject this PR and resolve in a different manner
