### PR TITLE
Use zip() for positional argument compatibility

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -114,13 +114,11 @@ class Markdown(object):
 
         # For backward compatibility, loop through old positional args
         pos = ['extensions', 'extension_configs', 'safe_mode', 'output_format']
-        for c, arg in enumerate(args):
-            if pos[c] not in kwargs:
-                kwargs[pos[c]] = arg
-            if c+1 == len(pos):  # pragma: no cover
-                # ignore any additional args
-                break
-        if len(args):
+        for arg, pos_arg in zip(args, pos):
+            if pos_arg not in kwargs:
+                kwargs[pos_arg] = arg
+
+        if args:
             warnings.warn('Positional arguments are deprecated in Markdown. '
                           'Use keyword arguments only.',
                           DeprecationWarning)
@@ -510,14 +508,11 @@ def markdownFromFile(*args, **kwargs):
     """
     # For backward compatibility loop through positional args
     pos = ['input', 'output', 'extensions', 'encoding']
-    c = 0
-    for arg in args:
-        if pos[c] not in kwargs:
-            kwargs[pos[c]] = arg
-        c += 1
-        if c == len(pos):
-            break
-    if len(args):
+    for arg, pos_arg in zip(args, pos):
+        if pos_arg not in kwargs:
+            kwargs[pos_arg] = arg
+
+    if args:
         warnings.warn('Positional arguments are depreacted in '
                       'Markdown and will raise an error in version 2.7. '
                       'Use keyword arguments only.',

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -88,7 +88,7 @@ class Markdown(object):
            If they are of type string, the module mdx_name.py will be loaded.
            If they are a subclass of markdown.Extension, they will be used
            as-is.
-        * extension_configs: Configuration settingis for extensions.
+        * extension_configs: Configuration settings for extensions.
         * output_format: Format of output. Supported formats are:
             * "xhtml1": Outputs XHTML 1.x. Default.
             * "xhtml5": Outputs XHTML style tags of HTML 5
@@ -400,7 +400,7 @@ class Markdown(object):
         return output.strip()
 
     def convertFile(self, input=None, output=None, encoding=None):
-        """Converts a markdown file and returns the HTML as a unicode string.
+        """Converts a Markdown file and returns the HTML as a Unicode string.
 
         Decodes the file using the provided encoding (defaults to utf-8),
         passes the file content to markdown, and outputs the html to either
@@ -408,9 +408,9 @@ class Markdown(object):
         encoding as the source file. The 'xmlcharrefreplace' error handler is
         used when encoding the output.
 
-        **Note:** This is the only place that decoding and encoding of unicode
-        takes place in Python-Markdown.  (All other code is unicode-in /
-        unicode-out.)
+        **Note:** This is the only place that decoding and encoding of Unicode
+        takes place in Python-Markdown.  (All other code is Unicode-in /
+        Unicode-out.)
 
         Keyword arguments:
 
@@ -476,7 +476,7 @@ markdownFromFile().
 
 
 def markdown(text, *args, **kwargs):
-    """Convert a markdown string to HTML and return HTML as a unicode string.
+    """Convert a Markdown string to HTML and return HTML as a Unicode string.
 
     This is a shortcut function for `Markdown` class to cover the most
     basic use case.  It initializes an instance of Markdown, loads the


### PR DESCRIPTION
This PR refactors `__init__.py` to use `zip()` for positional argument compatibility, and also fixes some miscellaneous capitalization/spelling errors.
- The list returned by `zip()` is automatically truncated to the length of the shortest argument list, which greatly simplifies the code that loops through the list of positional arguments.
- The expression `if len(args):` relies on the truthiness of `len(args)`; using `if args:` does not change the behaviour of the conditional, but is easier to understand at a glance (since what's really being checked is whether or not there are any arguments).
