### PR TITLE
Fixed #414 parser ignoring value of `tab_length`

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -311,18 +311,13 @@ class OListProcessor(BlockProcessor):
     def __init__(self, parser):
         BlockProcessor.__init__(self, parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-        self.RE = re.compile(
-                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
-                         r'}\d+\.[ ]+(.*)']))
+        self.RE = re.compile(r'^[ ]{0,%d}\d+\.[ ]+(.*)' % (self.tab_length - 1))
         # Detect items on secondary lines. they can be of either list type.
-        self.CHILD_RE = re.compile(
-                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
-                         r'}((\d+\.)|[*+-])[ ]+(.*)']))
+        self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.)|[*+-])[ ]+(.*)' %
+                                   (self.tab_length - 1))
         # Detect indented (nested) items of either type
-        self.INDENT_RE = re.compile(
-                ''.join([r'^[ ]{', str(self.tab_length), ',', 
-                         str(self.tab_length * 2 - 1), 
-                         r'}((\d+\.)|[*+-])[ ]+.*']))
+        self.INDENT_RE = re.compile(r'^[ ]{%d,%d}((\d+\.)|[*+-])[ ]+.*' %
+                                    (self.tab_length, self.tab_length * 2 - 1))
 
     def test(self, parent, block):
         return bool(self.RE.match(block))
@@ -421,9 +416,7 @@ class UListProcessor(OListProcessor):
     def __init__(self, parser):
         OListProcessor.__init__(self, parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-        self.RE = re.compile(
-                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
-                         r'}[*+-][ ]+(.*)']))
+        self.RE = re.compile(r'^[ ]{0,%d}[*+-][ ]+(.*)' % (self.tab_length - 1))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -300,12 +300,6 @@ class OListProcessor(BlockProcessor):
     """ Process ordered list blocks. """
 
     TAG = 'ol'
-    # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-    RE = re.compile(r'^[ ]{0,3}\d+\.[ ]+(.*)')
-    # Detect items on secondary lines. they can be of either list type.
-    CHILD_RE = re.compile(r'^[ ]{0,3}((\d+\.)|[*+-])[ ]+(.*)')
-    # Detect indented (nested) items of either type
-    INDENT_RE = re.compile(r'^[ ]{4,7}((\d+\.)|[*+-])[ ]+.*')
     # The integer (python string) with which the lists starts (default=1)
     # Eg: If list is intialized as)
     #   3. Item
@@ -313,6 +307,20 @@ class OListProcessor(BlockProcessor):
     STARTSWITH = '1'
     # List of allowed sibling tags.
     SIBLING_TAGS = ['ol', 'ul']
+
+    def __init__(self, parser):
+        BlockProcessor.__init__(self, parser)
+        # Detect an item (``1. item``). ``group(1)`` contains contents of item.
+        self.RE = re.compile(''.join([
+            r'^[ ]{0,', str(self.tab_length - 1), r'}\d+\.[ ]+(.*)']))
+        # Detect items on secondary lines. they can be of either list type.
+        self.CHILD_RE = re.compile(''.join([
+            r'^[ ]{0,', str(self.tab_length - 1), '}((\d+\.)|[*+-])[ ]+(.*)']))
+        # Detect indented (nested) items of either type
+        self.INDENT_RE = re.compile(''.join([
+            r'^[ ]{', str(self.tab_length), ',', str(self.tab_length * 2 - 1), 
+            r'}((\d+\.)|[*+-])[ ]+.*']))
+
 
     def test(self, parent, block):
         return bool(self.RE.match(block))
@@ -407,7 +415,12 @@ class UListProcessor(OListProcessor):
     """ Process unordered list blocks. """
 
     TAG = 'ul'
-    RE = re.compile(r'^[ ]{0,3}[*+-][ ]+(.*)')
+
+    def __init__(self, parser):
+        OListProcessor.__init__(self, parser)
+        # Detect an item (``1. item``). ``group(1)`` contains contents of item.
+        self.RE = re.compile(''.join([
+            r'^[ ]{0,', str(self.tab_length - 1), r'}[*+-][ ]+(.*)']))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -38,7 +38,7 @@ def build_block_parser(md_instance, **kwargs):
     return parser
 
 
-class BlockProcessor:
+class BlockProcessor(object):
     """ Base class for block processors.
 
     Each subclass will provide the methods below to work with the source and
@@ -141,7 +141,7 @@ class ListIndentProcessor(BlockProcessor):
     LIST_TYPES = ['ul', 'ol']
 
     def __init__(self, *args):
-        BlockProcessor.__init__(self, *args)
+        super(ListIndentProcessor, self).__init__(*args)
         self.INDENT_RE = re.compile(r'^(([ ]{%s})+)' % self.tab_length)
 
     def test(self, parent, block):
@@ -309,7 +309,7 @@ class OListProcessor(BlockProcessor):
     SIBLING_TAGS = ['ol', 'ul']
 
     def __init__(self, parser):
-        BlockProcessor.__init__(self, parser)
+        super(OListProcessor, self).__init__(parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
         self.RE = re.compile(r'^[ ]{0,%d}\d+\.[ ]+(.*)' % (self.tab_length - 1))
         # Detect items on secondary lines. they can be of either list type.
@@ -414,7 +414,7 @@ class UListProcessor(OListProcessor):
     TAG = 'ul'
 
     def __init__(self, parser):
-        OListProcessor.__init__(self, parser)
+        super(UListProcessor, self).__init__(parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
         self.RE = re.compile(r'^[ ]{0,%d}[*+-][ ]+(.*)' % (self.tab_length - 1))
 

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -311,16 +311,18 @@ class OListProcessor(BlockProcessor):
     def __init__(self, parser):
         BlockProcessor.__init__(self, parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-        self.RE = re.compile(''.join([
-            r'^[ ]{0,', str(self.tab_length - 1), r'}\d+\.[ ]+(.*)']))
+        self.RE = re.compile(
+                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
+                         r'}\d+\.[ ]+(.*)']))
         # Detect items on secondary lines. they can be of either list type.
-        self.CHILD_RE = re.compile(''.join([
-            r'^[ ]{0,', str(self.tab_length - 1), '}((\d+\.)|[*+-])[ ]+(.*)']))
+        self.CHILD_RE = re.compile(
+                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
+                         r'}((\d+\.)|[*+-])[ ]+(.*)']))
         # Detect indented (nested) items of either type
-        self.INDENT_RE = re.compile(''.join([
-            r'^[ ]{', str(self.tab_length), ',', str(self.tab_length * 2 - 1), 
-            r'}((\d+\.)|[*+-])[ ]+.*']))
-
+        self.INDENT_RE = re.compile(
+                ''.join([r'^[ ]{', str(self.tab_length), ',', 
+                         str(self.tab_length * 2 - 1), 
+                         r'}((\d+\.)|[*+-])[ ]+.*']))
 
     def test(self, parent, block):
         return bool(self.RE.match(block))
@@ -419,8 +421,9 @@ class UListProcessor(OListProcessor):
     def __init__(self, parser):
         OListProcessor.__init__(self, parser)
         # Detect an item (``1. item``). ``group(1)`` contains contents of item.
-        self.RE = re.compile(''.join([
-            r'^[ ]{0,', str(self.tab_length - 1), r'}[*+-][ ]+(.*)']))
+        self.RE = re.compile(
+                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
+                         r'}[*+-][ ]+(.*)']))
 
 
 class HashHeaderProcessor(BlockProcessor):

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -28,9 +28,8 @@ class SaneOListProcessor(OListProcessor):
 
     def __init__(self, parser):
         OListProcessor.__init__(self, parser)
-        self.CHILD_RE = re.compile(
-                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
-                         r'}((\d+\.))[ ]+(.*)']))
+        self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.))[ ]+(.*)' %
+                                   (self.tab_length - 1))
 
 
 class SaneUListProcessor(UListProcessor):
@@ -39,9 +38,8 @@ class SaneUListProcessor(UListProcessor):
 
     def __init__(self, parser):
         UListProcessor.__init__(self, parser)
-        self.CHILD_RE = re.compile(
-                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
-                         r'}(([*+-]))[ ]+(.*)']))
+        self.CHILD_RE = re.compile(r'^[ ]{0,%d}(([*+-]))[ ]+(.*)' %
+                                   (self.tab_length - 1))
 
 
 class SaneListExtension(Extension):

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -27,7 +27,7 @@ class SaneOListProcessor(OListProcessor):
     SIBLING_TAGS = ['ol']
 
     def __init__(self, parser):
-        OListProcessor.__init__(self, parser)
+        super(SaneOListProcessor, self).__init__(parser)
         self.CHILD_RE = re.compile(r'^[ ]{0,%d}((\d+\.))[ ]+(.*)' %
                                    (self.tab_length - 1))
 
@@ -37,7 +37,7 @@ class SaneUListProcessor(UListProcessor):
     SIBLING_TAGS = ['ul']
 
     def __init__(self, parser):
-        UListProcessor.__init__(self, parser)
+        super(SaneUListProcessor, self).__init__(parser)
         self.CHILD_RE = re.compile(r'^[ ]{0,%d}(([*+-]))[ ]+(.*)' %
                                    (self.tab_length - 1))
 

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -28,8 +28,9 @@ class SaneOListProcessor(OListProcessor):
 
     def __init__(self, parser):
         OListProcessor.__init__(self, parser)
-        self.CHILD_RE = re.compile(''.join([
-            r'^[ ]{0,', str(self.tab_length - 1), r'}((\d+\.))[ ]+(.*)']))
+        self.CHILD_RE = re.compile(
+                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
+                         r'}((\d+\.))[ ]+(.*)']))
 
 
 class SaneUListProcessor(UListProcessor):
@@ -38,8 +39,9 @@ class SaneUListProcessor(UListProcessor):
 
     def __init__(self, parser):
         UListProcessor.__init__(self, parser)
-        self.CHILD_RE = re.compile(''.join([
-            r'^[ ]{0,', str(self.tab_length - 1), r'}(([*+-]))[ ]+(.*)']))
+        self.CHILD_RE = re.compile(
+                ''.join([r'^[ ]{0,', str(self.tab_length - 1), 
+                         r'}(([*+-]))[ ]+(.*)']))
 
 
 class SaneListExtension(Extension):

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -24,14 +24,22 @@ import re
 
 class SaneOListProcessor(OListProcessor):
 
-    CHILD_RE = re.compile(r'^[ ]{0,3}((\d+\.))[ ]+(.*)')
     SIBLING_TAGS = ['ol']
+
+    def __init__(self, parser):
+        OListProcessor.__init__(self, parser)
+        self.CHILD_RE = re.compile(''.join([
+            r'^[ ]{0,', str(self.tab_length - 1), r'}((\d+\.))[ ]+(.*)']))
 
 
 class SaneUListProcessor(UListProcessor):
 
-    CHILD_RE = re.compile(r'^[ ]{0,3}(([*+-]))[ ]+(.*)')
     SIBLING_TAGS = ['ul']
+
+    def __init__(self, parser):
+        UListProcessor.__init__(self, parser)
+        self.CHILD_RE = re.compile(''.join([
+            r'^[ ]{0,', str(self.tab_length - 1), r'}(([*+-]))[ ]+(.*)']))
 
 
 class SaneListExtension(Extension):


### PR DESCRIPTION
Changed hard-coded numbers assuming tab length to be 4 to use `self.tab_length`.

This change applies to he default parsers in `mardown/blockprocessors.py` and those in `markdown/extensions/sane_lists.py`.

All current tests should pass.
