### PR TITLE
Issue #368: Fix Markdown in raw HTML stops working

### DIFF
--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -174,9 +174,10 @@ class HtmlBlockPreprocessor(Preprocessor):
                 else:  # raw html
                     if len(items) - right_listindex <= 1:  # last element
                         right_listindex -= 1
+                    offset = 1 if i == right_listindex else 0
                     placeholder = self.markdown.htmlStash.store('\n\n'.join(
-                        items[i:right_listindex + 1]))
-                    del items[i:right_listindex + 1]
+                        items[i:right_listindex + offset]))
+                    del items[i:right_listindex + offset]
                     items.insert(i, placeholder)
         return items
 

--- a/tests/extensions/extra/raw-html.html
+++ b/tests/extensions/extra/raw-html.html
@@ -27,11 +27,18 @@ Note: Subelements are not required to have tail text.</div>
 Raw html blocks may also be nested.
 </div>
 
-
-
 </div>
 <p>This text is after the markdown in html.</p>
 <div name="issue308">
 <p><span>1</span>
 <span>2</span></p>
 </div>
+<div name="issue368">
+<p>Markdown is <em>active</em> here.</p>
+<div name="RawHtml">
+Raw html blocks may also be nested.
+</div>
+
+<p>Markdown is <em>still</em> active here.</p>
+</div>
+<p>Markdown is <em>active again</em> here.</p>

--- a/tests/extensions/extra/raw-html.txt
+++ b/tests/extensions/extra/raw-html.txt
@@ -51,3 +51,17 @@ This text is after the markdown in html.
 <span>2</span>
 
 </div>
+
+<div markdown="1" name="issue368">
+
+Markdown is *active* here.
+
+<div name="RawHtml">
+Raw html blocks may also be nested.
+</div>
+
+Markdown is *still* active here.
+
+</div>
+
+Markdown is *active again* here.


### PR DESCRIPTION
Originally there was an infinite loop issue that was patched in issue
#308.  Unfortunately, it was fixed all the way.  This fix patches the

infinite loop fix to only add an offset to the `right_listindex` when
it is in a infinite loop scenario.
