### PR TITLE
Improve robustness of extension configs.

### DIFF
--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -76,8 +76,9 @@ class Extension(object):
         if hasattr(items, 'items'):
             # it's a dict
             items = items.items()
-        for key, value in items:
-            self.setConfig(key, value)
+        if items:
+            for key, value in items:
+                self.setConfig(key, value)
 
     def extendMarkdown(self, md, md_globals):
         """


### PR DESCRIPTION
I found the problem when Python-Markdown working with py-gfm (Github-Flavored Markdown extension).

https://github.com/dart-lang/py-gfm

```
  File "/path/to/venv/local/lib/python2.7/site-packages/markdown/extensions/__init__.py", line 36, in __init__
    self.setConfigs(kwargs.pop('configs', {}))
  File "/path/to/venv/local/lib/python2.7/site-packages/markdown/extensions/__init__.py", line 75, in setConfigs
    for key, value in items:
TypeError: 'NoneType' object is not iterable
```

It is because the extension initialize configs as None.

Simply it is the extension's matter, but I think that more robust code of Python-Markdown is the better way.
