### PR TITLE
Allow tab indentation for multiline metadata.

### DIFF
--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -23,7 +23,7 @@ import re
 
 # Global Vars
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
-META_MORE_RE = re.compile(r'^[ ]{4,}(?P<value>.*)')
+META_MORE_RE = re.compile(r'^(?:[ ]{4,}|\t{1,})(?P<value>.*)')
 
 class MetaExtension (Extension):
     """ Meta-Data extension for Python-Markdown. """


### PR DESCRIPTION
Since the original Markdown reference does not enforce space-based indentation for Markdown sources (at least as far as I can see), the meta extension should also support tab indentation for continuation lines.
