### PR TITLE
Fix InlineProcessor and add better italic and bold support

### DIFF
--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -20,16 +20,18 @@ from __future__ import unicode_literals
 from . import Extension
 from ..inlinepatterns import SimpleTagPattern
 
-SMART_STRONG_RE = r'(?<!\w)(_{2})(?!_)(.+?)(?<!_)\2(?!\w)'
-STRONG_RE = r'(\*{2})(.+?)\2'
+SMART_STRONG_RE = r'(?<!\w)(_{2})(?![_\s])(.+?_*?)(?<!\s)\2(?!\w)'
+SMART_STRONG_EM_RE = r'(?<!\w)(_{3})(?![_\s])(.+?_*?)(?<!\s)\2(?!\w)'
 
 class SmartEmphasisExtension(Extension):
     """ Add smart_emphasis extension to Markdown class."""
 
     def extendMarkdown(self, md, md_globals):
         """ Modify inline patterns. """
-        md.inlinePatterns['strong'] = SimpleTagPattern(STRONG_RE, 'strong')
-        md.inlinePatterns.add('strong2', SimpleTagPattern(SMART_STRONG_RE, 'strong'), '>emphasis2')
+        md.inlinePatterns['strong2'] = SimpleTagPattern(SMART_STRONG_RE, 'strong')
+        md.inlinePatterns['strong_em2'] = SimpleTagPattern(SMART_STRONG_EM_RE, 'strong')
+        del md.inlinePatterns['strong_em4']
+        del md.inlinePatterns['em_strong2']
 
 def makeExtension(*args, **kwargs):
     return SmartEmphasisExtension(*args, **kwargs)

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -26,15 +26,15 @@ SMART_STRONG_2_RE = r'(?<!\w)(_{2})(?![\s_])%s(?<!\s)\2(?!\w)' % SMART_CONTENT
 # Smart rules for when "smart emphasis" is enabled
 # ___strong,em_strong__
 SMART_STRONG_EM_4_RE = \
-r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_(?!\w)%s(?<!\s)_{2}(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
 # ___em,strong__em_
 SMART_EM_STRONG_2_RE = \
-r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_{2}(?![\s_])%s(?<!\s)_(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_{2}(?!\w)%s(?<!\s)_(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
 
 # Smart rules for when "smart emphasis" is disabled
 # ___strong,em_strong__
 STRONG_EM_4_RE = \
-r'(?<!\w)(_{3})(?!\s)%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (UNDER_CONTENT, SMART_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (UNDER_CONTENT, SMART_CONTENT)
 # ___em,strong__em_
 EM_STRONG_2_RE = \
 r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_{2}(?!\w)%s(?<!\s)_' % (SMART_CONTENT, UNDER_CONTENT)

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -4,34 +4,57 @@ Smart_Strong Extension for Python-Markdown
 
 This extention adds smarter handling of double underscores within words.
 
-See <https://pythonhosted.org/Markdown/extensions/smart_strong.html> 
+See <https://pythonhosted.org/Markdown/extensions/smart_strong.html>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)
 
 All changes Copyright 2011-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 '''
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
-from ..inlinepatterns import SimpleTagPattern
+from ..inlinepatterns import SimpleTagPattern, DoubleTagPattern
+from ..inlinepatterns import UNDER_CONTENT, SMART_CONTENT, SMART_STRONG_EM_RE
 
-SMART_STRONG_RE = r'(?<!\w)(_{2})(?![_\s])(.+?_*?)(?<!\s)\2(?!\w)'
-SMART_STRONG_EM_RE = r'(?<!\w)(_{3})(?![_\s])(.+?_*?)(?<!\s)\2(?!\w)'
+SMART_STRONG_2_RE = r'(?<!\w)(_{2})(?![\s_])%s(?<!\s)\2(?!\w)' % SMART_CONTENT
+
+# Smart rules for when "smart emphasis" is enabled
+# ___strong,em_strong__
+SMART_STRONG_EM_4_RE = \
+r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
+# ___em,strong__em_
+SMART_EM_STRONG_2_RE = \
+r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_{2}(?![\s_])%s(?<!\s)_(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
+
+# Smart rules for when "smart emphasis" is disabled
+# ___strong,em_strong__
+STRONG_EM_4_RE = \
+r'(?<!\w)(_{3})(?!\s)%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (UNDER_CONTENT, SMART_CONTENT)
+# ___em,strong__em_
+EM_STRONG_2_RE = \
+r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_{2}(?!\w)%s(?<!\s)_' % (SMART_CONTENT, UNDER_CONTENT)
+
 
 class SmartEmphasisExtension(Extension):
     """ Add smart_emphasis extension to Markdown class."""
 
     def extendMarkdown(self, md, md_globals):
         """ Modify inline patterns. """
-        md.inlinePatterns['strong2'] = SimpleTagPattern(SMART_STRONG_RE, 'strong')
-        md.inlinePatterns['strong_em2'] = SimpleTagPattern(SMART_STRONG_EM_RE, 'strong')
-        del md.inlinePatterns['strong_em4']
-        del md.inlinePatterns['em_strong2']
+
+        md.inlinePatterns['strong2'] = SimpleTagPattern(SMART_STRONG_2_RE, 'strong')
+        md.inlinePatterns['strong_em2'] = DoubleTagPattern(SMART_STRONG_EM_RE, 'strong,em')
+
+        if not md.smart_emphasis:
+            md.inlinePatterns['em_strong2'] = DoubleTagPattern(EM_STRONG_2_RE, 'em,strong')
+            md.inlinePatterns['strong_em4'] = DoubleTagPattern(STRONG_EM_4_RE, 'strong,em')
+        else:
+            md.inlinePatterns['em_strong2'] = DoubleTagPattern(SMART_EM_STRONG_2_RE, 'em,strong')
+            md.inlinePatterns['strong_em4'] = DoubleTagPattern(SMART_STRONG_EM_4_RE, 'strong,em')
 
 def makeExtension(*args, **kwargs):
     return SmartEmphasisExtension(*args, **kwargs)

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -26,10 +26,10 @@ SMART_STRONG_2_RE = r'(?<!\w)(_{2})(?![\s_])%s(?<!\s)\2(?!\w)' % SMART_CONTENT
 # Smart rules for when "smart emphasis" is enabled
 # ___strong,em_strong__
 SMART_STRONG_EM_4_RE = \
-r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
 # ___em,strong__em_
 SMART_EM_STRONG_2_RE = \
-r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_{2}(?![\s_])%s(?<!\s)_(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_{2}(?![\s_])%s(?<!\s)_(?!\w)' % (SMART_CONTENT, SMART_CONTENT)
 
 # Smart rules for when "smart emphasis" is disabled
 # ___strong,em_strong__
@@ -37,7 +37,7 @@ STRONG_EM_4_RE = \
 r'(?<!\w)(_{3})(?!\s)%s(?<!\s)_%s(?<!\s)_{2}(?!\w)' % (UNDER_CONTENT, SMART_CONTENT)
 # ___em,strong__em_
 EM_STRONG_2_RE = \
-r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_{2}(?!\w)%s(?<!\s)_' % (SMART_CONTENT, UNDER_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_{2}(?!\w)%s(?<!\s)_' % (SMART_CONTENT, UNDER_CONTENT)
 
 
 class SmartEmphasisExtension(Extension):

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -168,7 +168,7 @@ class Pattern(object):
 
         """
         self.pattern = pattern
-        self.compiled_re = re.compile("^(.*?)%s(.*?)$" % pattern, 
+        self.compiled_re = re.compile("^(.*?)%s(.*?)$" % pattern,
                                       re.DOTALL | re.UNICODE)
 
         # Api for Markdown to pass safe_mode into instance
@@ -222,7 +222,7 @@ class Pattern(object):
                     return value
                 else:
                     # An etree Element - return text content only
-                    return ''.join(itertext(value)) 
+                    return ''.join(itertext(value))
         return util.INLINE_PLACEHOLDER_RE.sub(get_stash, text)
 
 
@@ -240,7 +240,7 @@ class EscapePattern(Pattern):
         if char in self.markdown.ESCAPED_CHARS:
             return '%s%s%s' % (util.STX, ord(char), util.ETX)
         else:
-            return None 
+            return None
 
 
 class SimpleTagPattern(Pattern):
@@ -314,7 +314,7 @@ class HtmlPattern(Pattern):
                     return self.markdown.serializer(value)
                 except:
                     return '\%s' % value
-            
+
         return util.INLINE_PLACEHOLDER_RE.sub(get_stash, text)
 
 
@@ -334,7 +334,7 @@ class LinkPattern(Pattern):
             el.set("href", "")
 
         if title:
-            title = dequote(self.unescape(title)) 
+            title = dequote(self.unescape(title))
             el.set("title", title)
         return el
 
@@ -358,19 +358,19 @@ class LinkPattern(Pattern):
         if not self.markdown.safeMode:
             # Return immediately bipassing parsing.
             return url
-        
+
         try:
             scheme, netloc, path, params, query, fragment = url = urlparse(url)
         except ValueError: #pragma: no cover
             # Bad url - so bad it couldn't be parsed.
             return ''
-        
+
         locless_schemes = ['', 'mailto', 'news']
         allowed_schemes = locless_schemes + ['http', 'https', 'ftp', 'ftps']
         if scheme not in allowed_schemes:
             # Not a known (allowed) scheme. Not safe.
             return ''
-            
+
         if netloc == '' and scheme not in locless_schemes: #pragma: no cover
             # This should not happen. Treat as suspect.
             return ''

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -128,7 +128,7 @@ STRONG_EM_3_RE = \
 r'(\*{3})(?!\s)%s(?<!\s)\*%s(?<!\s)\*{2}' % (STAR_CONTENT, STAR_CONTENT2)
 # ___strong,em_strong__
 STRONG_EM_4_RE = \
-r'(_{3})(?!\s)%s(?<!\s)_%s(?<!\s)_{2}' % (UNDER_CONTENT2, UNDER_CONTENT)
+r'(_{3})(?!\s)%s(?<!\s)_%s(?<!\s)_{2}' % (UNDER_CONTENT, UNDER_CONTENT2)
 # ***em,strong**em*
 EM_STRONG_RE = \
 r'(\*{3})(?!\s)%s(?<!\s)\*{2}%s(?<!\s)\*' % (STAR_CONTENT2, STAR_CONTENT)

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -76,7 +76,13 @@ def build_inlinepatterns(md_instance, **kwargs):
     inlinePatterns["entity"] = HtmlPattern(ENTITY_RE, md_instance)
     inlinePatterns["not_strong"] = SimpleTextPattern(NOT_STRONG_RE)
     inlinePatterns["strong_em"] = DoubleTagPattern(STRONG_EM_RE, 'strong,em')
+    inlinePatterns["strong_em2"] = DoubleTagPattern(STRONG_EM_2_RE, 'strong,em')
+    inlinePatterns["strong_em3"] = DoubleTagPattern(STRONG_EM_3_RE, 'strong,em')
+    inlinePatterns["strong_em4"] = DoubleTagPattern(STRONG_EM_4_RE, 'strong,em')
+    inlinePatterns["em_strong"] = DoubleTagPattern(EM_STRONG_RE, 'em,strong')
+    inlinePatterns["em_strong2"] = DoubleTagPattern(EM_STRONG_2_RE, 'em,strong')
     inlinePatterns["strong"] = SimpleTagPattern(STRONG_RE, 'strong')
+    inlinePatterns["strong2"] = SimpleTagPattern(STRONG_2_RE, 'strong')
     inlinePatterns["emphasis"] = SimpleTagPattern(EMPHASIS_RE, 'em')
     if md_instance.smart_emphasis:
         inlinePatterns["emphasis2"] = SimpleTagPattern(SMART_EMPHASIS_RE, 'em')
@@ -96,13 +102,19 @@ BRK = ( r'\[('
         + NOBRACKET + r')\]' )
 NOIMG = r'(?<!\!)'
 
-BACKTICK_RE = r'(?<!\\)(`+)(.+?)(?<!`)\2(?!`)' # `e=f()` or ``e=f("`")``
-ESCAPE_RE = r'\\(.)'                             # \<
-EMPHASIS_RE = r'(\*)([^\*]+)\2'                    # *emphasis*
-STRONG_RE = r'(\*{2}|_{2})(.+?)\2'                      # **strong**
-STRONG_EM_RE = r'(\*{3}|_{3})(.+?)\2'            # ***strong***
-SMART_EMPHASIS_RE = r'(?<!\w)(_)(?!_)(.+?)(?<!_)\2(?!\w)'  # _smart_emphasis_
-EMPHASIS_2_RE = r'(_)(.+?)\2'                 # _emphasis_
+BACKTICK_RE = r'(?<!\\)(`+)(.+?)(?<!`)\2(?!`)'                    # `e=f()` or ``e=f("`")``
+ESCAPE_RE = r'\\(.)'                                              # \<
+STRONG_RE = r'(\*{2})(?!\s)(.+?)(?<!\s)\2'                        # **strong**
+STRONG_2_RE = r'(_{2})(?!\s)(.+?)(?<!\s)\2'                       # __strong__
+STRONG_EM_RE = r'(\*{3})(?!\s)(.+?)(?<!\s)\2'                     # ***strong,em***
+STRONG_EM_2_RE = r'(_{3})(?!\s)(.+?)(?<!\s)\2'                    # ___strong,em___
+STRONG_EM_3_RE = r'(\*{3})(?!\s)(.+?)(?<!\s)\*{2}(.+?)(?<!\s)\*'  # ***strong**em*
+STRONG_EM_4_RE = r'(_{3})(?!\s)(.+?)(?<!\s)_{2}(.+?)(?<!\s)_'     # ___strong__em_
+EMPHASIS_RE = r'(\*)(?!\s)(.+?)(?<!\s)\2'                         # *emphasis*
+EMPHASIS_2_RE = r'(_)(?!\s)(.+?)(?<!\s)\2'                        # _emphasis_
+SMART_EMPHASIS_RE = r'(?<!\w)(_)(?![_\s])(.+?_*?)(?<!\s)\2(?!\w)' # _smart_emphasis_
+EM_STRONG_RE = r'(\*{3})(?!\s)(.+?)(?<!\s)\*(.+?)(?<!\s)\*{2}'    # ***em*strong**
+EM_STRONG_2_RE = r'(_{3})(?!\s)(.+?)(?<!\s)_(.+?)(?<!\s)_{2}'     # ___em_strong__
 LINK_RE = NOIMG + BRK + \
 r'''\(\s*(<.*?>|((?:(?:\(.*?\))|[^\(\)]))*?)\s*((['"])(.*?)\12\s*)?\)'''
 # [text](url) or [text](<url>) or [text](url "title")
@@ -276,6 +288,8 @@ class DoubleTagPattern(SimpleTagPattern):
         el1 = util.etree.Element(tag1)
         el2 = util.etree.SubElement(el1, tag2)
         el2.text = m.group(3)
+        if len(m.groups()) == 5:
+            el2.tail = m.group(4)
         return el1
 
 
@@ -476,4 +490,3 @@ class AutomailPattern(Pattern):
                           ord(letter) for letter in mailto])
         el.set('href', mailto)
         return el
-

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -113,11 +113,11 @@ NOIMG = r'(?<!\!)'
 
 BACKTICK_RE = r'(?<!\\)(`+)(.+?)(?<!`)\2(?!`)'        # `e=f()` or ``e=f("`")``
 ESCAPE_RE = r'\\(.)'                                  # \<
-SMART_CONTENT = r'((?:[^_]|(?<!_)_(?=[^\W_]))+?_*)'
+SMART_CONTENT = r'((?:[^_]|_(?=\w))+?_*)'
 UNDER_CONTENT = r'(_|[^_]+?)'
-UNDER_CONTENT2 = r'((?:[^_]|(?<!_)_(?=[^\W_]))+?)'
+UNDER_CONTENT2 = r'((?:[^_]|(?<!_)_(?=\w))+?)'
 STAR_CONTENT = r'(\*|[^\*]+?)'
-STAR_CONTENT2 = r'((?:[^\*]|(?<!\*)\*(?=[^\W\*]))+?)'
+STAR_CONTENT2 = r'((?:[^\*]|(?<!\*)\*(?=[^\W_]))+?)'
 
 # ***strong,em***
 STRONG_EM_RE = r'(\*{3})(?!\s)(\*{1,2}|[^\*]+?)(?<!\s)\2'
@@ -125,16 +125,16 @@ STRONG_EM_RE = r'(\*{3})(?!\s)(\*{1,2}|[^\*]+?)(?<!\s)\2'
 STRONG_EM_2_RE = r'(_{3})(?!\s)(_{1,2}|[^_]+?)(?<!\s)\2'
 # ***strong,em*strong**
 STRONG_EM_3_RE = \
-r'(\*{3})(?!\s)%s(?<!\s)\*%s(?<!\s)\*{2}' % (STAR_CONTENT, STAR_CONTENT2)
+r'(\*{3})(?![\s\*])%s(?<!\s)\*%s(?<!\s)\*{2}' % (STAR_CONTENT, STAR_CONTENT2)
 # ___strong,em_strong__
 STRONG_EM_4_RE = \
-r'(_{3})(?!\s)%s(?<!\s)_%s(?<!\s)_{2}' % (UNDER_CONTENT, UNDER_CONTENT2)
+r'(_{3})(?![\s_])%s(?<!\s)_%s(?<!\s)_{2}' % (UNDER_CONTENT, UNDER_CONTENT2)
 # ***em,strong**em*
 EM_STRONG_RE = \
-r'(\*{3})(?!\s)%s(?<!\s)\*{2}%s(?<!\s)\*' % (STAR_CONTENT2, STAR_CONTENT)
+r'(\*{3})(?![\s\*])%s(?<!\s)\*{2}%s(?<!\s)\*' % (STAR_CONTENT2, STAR_CONTENT)
 # ___em,strong__em_
 EM_STRONG_2_RE = \
-r'(_{3})(?!\s)%s(?<!\s)_{2}%s(?<!\s)_' % (UNDER_CONTENT2, UNDER_CONTENT)
+r'(_{3})(?![\s_])%s(?<!\s)_{2}%s(?<!\s)_' % (UNDER_CONTENT2, UNDER_CONTENT)
 # **strong**
 STRONG_RE = r'(\*{2})(?!\s)%s(?<!\s)\2' % STAR_CONTENT2
 # __strong__
@@ -146,7 +146,7 @@ EMPHASIS_2_RE = r'(_)(?!\s)%s(?<!\s)\2' % UNDER_CONTENT
 
 # SMART: ___strong,em___
 SMART_STRONG_EM_RE = \
-r'(?<!\w)(_{3})(?![\s_])((?:[^_]|_(?=[^\W]))+?_*)(?<!\s)\2(?!\w)'
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)\2(?!\w)' % SMART_CONTENT
 # SMART: ___strong,em_strong__
 SMART_STRONG_EM_4_RE = \
 r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_(?!\w)%s(?<!\s)_{2}' % (SMART_CONTENT, UNDER_CONTENT2)

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -117,7 +117,7 @@ SMART_CONTENT = r'((?:[^_]|_(?=\w))+?_*)'
 UNDER_CONTENT = r'(_|[^_]+?)'
 UNDER_CONTENT2 = r'((?:[^_]|(?<!_)_(?=\w))+?)'
 STAR_CONTENT = r'(\*|[^\*]+?)'
-STAR_CONTENT2 = r'((?:[^\*]|(?<!\*)\*(?=[^\W_]))+?)'
+STAR_CONTENT2 = r'((?:[^\*]|(?<!\*)\*(?=[^\W_]|\*))+?)'
 
 # ***strong,em***
 STRONG_EM_RE = r'(\*{3})(?!\s)(\*{1,2}|[^\*]+?)(?<!\s)\2'

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -149,7 +149,7 @@ SMART_STRONG_EM_RE = \
 r'(?<!\w)(_{3})(?![\s_])((?:[^_]|_(?=[^\W]))+?_*)(?<!\s)\2(?!\w)'
 # SMART: ___strong,em_strong__
 SMART_STRONG_EM_4_RE = \
-r'(?<!\w)(_{3})(?!\s)(?![\s_])%s(?<!\s)_(?!\w)%s(?<!\s)_{2}' % (SMART_CONTENT, UNDER_CONTENT2)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_(?!\w)%s(?<!\s)_{2}' % (SMART_CONTENT, UNDER_CONTENT2)
 # SMART: ___em,strong__em_
 SMART_EM_STRONG_2_RE = \
 r'(?<!\w)(_{3})(?!\s)%s(?<!\s)_{2}(?![\s_])%s(?<!\s)_(?!\w)' % (UNDER_CONTENT2, SMART_CONTENT)

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -152,7 +152,7 @@ SMART_STRONG_EM_4_RE = \
 r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_(?!\w)%s(?<!\s)_{2}' % (SMART_CONTENT, UNDER_CONTENT2)
 # SMART: ___em,strong__em_
 SMART_EM_STRONG_2_RE = \
-r'(?<!\w)(_{3})(?!\s)%s(?<!\s)_{2}(?![\s_])%s(?<!\s)_(?!\w)' % (UNDER_CONTENT2, SMART_CONTENT)
+r'(?<!\w)(_{3})(?![\s_])%s(?<!\s)_{2}%s(?<!\s)_(?!\w)' % (UNDER_CONTENT2, SMART_CONTENT)
 # SMART _em_
 SMART_EMPHASIS_RE = r'(?<!\w)(_)(?![\s_])%s(?<!\s)\2(?!\w)' % SMART_CONTENT
 

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -292,9 +292,9 @@ class InlineProcessor(Treeprocessor):
                 if child.tail:
                     tail = self.__handleInline(child.tail)
                     dumby = util.etree.Element('d')
-                    tailResult = self.__processPlaceholders(tail, dumby)
-                    if dumby.text:
-                        child.tail = dumby.text
+                    tailResult = self.__processPlaceholders(tail, dumby, False)
+                    if dumby.tail:
+                        child.tail = dumby.tail
                     else:
                         child.tail = None
                     pos = list(currElement).index(child) + 1

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -187,7 +187,7 @@ class InlineProcessor(Treeprocessor):
                         for child in [node] + list(node):
                             if child.tail:
                                 if child.tail.strip():
-                                    self.__processElementText(node, child,False)
+                                    self.__processElementText(node, child, False)
                             if child.text:
                                 if child.text.strip():
                                     self.__processElementText(child, child)
@@ -292,11 +292,10 @@ class InlineProcessor(Treeprocessor):
                 if child.tail:
                     tail = self.__handleInline(child.tail)
                     dumby = util.etree.Element('d')
+                    child.tail = None
                     tailResult = self.__processPlaceholders(tail, dumby, False)
                     if dumby.tail:
                         child.tail = dumby.tail
-                    else:
-                        child.tail = None
                     pos = list(currElement).index(child) + 1
                     tailResult.reverse()
                     for newChild in tailResult:

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -34,8 +34,8 @@ class Treeprocessor(util.Processor):
     def run(self, root):
         """
         Subclasses of Treeprocessor should implement a `run` method, which
-        takes a root ElementTree. This method can return another ElementTree 
-        object, and the existing root ElementTree will be replaced, or it can 
+        takes a root ElementTree. This method can return another ElementTree
+        object, and the existing root ElementTree will be replaced, or it can
         modify the current tree and return None.
         """
         pass #pragma: no cover
@@ -71,7 +71,7 @@ class InlineProcessor(Treeprocessor):
         * index: index, from which we start search
 
         Returns: placeholder id and string index, after the found placeholder.
-        
+
         """
         m = self.__placeholder_re.search(data, index)
         if m:
@@ -151,7 +151,7 @@ class InlineProcessor(Treeprocessor):
         * parent: Element, which contains processing inline data
 
         Returns: list with ElementTree elements with applied inline patterns.
-        
+
         """
         def linkText(text):
             if text:
@@ -240,7 +240,7 @@ class InlineProcessor(Treeprocessor):
                 # We need to process current node too
                 for child in [node] + list(node):
                     if not isString(node):
-                        if child.text: 
+                        if child.text:
                             child.text = self.__handleInline(child.text,
                                                             patternIndex + 1)
                         if child.tail:
@@ -304,7 +304,7 @@ class InlineProcessor(Treeprocessor):
                 if self.markdown.enable_attributes:
                     if element.text and isString(element.text):
                         element.text = \
-                            inlinepatterns.handleAttributes(element.text, 
+                            inlinepatterns.handleAttributes(element.text,
                                                                     element)
                 i = 0
                 for newChild in lst:

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -129,11 +129,10 @@ class InlineProcessor(Treeprocessor):
             text = subnode.tail
             subnode.tail = None
 
-        childResult = self.__processPlaceholders(text, subnode)
+        childResult = self.__processPlaceholders(text, subnode, isText)
 
         if not isText and node is not subnode:
             pos = list(node).index(subnode)
-            node.remove(subnode)
         else:
             pos = 0
 
@@ -141,7 +140,7 @@ class InlineProcessor(Treeprocessor):
         for newChild in childResult:
             node.insert(pos, newChild)
 
-    def __processPlaceholders(self, data, parent):
+    def __processPlaceholders(self, data, parent, isText=True):
         """
         Process string with placeholders and generate ElementTree tree.
 
@@ -160,6 +159,11 @@ class InlineProcessor(Treeprocessor):
                         result[-1].tail += text
                     else:
                         result[-1].tail = text
+                elif not isText:
+                    if parent.tail:
+                        parent.tail += text
+                    else:
+                        parent.tail = text
                 else:
                     if parent.text:
                         parent.text += text

--- a/tests/extensions/extra/smart_strong.html
+++ b/tests/extensions/extra/smart_strong.html
@@ -1,0 +1,26 @@
+<p>___test test__ test test_</p>
+<p><strong><em>test test</em> test test</strong></p>
+<p>___test test_ test test_</p>
+<p>__test test_ test test_</p>
+<p>__test_</p>
+<p>___test_</p>
+<p>____test_</p>
+<p>_____test_</p>
+<p>______test_</p>
+<p><strong><em>test</em></strong></p>
+<p><strong>test_</strong></p>
+<p>_____test___</p>
+<p>______test___</p>
+<p><strong><em>test___test</em></strong></p>
+<p><strong><em>test__test</em></strong></p>
+<p>____test___test___</p>
+<p><strong><em>test</em> test_</strong></p>
+<p>__test_ test__</p>
+<p><strong><em>test</em> test</strong></p>
+<p><strong><em>test_test test</em></strong></p>
+<p><strong><em>test__test test</em></strong></p>
+<p><em>test_test test_test</em></p>
+<p><strong><em>test_test_test</em> test_test test</strong></p>
+<p><strong><em>test</em>test_test</strong> test_test_test_</p>
+<p>___test_ test_ test__</p>
+<p><strong><em>test_test __test_____test test</em></strong></p>

--- a/tests/extensions/extra/smart_strong.html
+++ b/tests/extensions/extra/smart_strong.html
@@ -1,26 +1,26 @@
-<p><em><strong>test test</strong> test test</em></p>
-<p><strong><em>test test</em> test test</strong></p>
-<p>___test test_ test test_</p>
-<p>__test test_ test test_</p>
-<p>__test_</p>
-<p>___test_</p>
-<p>____test_</p>
-<p>_____test_</p>
-<p>______test_</p>
-<p><strong><em>test</em></strong></p>
-<p><strong>test_</strong></p>
-<p>_____test___</p>
-<p>______test___</p>
-<p><strong><em>test___test</em></strong></p>
-<p><strong><em>test__test</em></strong></p>
-<p>____test___test___</p>
-<p><strong><em>test</em> test_</strong></p>
-<p>__test_ test__</p>
-<p><strong><em>test</em> test</strong></p>
-<p><strong><em>test_test test</em></strong></p>
-<p><strong><em>test__test test</em></strong></p>
-<p><em>test_test test_test</em></p>
-<p><strong><em>test_test_test</em> test_test test</strong></p>
-<p><em><strong>test_test_test</strong> test_test_test</em></p>
-<p>___test_ test_ test__</p>
-<p><strong><em>test_test __test_____test test</em></strong></p>
+<p><strong><em>normal _ strong em</em></strong></p>
+<p><strong><em>normal_____strong____em</em></strong></p>
+<p>Breaks normal strong em. <strong><em>strong em</em> just strong with trailing underscore_</strong></p>
+<p><strong><em>eat trailing tokens____</em></strong></p>
+<p>____smart boundary to left wont let this trigger___</p>
+<p><strong><em>normal_strong__and_em</em></strong></p>
+<p><strong><em>strong em</em> just strong</strong></p>
+<p><em><strong>em strong</strong> just em</em></p>
+<p>___ not valid ___</p>
+<p>__ not valid __</p>
+<p>_ not valid _</p>
+<p>___not valid__ not valid _</p>
+<p>___not valid_ not valid _</p>
+<p>___ not valid __em_</p>
+<p>___ not valid <em>em_</em></p>
+<p><strong>strong</strong> text_</p>
+<p><em>em</em> text_</p>
+<p>text___not valid___ text</p>
+<p>text ___not valid___text</p>
+<p>text <strong><em>valid</em></strong> text</p>
+<p>text__not valid__ text</p>
+<p>text __not valid__text</p>
+<p>text <strong>valid</strong> text</p>
+<p>text_not valid_ text</p>
+<p>text _not valid_text</p>
+<p>text <em>valid</em> text</p>

--- a/tests/extensions/extra/smart_strong.html
+++ b/tests/extensions/extra/smart_strong.html
@@ -2,6 +2,7 @@
 <p><strong><em>normal_____strong____em</em></strong></p>
 <p><strong>smart______strong</strong></p>
 <p><em>smart____em</em></p>
+<p><strong>dumb_strong</strong></p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong with trailing underscore_</strong></p>
 <p><strong><em>eat trailing tokens____</em></strong></p>
 <p>____smart boundary to left wont let this trigger___</p>

--- a/tests/extensions/extra/smart_strong.html
+++ b/tests/extensions/extra/smart_strong.html
@@ -1,4 +1,4 @@
-<p>___test test__ test test_</p>
+<p><em><strong>test test</strong> test test</em></p>
 <p><strong><em>test test</em> test test</strong></p>
 <p>___test test_ test test_</p>
 <p>__test test_ test test_</p>
@@ -21,6 +21,6 @@
 <p><strong><em>test__test test</em></strong></p>
 <p><em>test_test test_test</em></p>
 <p><strong><em>test_test_test</em> test_test test</strong></p>
-<p><strong><em>test</em>test_test</strong> test_test_test_</p>
+<p><em><strong>test_test_test</strong> test_test_test</em></p>
 <p>___test_ test_ test__</p>
 <p><strong><em>test_test __test_____test test</em></strong></p>

--- a/tests/extensions/extra/smart_strong.html
+++ b/tests/extensions/extra/smart_strong.html
@@ -1,5 +1,7 @@
 <p><strong><em>normal _ strong em</em></strong></p>
 <p><strong><em>normal_____strong____em</em></strong></p>
+<p><strong>smart______strong</strong></p>
+<p><em>smart____em</em></p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong with trailing underscore_</strong></p>
 <p><strong><em>eat trailing tokens____</em></strong></p>
 <p>____smart boundary to left wont let this trigger___</p>

--- a/tests/extensions/extra/smart_strong.txt
+++ b/tests/extensions/extra/smart_strong.txt
@@ -2,6 +2,10 @@ ___normal _ strong em___
 
 ___normal_____strong____em___
 
+__smart______strong__
+
+_smart____em_
+
 Breaks normal strong em. ___strong em_ just strong with trailing underscore___
 
 ___eat trailing tokens_______

--- a/tests/extensions/extra/smart_strong.txt
+++ b/tests/extensions/extra/smart_strong.txt
@@ -6,6 +6,8 @@ __smart______strong__
 
 _smart____em_
 
+__dumb_strong__
+
 Breaks normal strong em. ___strong em_ just strong with trailing underscore___
 
 ___eat trailing tokens_______

--- a/tests/extensions/extra/smart_strong.txt
+++ b/tests/extensions/extra/smart_strong.txt
@@ -1,51 +1,51 @@
-___test test__ test test_
+___normal _ strong em___
 
-___test test_ test test__
+___normal_____strong____em___
 
-___test test_ test test_
+Breaks normal strong em. ___strong em_ just strong with trailing underscore___
 
-__test test_ test test_
+___eat trailing tokens_______
 
-__test_
+____smart boundary to left wont let this trigger___
 
-___test_
+___normal_strong__and_em___
 
-____test_
+___strong em_ just strong__
 
-_____test_
+___em strong__ just em_
 
-______test_
+___ not valid ___
 
-___test___
+__ not valid __
 
-__test___
+_ not valid _
 
-_____test___
+___not valid__ not valid _
 
-______test___
+___not valid_ not valid _
 
-___test___test___
+___ not valid __em_
 
-___test__test___
+___ not valid _em__
 
-____test___test___
+__strong__ text_
 
-___test_ test___
+_em_ text_
 
-__test_ test__
+text___not valid___ text
 
-___test_ test__
+text ___not valid___text
 
-___test_test test___
+text ___valid___ text
 
-___test__test test___
+text__not valid__ text
 
-_test_test test_test_
+text __not valid__text
 
-___test_test_test_ test_test test__
+text __valid__ text
 
-___test_test_test__ test_test_test_
+text_not valid_ text
 
-___test_ test_ test__
+text _not valid_text
 
-___test_test __test_____test test___
+text _valid_ text

--- a/tests/extensions/extra/smart_strong.txt
+++ b/tests/extensions/extra/smart_strong.txt
@@ -1,0 +1,51 @@
+___test test__ test test_
+
+___test test_ test test__
+
+___test test_ test test_
+
+__test test_ test test_
+
+__test_
+
+___test_
+
+____test_
+
+_____test_
+
+______test_
+
+___test___
+
+__test___
+
+_____test___
+
+______test___
+
+___test___test___
+
+___test__test___
+
+____test___test___
+
+___test_ test___
+
+__test_ test__
+
+___test_ test__
+
+___test_test test___
+
+___test__test test___
+
+_test_test test_test_
+
+___test_test_test_ test_test test__
+
+___test_test_test__ test_test_test_
+
+___test_ test_ test__
+
+___test_test __test_____test test___

--- a/tests/extensions/extra/smart_strong_no_smart_em.html
+++ b/tests/extensions/extra/smart_strong_no_smart_em.html
@@ -9,7 +9,7 @@
 <p><em>_</em><em>_</em>test_</p>
 <p><strong><em>test</em></strong></p>
 <p><strong>test_</strong></p>
-<p><strong><em>_</em>test_</strong></p>
+<p><em>_</em><em><em>test</em></em>_</p>
 <p><em>_</em><em>_</em>test<em>_</em></p>
 <p><strong><em>test<em>_</em>test</em></strong></p>
 <p><strong><em>test__test</em></strong></p>

--- a/tests/extensions/extra/smart_strong_no_smart_em.html
+++ b/tests/extensions/extra/smart_strong_no_smart_em.html
@@ -1,0 +1,26 @@
+<p><em><strong>test test</strong> test test</em></p>
+<p><strong><em>test test</em> test test</strong></p>
+<p><em>_</em>test test_ test test_</p>
+<p><em><em>test test</em> test test</em></p>
+<p>_<em>test</em></p>
+<p><em>_</em>test_</p>
+<p><em>_</em><em>test</em></p>
+<p><em>_</em>_<em>test</em></p>
+<p><em>_</em><em>_</em>test_</p>
+<p><strong><em>test</em></strong></p>
+<p><strong>test_</strong></p>
+<p><strong><em>_</em>test_</strong></p>
+<p><em>_</em><em>_</em>test<em>_</em></p>
+<p><strong><em>test<em>_</em>test</em></strong></p>
+<p><strong><em>test__test</em></strong></p>
+<p><em>_</em><em>test</em><em><em>test</em></em>_</p>
+<p><strong><em>test</em> test_</strong></p>
+<p><em><em>test</em> test</em>_</p>
+<p><strong><em>test</em> test</strong></p>
+<p><strong><em>test_test test</em></strong></p>
+<p><strong><em>test__test test</em></strong></p>
+<p><em>test</em>test test<em>test</em></p>
+<p><em>_</em>test<em>test</em>test_ test<em>test test</em>_</p>
+<p><em><strong>test<em>test</em>test</strong> test</em>test<em>test</em></p>
+<p><em>_</em>test_ test_ test__</p>
+<p><strong><em>test<em>test <em><em>test</em></em></em>__test test</em></strong></p>

--- a/tests/extensions/extra/smart_strong_no_smart_em.html
+++ b/tests/extensions/extra/smart_strong_no_smart_em.html
@@ -2,6 +2,7 @@
 <p>Whole thing will be strong with sub em. <strong><em>em<em>_</em><em><em>em</em></em>__em</em></strong></p>
 <p><strong>smart<em>_</em><em>_</em>strong</strong></p>
 <p><em>em</em><em>_</em>em_</p>
+<p><strong>dumb_strong</strong></p>
 <p><strong><em>strong em</em> just strong with trailing underscore_</strong></p>
 <p><strong><em>eat trailing tokens (but regular em will claim an underscore)<em>_</em>_</em></strong></p>
 <p><em>_</em><em>only em will trigger on this</em>__</p>

--- a/tests/extensions/extra/smart_strong_no_smart_em.html
+++ b/tests/extensions/extra/smart_strong_no_smart_em.html
@@ -1,5 +1,7 @@
 <p><strong><em>normal _ strong em</em></strong></p>
 <p>Whole thing will be strong with sub em. <strong><em>em<em>_</em><em><em>em</em></em>__em</em></strong></p>
+<p><strong>smart<em>_</em><em>_</em>strong</strong></p>
+<p><em>em</em><em>_</em>em_</p>
 <p><strong><em>strong em</em> just strong with trailing underscore_</strong></p>
 <p><strong><em>eat trailing tokens (but regular em will claim an underscore)<em>_</em>_</em></strong></p>
 <p><em>_</em><em>only em will trigger on this</em>__</p>

--- a/tests/extensions/extra/smart_strong_no_smart_em.html
+++ b/tests/extensions/extra/smart_strong_no_smart_em.html
@@ -1,26 +1,26 @@
-<p><em><strong>test test</strong> test test</em></p>
-<p><strong><em>test test</em> test test</strong></p>
-<p><em>_</em>test test_ test test_</p>
-<p><em><em>test test</em> test test</em></p>
-<p>_<em>test</em></p>
-<p><em>_</em>test_</p>
-<p><em>_</em><em>test</em></p>
-<p><em>_</em>_<em>test</em></p>
-<p><em>_</em><em>_</em>test_</p>
-<p><strong><em>test</em></strong></p>
-<p><strong>test_</strong></p>
-<p><em>_</em><em><em>test</em></em>_</p>
-<p><em>_</em><em>_</em>test<em>_</em></p>
-<p><strong><em>test<em>_</em>test</em></strong></p>
-<p><strong><em>test__test</em></strong></p>
-<p><em>_</em><em>test</em><em><em>test</em></em>_</p>
-<p><strong><em>test</em> test_</strong></p>
-<p><em><em>test</em> test</em>_</p>
-<p><strong><em>test</em> test</strong></p>
-<p><strong><em>test_test test</em></strong></p>
-<p><strong><em>test__test test</em></strong></p>
-<p><em>test</em>test test<em>test</em></p>
-<p><em>_</em>test<em>test</em>test_ test<em>test test</em>_</p>
-<p><em><strong>test<em>test</em>test</strong> test</em>test<em>test</em></p>
-<p><em>_</em>test_ test_ test__</p>
-<p><strong><em>test<em>test <em><em>test</em></em></em>__test test</em></strong></p>
+<p><strong><em>normal _ strong em</em></strong></p>
+<p>Whole thing will be strong with sub em. <strong><em>em<em>_</em><em><em>em</em></em>__em</em></strong></p>
+<p><strong><em>strong em</em> just strong with trailing underscore_</strong></p>
+<p><strong><em>eat trailing tokens (but regular em will claim an underscore)<em>_</em>_</em></strong></p>
+<p><em>_</em><em>only em will trigger on this</em>__</p>
+<p>Em strong for entire scope, and sub ems. <strong><em>Here are some words<em>and more</em><em>and</em>more</em></strong></p>
+<p><strong><em>strong em</em> just strong</strong></p>
+<p><em><strong>em strong</strong> just em</em></p>
+<p><em>_</em> em will claim the underscores <em>_</em></p>
+<p>__ not valid __</p>
+<p>_ not valid _</p>
+<p><em>_</em>em__ not valid _</p>
+<p><em>_</em>em_ not valid _</p>
+<p><em>_</em> not valid _<em>em</em></p>
+<p><em>_</em> not valid <em>em</em>_</p>
+<p><strong>strong</strong> text_</p>
+<p><em>em</em> text_</p>
+<p>text<em>_</em>em underscores<em>_</em> text</p>
+<p>text <em>_</em>em underscores<em>_</em>text</p>
+<p>text <strong><em>em strong</em></strong> text</p>
+<p>text<em><em>em</em></em> text</p>
+<p>text <em><em>em</em></em>text</p>
+<p>text <strong>strong</strong> text</p>
+<p>text<em>em</em> text</p>
+<p>text <em>em</em>text</p>
+<p>text <em>em</em> text</p>

--- a/tests/extensions/extra/smart_strong_no_smart_em.txt
+++ b/tests/extensions/extra/smart_strong_no_smart_em.txt
@@ -1,51 +1,51 @@
-___test test__ test test_
+___normal _ strong em___
 
-___test test_ test test__
+Whole thing will be strong with sub em. ___em_____em____em___
 
-___test test_ test test_
+___strong em_ just strong with trailing underscore___
 
-__test test_ test test_
+___eat trailing tokens (but regular em will claim an underscore)_______
 
-__test_
+____only em will trigger on this___
 
-___test_
+Em strong for entire scope, and sub ems. ___Here are some words_and more__and_more___
 
-____test_
+___strong em_ just strong__
 
-_____test_
+___em strong__ just em_
 
-______test_
+___ em will claim the underscores ___
 
-___test___
+__ not valid __
 
-__test___
+_ not valid _
 
-_____test___
+___em__ not valid _
 
-______test___
+___em_ not valid _
 
-___test___test___
+___ not valid __em_
 
-___test__test___
+___ not valid _em__
 
-____test___test___
+__strong__ text_
 
-___test_ test___
+_em_ text_
 
-__test_ test__
+text___em underscores___ text
 
-___test_ test__
+text ___em underscores___text
 
-___test_test test___
+text ___em strong___ text
 
-___test__test test___
+text__em__ text
 
-_test_test test_test_
+text __em__text
 
-___test_test_test_ test_test test__
+text __strong__ text
 
-___test_test_test__ test_test_test_
+text_em_ text
 
-___test_ test_ test__
+text _em_text
 
-___test_test __test_____test test___
+text _em_ text

--- a/tests/extensions/extra/smart_strong_no_smart_em.txt
+++ b/tests/extensions/extra/smart_strong_no_smart_em.txt
@@ -2,6 +2,10 @@ ___normal _ strong em___
 
 Whole thing will be strong with sub em. ___em_____em____em___
 
+__smart______strong__
+
+_em____em_
+
 ___strong em_ just strong with trailing underscore___
 
 ___eat trailing tokens (but regular em will claim an underscore)_______

--- a/tests/extensions/extra/smart_strong_no_smart_em.txt
+++ b/tests/extensions/extra/smart_strong_no_smart_em.txt
@@ -1,0 +1,51 @@
+___test test__ test test_
+
+___test test_ test test__
+
+___test test_ test test_
+
+__test test_ test test_
+
+__test_
+
+___test_
+
+____test_
+
+_____test_
+
+______test_
+
+___test___
+
+__test___
+
+_____test___
+
+______test___
+
+___test___test___
+
+___test__test___
+
+____test___test___
+
+___test_ test___
+
+__test_ test__
+
+___test_ test__
+
+___test_test test___
+
+___test__test test___
+
+_test_test test_test_
+
+___test_test_test_ test_test test__
+
+___test_test_test__ test_test_test_
+
+___test_ test_ test__
+
+___test_test __test_____test test___

--- a/tests/extensions/extra/smart_strong_no_smart_em.txt
+++ b/tests/extensions/extra/smart_strong_no_smart_em.txt
@@ -6,6 +6,8 @@ __smart______strong__
 
 _em____em_
 
+__dumb_strong__
+
 ___strong em_ just strong with trailing underscore___
 
 ___eat trailing tokens (but regular em will claim an underscore)_______

--- a/tests/extensions/extra/test.cfg
+++ b/tests/extensions/extra/test.cfg
@@ -27,6 +27,11 @@ tables_and_attr_list:
         - markdown.extensions.tables
         - markdown.extensions.attr_list
 
+smart_strong_no_smart_em:
+    smart_emphasis: False
+    extensions:
+        - markdown.extensions.smart_strong
+
 extra_config:
     extensions:
         - markdown.extensions.extra

--- a/tests/misc/em_strong.html
+++ b/tests/misc/em_strong.html
@@ -4,7 +4,7 @@
 <p>With spaces: * *</p>
 <p>Two underscores __</p>
 <p>with spaces: _ _</p>
-<p>three asterisks: ***</p>
+<p>three asterisks: <em>*</em></p>
 <p>with spaces: * * *</p>
 <p>three underscores: ___</p>
 <p>with spaces: _ _ _</p>

--- a/tests/misc/em_strong_complex.html
+++ b/tests/misc/em_strong_complex.html
@@ -1,0 +1,8 @@
+<p><strong><em>Strong Em</em> Just Em</strong></p>
+<p><strong><em>Strong Em</em> Just Em</strong></p>
+<p><em><strong>Em Strong</strong> Just Strong</em></p>
+<p><em><strong>Em Strong</strong> Just Strong</em></p>
+<p><em>*</em>Em Asterisk* with Plain Text*</p>
+<p>___Smart Rule_ Prevents Match_</p>
+<p><em>*Em</em> Plain Text*</p>
+<p>__Smart Rule_ Prevents Match_</p>

--- a/tests/misc/em_strong_complex.html
+++ b/tests/misc/em_strong_complex.html
@@ -1,6 +1,8 @@
 <h1>Underscore</h1>
 <p><strong><em>normal _ strong em</em></strong></p>
 <p>Whole thing strong em with sub strongs. <strong><em>strong,em_<strong><strong>strong,em</strong></strong>strong,em</em></strong></p>
+<p><strong>strong</strong>__<strong>strong</strong></p>
+<p><em>smart____em</em></p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong with trailing underscore</strong>_</p>
 <p><strong><em>eat trailing tokens____</em></strong></p>
 <p>__<strong>strong</strong>_</p>
@@ -28,6 +30,8 @@
 <h1>Asterisk</h1>
 <p>text <strong><em>normal * strong em</em></strong></p>
 <p>text <strong><em>strong,em</em></strong>*<em>em</em><strong><em>strong,em</em></strong></p>
+<p><strong>strong</strong>**<strong>strong</strong></p>
+<p><em>em</em><em>*</em>em*</p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong</strong>*</p>
 <p>text <strong><em>trailing tokens are eaten by ems</em></strong><em>*</em>*</p>
 <p>text *<strong><em>dumb rules make this strong,em</em></strong></p>

--- a/tests/misc/em_strong_complex.html
+++ b/tests/misc/em_strong_complex.html
@@ -3,6 +3,7 @@
 <p>Whole thing strong em with sub strongs. <strong><em>strong,em_<strong><strong>strong,em</strong></strong>strong,em</em></strong></p>
 <p><strong>strong</strong>__<strong>strong</strong></p>
 <p><em>smart____em</em></p>
+<p><strong>dumb_strong</strong></p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong with trailing underscore</strong>_</p>
 <p><strong><em>eat trailing tokens____</em></strong></p>
 <p>__<strong>strong</strong>_</p>
@@ -32,6 +33,7 @@
 <p>text <strong><em>strong,em</em></strong>*<em>em</em><strong><em>strong,em</em></strong></p>
 <p><strong>strong</strong>**<strong>strong</strong></p>
 <p><em>em</em><em>*</em>em*</p>
+<p><strong>dumb*strong</strong></p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong</strong>*</p>
 <p>text <strong><em>trailing tokens are eaten by ems</em></strong><em>*</em>*</p>
 <p>text *<strong><em>dumb rules make this strong,em</em></strong></p>

--- a/tests/misc/em_strong_complex.html
+++ b/tests/misc/em_strong_complex.html
@@ -1,52 +1,54 @@
-<p><em><strong>test test</strong> test test</em></p>
-<p><strong><em>test test</em> test test</strong></p>
-<p>___test test_ test test_</p>
-<p>__test test_ test test_</p>
-<p>__test_</p>
-<p>___test_</p>
-<p>____test_</p>
-<p>_____test_</p>
-<p>______test_</p>
-<p><strong><em>test</em></strong></p>
-<p><strong>test</strong>_</p>
-<p>___<strong>test</strong>_</p>
-<p>____<strong>test</strong>_</p>
-<p><strong><em>test___test</em></strong></p>
-<p><strong><em>test__test</em></strong></p>
-<p><strong><strong>test</strong>_test</strong>_</p>
-<p><strong><em>test</em> test</strong>_</p>
-<p>__test_ test__</p>
-<p><strong><em>test</em> test</strong></p>
-<p><strong><em>test_test test</em></strong></p>
-<p><strong><em>test__test test</em></strong></p>
-<p><em>test_test test_test</em></p>
-<p><strong><em>test_test_test</em> test_test test</strong></p>
-<p><em><strong>test_test_test</strong> test_test_test</em></p>
-<p>___test_ test_ test__</p>
-<p><strong><em>test_test <strong>test</strong>___test test</em></strong></p>
-<p><em><strong>test test</strong> test test</em></p>
-<p><strong><em>test test</em> test test</strong></p>
-<p><em>*</em>test test* test test*</p>
-<p><em><em>test test</em> test test</em></p>
-<p>*<em>test</em></p>
-<p><em>*</em>test*</p>
-<p><em>*</em><em>test</em></p>
-<p><em>*</em>*<em>test</em></p>
-<p><em>*</em><em>*</em>test*</p>
-<p><strong><em>test</em></strong></p>
-<p><strong>test</strong>*</p>
-<p>**<strong><em>test</em></strong></p>
-<p><em>*</em><strong><em>test</em></strong></p>
-<p><strong><em>test</em></strong>test<em>*</em></p>
-<p><em><strong>test</strong>test</em>**</p>
-<p><em><strong><em>test</em></strong>test</em>**</p>
-<p><strong><em>test</em> test</strong>*</p>
-<p><em><em>test</em> test</em>*</p>
-<p><strong><em>test</em> test</strong></p>
-<p><strong><em>test</em>test test</strong>*</p>
-<p><em><strong>test</strong>test test</em>**</p>
-<p><em>test</em>test test<em>test</em></p>
-<p><em>*</em>test<em>test</em>test* test<em>test test</em>*</p>
-<p><em><strong>test<em>test</em>test</strong> test</em>test<em>test</em></p>
-<p><em>*</em>test* test* test**</p>
-<p><em>*</em>test*test <strong>test</strong><strong><em>test test</em></strong></p>
+<h1>Underscore</h1>
+<p><strong><em>normal _ strong em</em></strong></p>
+<p>Whole thing strong em with sub strongs. <strong><em>strong,em_<strong><strong>strong,em</strong></strong>strong,em</em></strong></p>
+<p>Breaks normal strong em. <strong><em>strong em</em> just strong with trailing underscore</strong>_</p>
+<p><strong><em>eat trailing tokens____</em></strong></p>
+<p>__<strong>strong</strong>_</p>
+<p><strong><em>normal_strong__and_em</em></strong></p>
+<p><strong><em>strong em</em> just strong</strong></p>
+<p><em><strong>em strong</strong> just em</em></p>
+<p>___ not valid ___</p>
+<p>__ not valid __</p>
+<p>_ not valid _</p>
+<p>_<strong>not valid</strong> not valid _</p>
+<p>___not valid_ not valid _</p>
+<p>___ not valid __not valid_</p>
+<p>___ not valid <em>em_</em></p>
+<p><strong>strong</strong> text_</p>
+<p><em>em</em> text_</p>
+<p>text_<strong>strong</strong>_ text</p>
+<p>text _<strong>strong</strong>_text</p>
+<p>text <strong><em>strong,em</em></strong> text</p>
+<p>text<strong>strong</strong> text</p>
+<p>text <strong>strong</strong>text</p>
+<p>text <strong>strong</strong> text</p>
+<p>text_not valid_ text</p>
+<p>text _not valid_text</p>
+<p>text <em>em</em> text</p>
+<h1>Asterisk</h1>
+<p>text <strong><em>normal * strong em</em></strong></p>
+<p>text <strong><em>strong,em</em></strong>*<em>em</em><strong><em>strong,em</em></strong></p>
+<p>Breaks normal strong em. <strong><em>strong em</em> just strong</strong>*</p>
+<p>text <strong><em>trailing tokens are eaten by ems</em></strong><em>*</em>*</p>
+<p>text *<strong><em>dumb rules make this strong,em</em></strong></p>
+<p>Whole thing is em. <em><strong>strong*text</strong>and</em>em text<em>*</em></p>
+<p>text <strong><em>strong em</em> just strong</strong></p>
+<p>text <em><strong>em strong</strong> just em</em></p>
+<p>text <em>*</em> em claims asterisks <em>*</em></p>
+<p>text ** not valid **</p>
+<p>text * not valid *</p>
+<p>text *<strong>strong</strong> not valid *</p>
+<p>text <em>*</em>em* not valid *</p>
+<p>text <em>*</em> em to the left *<em>em</em></p>
+<p>text <em>*</em> em to the left <em>em</em>*</p>
+<p>text <strong>strong</strong> text*</p>
+<p>text <em>em</em> text*</p>
+<p>text<strong><em>strong,em</em></strong> text</p>
+<p>text <strong><em>strong,em</em></strong>text</p>
+<p>text <strong><em>strong,em</em></strong> text</p>
+<p>text<strong>strong</strong> text</p>
+<p>text <strong>strong</strong>text</p>
+<p>text <strong>strong</strong> text</p>
+<p>text<em>em</em> text</p>
+<p>text <em>em</em>text</p>
+<p>text <em>em</em> text</p>

--- a/tests/misc/em_strong_complex.html
+++ b/tests/misc/em_strong_complex.html
@@ -1,8 +1,52 @@
-<p><strong><em>Strong Em</em> Just Em</strong></p>
-<p><strong><em>Strong Em</em> Just Em</strong></p>
-<p><em><strong>Em Strong</strong> Just Strong</em></p>
-<p><em><strong>Em Strong</strong> Just Strong</em></p>
-<p><em>*</em>Em Asterisk* with Plain Text*</p>
-<p>___Smart Rule_ Prevents Match_</p>
-<p><em>*Em</em> Plain Text*</p>
-<p>__Smart Rule_ Prevents Match_</p>
+<p><em><strong>test test</strong> test test</em></p>
+<p><strong><em>test test</em> test test</strong></p>
+<p>___test test_ test test_</p>
+<p>__test test_ test test_</p>
+<p>__test_</p>
+<p>___test_</p>
+<p>____test_</p>
+<p>_____test_</p>
+<p>______test_</p>
+<p><strong><em>test</em></strong></p>
+<p><strong>test</strong>_</p>
+<p>___<strong>test</strong>_</p>
+<p>____<strong>test</strong>_</p>
+<p><strong><em>test___test</em></strong></p>
+<p><strong><em>test__test</em></strong></p>
+<p><strong><strong>test</strong>_test</strong>_</p>
+<p><strong><em>test</em> test</strong>_</p>
+<p>__test_ test__</p>
+<p><strong><em>test</em> test</strong></p>
+<p><strong><em>test_test test</em></strong></p>
+<p><strong><em>test__test test</em></strong></p>
+<p><em>test_test test_test</em></p>
+<p><strong><em>test_test_test</em> test_test test</strong></p>
+<p><em><strong>test_test_test</strong> test_test_test</em></p>
+<p>___test_ test_ test__</p>
+<p><strong><em>test_test <strong>test</strong>___test test</em></strong></p>
+<p><em><strong>test test</strong> test test</em></p>
+<p><strong><em>test test</em> test test</strong></p>
+<p><em>*</em>test test* test test*</p>
+<p><em><em>test test</em> test test</em></p>
+<p>*<em>test</em></p>
+<p><em>*</em>test*</p>
+<p><em>*</em><em>test</em></p>
+<p><em>*</em>*<em>test</em></p>
+<p><em>*</em><em>*</em>test*</p>
+<p><strong><em>test</em></strong></p>
+<p><strong>test</strong>*</p>
+<p>**<strong><em>test</em></strong></p>
+<p><em>*</em><strong><em>test</em></strong></p>
+<p><strong><em>test</em></strong>test<em>*</em></p>
+<p><em><strong>test</strong>test</em>**</p>
+<p><em><strong><em>test</em></strong>test</em>**</p>
+<p><strong><em>test</em> test</strong>*</p>
+<p><em><em>test</em> test</em>*</p>
+<p><strong><em>test</em> test</strong></p>
+<p><strong><em>test</em>test test</strong>*</p>
+<p><em><strong>test</strong>test test</em>**</p>
+<p><em>test</em>test test<em>test</em></p>
+<p><em>*</em>test<em>test</em>test* test<em>test test</em>*</p>
+<p><em><strong>test<em>test</em>test</strong> test</em>test<em>test</em></p>
+<p><em>*</em>test* test* test**</p>
+<p><em>*</em>test*test <strong>test</strong><strong><em>test test</em></strong></p>

--- a/tests/misc/em_strong_complex.txt
+++ b/tests/misc/em_strong_complex.txt
@@ -8,6 +8,8 @@ __strong______strong__
 
 _smart____em_
 
+__dumb_strong__
+
 Breaks normal strong em. ___strong em_ just strong with trailing underscore___
 
 ___eat trailing tokens_______
@@ -66,6 +68,8 @@ text ***strong,em*****em****strong,em***
 **strong******strong**
 
 *em****em*
+
+**dumb*strong**
 
 Breaks normal strong em. ***strong em* just strong***
 

--- a/tests/misc/em_strong_complex.txt
+++ b/tests/misc/em_strong_complex.txt
@@ -4,6 +4,10 @@ ___normal _ strong em___
 
 Whole thing strong em with sub strongs. ___strong,em_____strong,em____strong,em___
 
+__strong______strong__
+
+_smart____em_
+
 Breaks normal strong em. ___strong em_ just strong with trailing underscore___
 
 ___eat trailing tokens_______
@@ -58,6 +62,10 @@ text _em_ text
 text ***normal * strong em***
 
 text ***strong,em*****em****strong,em***
+
+**strong******strong**
+
+*em****em*
 
 Breaks normal strong em. ***strong em* just strong***
 

--- a/tests/misc/em_strong_complex.txt
+++ b/tests/misc/em_strong_complex.txt
@@ -1,0 +1,15 @@
+***Strong Em** Just Em*
+
+___Strong Em__ Just Em_
+
+***Em Strong* Just Strong**
+
+___Em Strong_ Just Strong__
+
+***Em Asterisk* with Plain Text*
+
+___Smart Rule_ Prevents Match_
+
+**Em* Plain Text*
+
+__Smart Rule_ Prevents Match_

--- a/tests/misc/em_strong_complex.txt
+++ b/tests/misc/em_strong_complex.txt
@@ -1,15 +1,103 @@
-***Strong Em** Just Em*
+___test test__ test test_
 
-___Strong Em__ Just Em_
+___test test_ test test__
 
-***Em Strong* Just Strong**
+___test test_ test test_
 
-___Em Strong_ Just Strong__
+__test test_ test test_
 
-***Em Asterisk* with Plain Text*
+__test_
 
-___Smart Rule_ Prevents Match_
+___test_
 
-**Em* Plain Text*
+____test_
 
-__Smart Rule_ Prevents Match_
+_____test_
+
+______test_
+
+___test___
+
+__test___
+
+_____test___
+
+______test___
+
+___test___test___
+
+___test__test___
+
+____test___test___
+
+___test_ test___
+
+__test_ test__
+
+___test_ test__
+
+___test_test test___
+
+___test__test test___
+
+_test_test test_test_
+
+___test_test_test_ test_test test__
+
+___test_test_test__ test_test_test_
+
+___test_ test_ test__
+
+___test_test __test_____test test___
+
+***test test** test test*
+
+***test test* test test**
+
+***test test* test test*
+
+**test test* test test*
+
+**test*
+
+***test*
+
+****test*
+
+*****test*
+
+******test*
+
+***test***
+
+**test***
+
+*****test***
+
+******test***
+
+***test***test***
+
+***test**test***
+
+****test***test***
+
+***test* test***
+
+**test* test**
+
+***test* test**
+
+***test*test test***
+
+***test**test test***
+
+*test*test test*test*
+
+***test*test*test* test*test test**
+
+***test*test*test** test*test*test*
+
+***test* test* test**
+
+***test*test **test*****test test***

--- a/tests/misc/em_strong_complex.txt
+++ b/tests/misc/em_strong_complex.txt
@@ -1,103 +1,108 @@
-___test test__ test test_
+# Underscore
 
-___test test_ test test__
+___normal _ strong em___
 
-___test test_ test test_
+Whole thing strong em with sub strongs. ___strong,em_____strong,em____strong,em___
 
-__test test_ test test_
+Breaks normal strong em. ___strong em_ just strong with trailing underscore___
 
-__test_
+___eat trailing tokens_______
 
-___test_
+____strong___
 
-____test_
+___normal_strong__and_em___
 
-_____test_
+___strong em_ just strong__
 
-______test_
+___em strong__ just em_
 
-___test___
+___ not valid ___
 
-__test___
+__ not valid __
 
-_____test___
+_ not valid _
 
-______test___
+___not valid__ not valid _
 
-___test___test___
+___not valid_ not valid _
 
-___test__test___
+___ not valid __not valid_
 
-____test___test___
+___ not valid _em__
 
-___test_ test___
+__strong__ text_
 
-__test_ test__
+_em_ text_
 
-___test_ test__
+text___strong___ text
 
-___test_test test___
+text ___strong___text
 
-___test__test test___
+text ___strong,em___ text
 
-_test_test test_test_
+text__strong__ text
 
-___test_test_test_ test_test test__
+text __strong__text
 
-___test_test_test__ test_test_test_
+text __strong__ text
 
-___test_ test_ test__
+text_not valid_ text
 
-___test_test __test_____test test___
+text _not valid_text
 
-***test test** test test*
+text _em_ text
 
-***test test* test test**
 
-***test test* test test*
+# Asterisk
 
-**test test* test test*
+text ***normal * strong em***
 
-**test*
+text ***strong,em*****em****strong,em***
 
-***test*
+Breaks normal strong em. ***strong em* just strong***
 
-****test*
+text ***trailing tokens are eaten by ems*******
 
-*****test*
+text ****dumb rules make this strong,em***
 
-******test*
+Whole thing is em. ***strong*text**and*em text***
 
-***test***
+text ***strong em* just strong**
 
-**test***
+text ***em strong** just em*
 
-*****test***
+text *** em claims asterisks ***
 
-******test***
+text ** not valid **
 
-***test***test***
+text * not valid *
 
-***test**test***
+text ***strong** not valid *
 
-****test***test***
+text ***em* not valid *
 
-***test* test***
+text *** em to the left **em*
 
-**test* test**
+text *** em to the left *em**
 
-***test* test**
+text **strong** text*
 
-***test*test test***
+text *em* text*
 
-***test**test test***
+text***strong,em*** text
 
-*test*test test*test*
+text ***strong,em***text
 
-***test*test*test* test*test test**
+text ***strong,em*** text
 
-***test*test*test** test*test*test*
+text**strong** text
 
-***test* test* test**
+text **strong**text
 
-***test*test **test*****test test***
+text **strong** text
+
+text*em* text
+
+text *em*text
+
+text *em* text

--- a/tests/misc/para-with-hr.html
+++ b/tests/misc/para-with-hr.html
@@ -2,5 +2,5 @@
 <hr />
 <p>Followed by another paragraph.</p>
 <p>Here is another paragraph, followed by:
-*** not an HR.
+<em>*</em> not an HR.
 Followed by more of the same paragraph.</p>

--- a/tests/misc/underscores.html
+++ b/tests/misc/underscores.html
@@ -3,4 +3,4 @@
 <p>Ok, at least <em>this</em> should work.</p>
 <p>THIS<strong>SHOULD</strong>STAY</p>
 <p>Here is some <strong>strong</strong> stuff.</p>
-<p>THIS<strong><em>SHOULD</em></strong>STAY?</p>
+<p>THIS_<strong>SHOULD</strong>_STAY?</p>

--- a/tests/options/no-smart-emphasis.html
+++ b/tests/options/no-smart-emphasis.html
@@ -1,1 +1,26 @@
-<p><em>connected</em>words_</p>
+<p><strong><em>normal _ strong em</em></strong></p>
+<p><strong><em>strong,em</em></strong>_<em>em</em><strong><em>strong,em</em></strong></p>
+<p>Breaks normal strong em. <strong><em>strong em</em> just strong</strong>_</p>
+<p><strong><em>trailing tokens are eaten by ems</em></strong><em>_</em>_</p>
+<p>_<strong><em>dumb rules make this strong,em</em></strong></p>
+<p>Whole thing is em. <em><strong>strong_text</strong>and</em>em text<em>_</em></p>
+<p><strong><em>strong em</em> just strong</strong></p>
+<p><em><strong>em strong</strong> just em</em></p>
+<p><em>_</em> em claims asterisks <em>_</em></p>
+<p>__ not valid __</p>
+<p>_ not valid _</p>
+<p>_<strong>strong</strong> not valid _</p>
+<p><em>_</em>em_ not valid _</p>
+<p><em>_</em> em to the left _<em>em</em></p>
+<p><em>_</em> em to the left <em>em</em>_</p>
+<p><strong>strong</strong> text_</p>
+<p><em>em</em> text_</p>
+<p>text<strong><em>strong,em</em></strong> text</p>
+<p>text <strong><em>strong,em</em></strong>text</p>
+<p>text <strong><em>strong,em</em></strong> text</p>
+<p>text<strong>strong</strong> text</p>
+<p>text <strong>strong</strong>text</p>
+<p>text <strong>strong</strong> text</p>
+<p>text<em>em</em> text</p>
+<p>text <em>em</em>text</p>
+<p>text <em>em</em> text</p>

--- a/tests/options/no-smart-emphasis.html
+++ b/tests/options/no-smart-emphasis.html
@@ -1,5 +1,7 @@
 <p><strong><em>normal _ strong em</em></strong></p>
 <p><strong><em>strong,em</em></strong>_<em>em</em><strong><em>strong,em</em></strong></p>
+<p><strong>strong</strong>__<strong>strong</strong></p>
+<p><em>em</em><em>_</em>em_</p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong</strong>_</p>
 <p><strong><em>trailing tokens are eaten by ems</em></strong><em>_</em>_</p>
 <p>_<strong><em>dumb rules make this strong,em</em></strong></p>

--- a/tests/options/no-smart-emphasis.html
+++ b/tests/options/no-smart-emphasis.html
@@ -2,6 +2,7 @@
 <p><strong><em>strong,em</em></strong>_<em>em</em><strong><em>strong,em</em></strong></p>
 <p><strong>strong</strong>__<strong>strong</strong></p>
 <p><em>em</em><em>_</em>em_</p>
+<p><strong>dumb_strong</strong></p>
 <p>Breaks normal strong em. <strong><em>strong em</em> just strong</strong>_</p>
 <p><strong><em>trailing tokens are eaten by ems</em></strong><em>_</em>_</p>
 <p>_<strong><em>dumb rules make this strong,em</em></strong></p>

--- a/tests/options/no-smart-emphasis.txt
+++ b/tests/options/no-smart-emphasis.txt
@@ -1,1 +1,51 @@
-_connected_words_
+___normal _ strong em___
+
+___strong,em_____em____strong,em___
+
+Breaks normal strong em. ___strong em_ just strong___
+
+___trailing tokens are eaten by ems_______
+
+____dumb rules make this strong,em___
+
+Whole thing is em. ___strong_text__and_em text___
+
+___strong em_ just strong__
+
+___em strong__ just em_
+
+___ em claims asterisks ___
+
+__ not valid __
+
+_ not valid _
+
+___strong__ not valid _
+
+___em_ not valid _
+
+___ em to the left __em_
+
+___ em to the left _em__
+
+__strong__ text_
+
+_em_ text_
+
+text___strong,em___ text
+
+text ___strong,em___text
+
+text ___strong,em___ text
+
+text__strong__ text
+
+text __strong__text
+
+text __strong__ text
+
+text_em_ text
+
+text _em_text
+
+text _em_ text

--- a/tests/options/no-smart-emphasis.txt
+++ b/tests/options/no-smart-emphasis.txt
@@ -2,6 +2,10 @@ ___normal _ strong em___
 
 ___strong,em_____em____strong,em___
 
+__strong______strong__
+
+_em____em_
+
 Breaks normal strong em. ___strong em_ just strong___
 
 ___trailing tokens are eaten by ems_______

--- a/tests/options/no-smart-emphasis.txt
+++ b/tests/options/no-smart-emphasis.txt
@@ -6,6 +6,8 @@ __strong______strong__
 
 _em____em_
 
+__dumb_strong__
+
 Breaks normal strong em. ___strong em_ just strong___
 
 ___trailing tokens are eaten by ems_______

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -382,6 +382,14 @@ class testETreeComments(unittest.TestCase):
         self.assertEqual(markdown.serializers.to_html_string(self.comment),
                     '<!--foo-->\n')
 
+    def testBrPrettify(self):
+        pretty = markdown.treeprocessors.PrettifyTreeprocessor()
+        root = markdown.util.etree.Element('root')
+        br = markdown.util.etree.SubElement(root, 'br')
+        self.assertEqual(br.tail, None)
+        pretty.run(root)
+        self.assertEqual(br.tail, "\n")
+
 
 class testSerializers(unittest.TestCase):
     """ Test the html and xhtml serializers. """

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -382,12 +382,18 @@ class testETreeComments(unittest.TestCase):
         self.assertEqual(markdown.serializers.to_html_string(self.comment),
                     '<!--foo-->\n')
 
-    def testBrPrettify(self):
-        pretty = markdown.treeprocessors.PrettifyTreeprocessor()
+
+class testElementTailTests(unittest.TestCase):
+    """ Element Tail Tests """
+    def setUp(self):
+        self.pretty = markdown.treeprocessors.PrettifyTreeprocessor()
+
+    def testBrTailNoNewline(self):
+        """ Test that last <br> in tree has a new line tail """
         root = markdown.util.etree.Element('root')
         br = markdown.util.etree.SubElement(root, 'br')
         self.assertEqual(br.tail, None)
-        pretty.run(root)
+        self.pretty.run(root)
         self.assertEqual(br.tail, "\n")
 
 


### PR DESCRIPTION
### Changes
- Fixes issues with tails in InlineProcessor
- Adds better italic and bold support
- New tests for changes and improved code coverage
### Tests

I cannot install Python 3.1 on my OSX Mavericks

```
  py27: commands succeeded
ERROR:   py31: InterpreterNotFound: python3.1
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
```

```
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
markdown/__init__                    193     42    78%   141, 330-333, 391-434, 479-493
markdown/__main__                     40      0   100%
markdown/blockparser                  30      0   100%
markdown/blockprocessors             273      7    97%   189, 194-195, 204, 253, 546, 552
markdown/extensions/__init__          34      4    88%   28-29, 36-37
markdown/extensions/abbr              38      0   100%
markdown/extensions/admonition        45      0   100%
markdown/extensions/attr_list         96      0   100%
markdown/extensions/codehilite        99     19    81%   25-27, 43-44, 105-120, 177-178, 181
markdown/extensions/def_list          59      2    97%   95-96
markdown/extensions/extra             54      0   100%
markdown/extensions/fenced_code       48      0   100%
markdown/extensions/footnotes        176      8    95%   91-92, 105, 111, 118, 243, 288-289
markdown/extensions/headerid          84      4    95%   72-73, 75, 103
markdown/extensions/meta              35      0   100%
markdown/extensions/nl2br             11      0   100%
markdown/extensions/sane_lists        17      0   100%
markdown/extensions/smart_strong      14      0   100%
markdown/extensions/smarty            87      0   100%
markdown/extensions/tables            56      0   100%
markdown/extensions/toc              134     18    87%   50-52, 96-104, 118-120, 151, 182, 191
markdown/extensions/wikilinks         49      0   100%
markdown/inlinepatterns              247      1    99%   225
markdown/odict                       113     37    67%   25-32, 35, 42, 54, 57, 60-66, 69-71, 104-105, 108-110, 119-122, 129, 136, 139-140, 160, 185-189
markdown/postprocessors               49      0   100%
markdown/preprocessors               207     17    92%   87, 92, 116, 135, 171, 199, 273, 292-304
markdown/serializers                 153     48    69%   82-83, 106-117, 143, 147-150, 158, 160, 165, 169-174, 181, 203, 218, 224-235, 238, 254, 259, 262, 266, 269
markdown/treeprocessors              187      4    98%   80, 203-205
markdown/util                         59      0   100%
----------------------------------------------------------------
TOTAL                               2687    211    92%
```

The only modification that had to be made to existing tests were for these two issues (which I view as improvements):

``` diff
--- /Users/facelessuser/Desktop/Python-Markdown/tests/misc/para-with-hr.html
+++ actual_output.html
@@ -2,5 +2,5 @@
 <hr />
 <p>Followed by another paragraph.</p>
 <p>Here is another paragraph, followed by:
-*** not an HR.
+<em>*</em> not an HR.
 Followed by more of the same paragraph.</p>
```

``` diff
--- /Users/facelessuser/Desktop/Python-Markdown/tests/misc/em_strong.html
+++ actual_output.html
@@ -4,7 +4,7 @@
 <p>With spaces: * *</p>
 <p>Two underscores __</p>
 <p>with spaces: _ _</p>
-<p>three asterisks: ***</p>
+<p>three asterisks: <em>*</em></p>
 <p>with spaces: * * *</p>
 <p>three underscores: ___</p>
 <p>with spaces: _ _ _</p>
```

Let me know what you think.
