### PR TITLE
Get python 2.6 working again.

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -50,7 +50,12 @@ from .serializers import to_html_string, to_xhtml_string
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
 
 logger = logging.getLogger('MARKDOWN')
-logging.captureWarnings(True)
+
+try:
+    logging.captureWarnings(True)
+except AttributeError:
+    # Python 2.6 does not contain `captureWarnings`, ignore for now.
+    pass
 
 
 class Markdown(object):
@@ -180,7 +185,7 @@ class Markdown(object):
                 ext = self.build_extension(ext, configs.get(ext, {}))
             if isinstance(ext, Extension):
                 ext.extendMarkdown(self, globals())
-                logger.info('Successfully loaded extension "%s.%s".' 
+                logger.info('Successfully loaded extension "%s.%s".'
                             % (ext.__class__.__module__, ext.__class__.__name__))
             elif ext is not None:
                 raise TypeError(
@@ -196,9 +201,9 @@ class Markdown(object):
         following format: "extname(key1=value1,key2=value2)"
 
         """
-        
+
         configs = dict(configs)
-        
+
         # Parse extensions config params (ignore the order)
         pos = ext_name.find("(") # find the first "("
         if pos > 0:
@@ -210,33 +215,33 @@ class Markdown(object):
                           'It is recommended that you pass an instance of the extension class to '
                           'Markdown or use the "extension_configs" keyword. The current behavior '
                           'will be deprecated in version 2.6 and raise an error in version 2.7. '
-                          'See the Release Notes for Python-Markdown version 2.5 for more info.', 
+                          'See the Release Notes for Python-Markdown version 2.5 for more info.',
                           PendingDeprecationWarning)
 
         # Get class name (if provided): `path.to.module:ClassName`
         ext_name, class_name = ext_name.split(':', 1) if ':' in ext_name else (ext_name, '')
 
         # Try loading the extension first from one place, then another
-        try: 
+        try:
             # Assume string uses dot syntax (`path.to.some.module`)
             module = importlib.import_module(ext_name)
             logger.debug('Successfuly imported extension module "%s".' % ext_name)
         except ImportError:
             # Preppend `markdown.extensions.` to name
             module_name = '.'.join(['markdown.extensions', ext_name])
-            try: 
+            try:
                 module = importlib.import_module(module_name)
                 logger.debug('Successfuly imported extension module "%s".' % module_name)
                 warnings.warn('Using short names for Markdown\'s builtin extensions is pending deprecation. '
                               'Use the full path to the extension with Python\'s dot notation '
                               '(eg: "%s" instead of "%s"). The current behavior will be deprecated in '
                               'version 2.6 and raise an error in version 2.7. See the Release Notes for '
-                              'Python-Markdown version 2.5 for more info.' % (module_name, ext_name), 
-                              PendingDeprecationWarning) 
+                              'Python-Markdown version 2.5 for more info.' % (module_name, ext_name),
+                              PendingDeprecationWarning)
             except ImportError:
                 # Preppend `mdx_` to name
                 module_name_old_style = '_'.join(['mdx', ext_name])
-                try: 
+                try:
                     module = importlib.import_module(module_name_old_style)
                     logger.debug('Successfuly imported extension module "%s".' % module_name_old_style)
                     warnings.warn('Markdown\'s behavuor of appending "mdx_" to an extension name '
@@ -245,7 +250,7 @@ class Markdown(object):
                                   'current behavior will be deprecated in version 2.6 and raise an '
                                   'error in version 2.7. See the Release Notes for Python-Markdown '
                                   'version 2.5 for more info.' % (module_name_old_style, ext_name),
-                                  PendingDeprecationWarning) 
+                                  PendingDeprecationWarning)
                 except ImportError as e:
                     message = "Failed loading extension '%s' from '%s', '%s' or '%s'" \
                         % (ext_name, ext_name, module_name, module_name_old_style)
@@ -293,7 +298,7 @@ class Markdown(object):
             valid_formats = list(self.output_formats.keys())
             valid_formats.sort()
             message = 'Invalid Output Format: "%s". Use one of %s.' \
-                       % (self.output_format, 
+                       % (self.output_format,
                           '"' + '", "'.join(valid_formats) + '"')
             e.args = (message,) + e.args[1:]
             raise
@@ -422,7 +427,7 @@ class Markdown(object):
                 output_file.write(html)
                 # Don't close here. User may want to write more.
         else:
-            # Encode manually and write bytes to stdout. 
+            # Encode manually and write bytes to stdout.
             html = html.encode(encoding, "xmlcharrefreplace")
             try:
                 # Write bytes directly to buffer (Python 3).

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ if version_info[3] == 'alpha' and version_info[4] == 0:
 else:
     DEVSTATUS = dev_status_map[version_info[3]]
 
+if sys.version_info[:2] == (2, 6):
+    install_dependencies = ['importlib']
+else:
+    install_dependencies = []
+
 # The command line script name.  Currently set to "markdown_py" so as not to
 # conflict with the perl implimentation (which uses "markdown").  We can't use
 # "markdown.py" as the default config on some systems will cause the script to
@@ -193,10 +198,10 @@ class md_build(build):
     sub_commands = build.sub_commands + [('build_docs', has_docs)]
 
 long_description = \
-'''This is a Python implementation of John Gruber's Markdown_. 
+'''This is a Python implementation of John Gruber's Markdown_.
 It is almost completely compliant with the reference implementation,
-though there are a few known issues. See Features_ for information 
-on what exactly is supported and what is not. Additional features are 
+though there are a few known issues. See Features_ for information
+on what exactly is supported and what is not. Additional features are
 supported by the `Available Extensions`_.
 
 .. _Markdown: http://daringfireball.net/projects/markdown/
@@ -226,6 +231,7 @@ setup(
     maintainer_email = 'waylan [at] gmail.com',
     license =       'BSD License',
     packages =      ['markdown', 'markdown.extensions'],
+    install_requires = install_dependencies,
     scripts =       ['bin/%s' % SCRIPT_NAME],
     cmdclass =      {'install_scripts': md_install_scripts,
                      'build_docs': build_docs,
@@ -235,6 +241,7 @@ setup(
                      'Operating System :: OS Independent',
                      'Programming Language :: Python',
                      'Programming Language :: Python :: 2',
+                     'Programming Language :: Python :: 2.6',
                      'Programming Language :: Python :: 2.7',
                      'Programming Language :: Python :: 3',
                      'Programming Language :: Python :: 3.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py31, py32, py33, py34
+envlist = py26, py27, py31, py32, py33, py34
 
 [testenv]
 downloadcache = {toxworkdir}/cache


### PR DESCRIPTION
- Add importlib to dependencies if Python 2.6
- Ignore warning-capturing if on Python 2.6
