### PR TITLE
Change sanitize_url method of the LinkPattern class so it can handle Twitter pic URL

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -410,9 +410,12 @@ class LinkPattern(Pattern):
 
         for part in url[2:]:
             if ":" in part:
-                # A colon in "path", "parameters", "query"
-                # or "fragment" is suspect.
-                return ''
+                # Check if this is just Twitter media link with 'size'
+                colon_regex = re.compile('[/\w]*?\.(jpe?g|png|gif)(:large)?')
+                if not colon_regex.match(part):
+                    # If not -- a colon in "path", "parameters", "query"
+                    # or "fragment" is suspect.
+                    return ''
 
         # Url passes all tests. Return url as-is.
         return urlunparse(url)


### PR DESCRIPTION
When parsing links like Twitter pics with `size` attribute (see Twitter [docs](https://dev.twitter.com/overview/api/entities-in-twitter-objects)), e. g. [this](https://pbs.twimg.com/media/CCOzV7vUgAE79pq.jpg:large), Python-Markdown return HTML tag `<a>` with empty `href` attirbute, because `sanitize_url` make of colon  in "path", "parameters", "query" or "fragment" is suspect.
