### PR TITLE
Fix processing angle quotes in smarty extension

### DIFF
--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -211,10 +211,10 @@ class SmartyExtension(Extension):
         rightAngledQuotePattern = SubstituteTextPattern(
             r'\>\>', (self.substitutions['right-angle-quote'],), md
         )
-        self.inlinePatterns.add(
+        self.angledQuotesPatterns.add(
             'smarty-left-angle-quotes', leftAngledQuotePattern, '_begin'
         )
-        self.inlinePatterns.add(
+        self.angledQuotesPatterns.add(
             'smarty-right-angle-quotes',
             rightAngledQuotePattern,
             '>smarty-left-angle-quotes'
@@ -249,14 +249,18 @@ class SmartyExtension(Extension):
             self.educateEllipses(md)
         if configs['smart_quotes']:
             self.educateQuotes(md)
-        if configs['smart_angled_quotes']:
-            self.educateAngledQuotes(md)
         if configs['smart_dashes']:
             self.educateDashes(md)
         inlineProcessor = InlineProcessor(md)
         inlineProcessor.inlinePatterns = self.inlinePatterns
         md.treeprocessors.add('smarty', inlineProcessor, '_end')
         md.ESCAPED_CHARS.extend(['"', "'"])
+        if configs['smart_angled_quotes']:
+            self.angledQuotesPatterns = OrderedDict()
+            self.educateAngledQuotes(md)
+            angledQuotesProcessor = InlineProcessor(md)
+            angledQuotesProcessor.inlinePatterns = self.angledQuotesPatterns
+            md.treeprocessors.add('smarty-angledquotes', angledQuotesProcessor, '<inline')
 
 
 def makeExtension(*args, **kwargs):

--- a/tests/extensions/smarty.html
+++ b/tests/extensions/smarty.html
@@ -16,6 +16,7 @@ em-dashes (&mdash;) and ellipes (&hellip;)<br />
 &ldquo;<a href="http://example.com">Link</a>&rdquo; &mdash; she said.</p>
 <p>&ldquo;Ellipsis within quotes&hellip;&rdquo;</p>
 <p>Кавычки-&laquo;ёлочки&raquo;<br />
+&laquo;hello&raquo;<br />
 Anführungszeichen-&raquo;Chevrons&laquo;</p>
 <hr />
 <p>Escaped -- ndash<br />

--- a/tests/extensions/smarty.txt
+++ b/tests/extensions/smarty.txt
@@ -19,6 +19,7 @@ em-dashes (---) and ellipes (...)
 "Ellipsis within quotes..."
 
 Кавычки-<<ёлочки>>  
+<<hello>>  
 Anführungszeichen->>Chevrons<<
 
 --- -- ---


### PR DESCRIPTION
I have got the following bug report privately:

``` pyconsole
>>> import markdown
>>> from markdown.extensions.smarty import SmartyExtension
>>> md = markdown.Markdown(extensions=[SmartyExtension(smart_angled_quotes=True)])
>>> md.convert("<<hello>>")
'<p>&lt;<hello>&gt;</p>'
```

(Expected result will be `'<p>&laquo;hello&raquo;</p>'`).

This pull request fixes it. @waylan: I have not pushed it directly because you may know better ways to fix it, than separating the processors. If I just move everything to before inline, then I get the Python-Markdown internals leaking into the resulting HTML.
