### PR TITLE
Fix tail out of order issue

### DIFF
--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -132,7 +132,7 @@ class InlineProcessor(Treeprocessor):
         childResult = self.__processPlaceholders(text, subnode, isText)
 
         if not isText and node is not subnode:
-            pos = list(node).index(subnode)
+            pos = list(node).index(subnode) + 1
         else:
             pos = 0
 

--- a/tests/misc/nested-patterns.html
+++ b/tests/misc/nested-patterns.html
@@ -5,3 +5,4 @@
 <strong><a href="http://example.com"><em>link</em></a></strong>
 <strong><a href="http://example.com"><em>link</em></a></strong>
 <a href="http://example.com"><strong><em>link</em></strong></a></p>
+<p><strong><em>I am <strong><em>italic</em> and</strong> bold</em> I am <code>just</code> bold</strong></p>

--- a/tests/misc/nested-patterns.txt
+++ b/tests/misc/nested-patterns.txt
@@ -5,3 +5,5 @@ __[_link_](http://example.com)__
 __[*link*](http://example.com)__
 **[_link_](http://example.com)**
 [***link***](http://example.com)
+
+***I am ___italic_ and__ bold* I am `just` bold**


### PR DESCRIPTION
This is a rework of #356.

This issue was discovered when dealing with nested inlines.  In
treeprocessors.py it was incorrectly handling tails.  In short, tail
elements were being inserted earlier than they were supposed to be.

In order to fix this, the insertion index should be incremented by 1 so
that when the tails are inserted into the parent, they will be just
after the child they came from.

Also added a test in nested-patterns to catch this issue.
