### PR TITLE
Fix out of order tail issue

### DIFF
--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -132,7 +132,7 @@ class InlineProcessor(Treeprocessor):
         childResult = self.__processPlaceholders(text, subnode, isText)
 
         if not isText and node is not subnode:
-            pos = list(node).index(subnode)
+            pos = list(node).index(subnode) + 1
         else:
             pos = 0
 

--- a/tests/extensions/nl2br_tail_stress.html
+++ b/tests/extensions/nl2br_tail_stress.html
@@ -1,0 +1,2 @@
+<p>This should remain in order:</p>
+<p><strong><em>I am <strong><em>italic</em> and</strong> bold</em> I am <code>just</code> bold</strong></p>

--- a/tests/extensions/nl2br_tail_stress.txt
+++ b/tests/extensions/nl2br_tail_stress.txt
@@ -1,0 +1,3 @@
+This should remain in order:
+
+***I am ___italic_ and__ bold* I am `just` bold**


### PR DESCRIPTION
While experimenting, I stumbled on a issue where tails get inserted out of order if put under the right stress.

Test (the case below is absurd, but I had to recreate the issue without the extension I was testing):

```
This should remain in order:

***I am ___italic_ and__ bold* I am `just` bold**
```

Expected compared against actual:

``` diff
--- right.html  Fri Oct 17 09:28:35 2014
+++ wrong.html  Fri Oct 17 09:28:26 2014
@@ -1,2 +1,2 @@
 <p>This should remain in order:</p>
-<p><strong><em>I am <strong><em>italic</em> and</strong> bold</em> I am <code>just</code> bold</strong></p>
+<p><strong><code>just</code> bold<em>I am <strong><em>italic</em> and</strong> bold</em> I am </strong></p>
```

The fix was very straight forward.  Tails of subnodes, when inserted back into the parent, should be inserted after the subnode.
