### PR TITLE
Inline CSS class specification

### DIFF
--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -40,11 +40,12 @@ class FencedBlockPreprocessor(Preprocessor):
 (\{?\.?(?P<lang>[a-zA-Z0-9_+-]*))?[ ]*  # Optional {, and lang
 # Optional highlight lines, single- or double-quote-delimited
 (hl_lines=(?P<quot>"|')(?P<hl_lines>.*?)(?P=quot))?[ ]*
+# Optional CSS classes
+(?P<classes>[a-zA-Z0.9_\\.+ -]+)?[ ]*
 }?[ ]*\n                                # Optional closing }
 (?P<code>.*?)(?<=\n)
 (?P=fence)[ ]*$''', re.MULTILINE | re.DOTALL | re.VERBOSE)
     CODE_WRAP = '<pre><code%s>%s</code></pre>'
-    LANG_TAG = ' class="%s"'
 
     def __init__(self, md):
         super(FencedBlockPreprocessor, self).__init__(md)
@@ -68,18 +69,30 @@ class FencedBlockPreprocessor(Preprocessor):
         while 1:
             m = self.FENCED_BLOCK_RE.search(text)
             if m:
-                lang = ''
-                if m.group('lang'):
-                    lang = self.LANG_TAG % m.group('lang')
+
+                # inline CSS classes may be specified as .class .class2
+                # etc...
+                classes = []
+                def addclasses(s):
+                    if not s: return
+                    classes.extend(s\
+                                   .replace('.','')\
+                                   .strip()\
+                                   .split(' '))
+                addclasses(m.group('classes'))
+                addclasses(m.group('lang'))
 
                 # If config is not empty, then the codehighlite extension
                 # is enabled, so we call it to highlight the code
                 if self.codehilite_conf:
+                    addclasses(self.codehilite_conf['css_class'][0])
+
+                    classes = ' '.join(classes)
                     highliter = CodeHilite(
                         m.group('code'),
                         linenums=self.codehilite_conf['linenums'][0],
                         guess_lang=self.codehilite_conf['guess_lang'][0],
-                        css_class=self.codehilite_conf['css_class'][0],
+                        css_class=classes,
                         style=self.codehilite_conf['pygments_style'][0],
                         lang=(m.group('lang') or None),
                         noclasses=self.codehilite_conf['noclasses'][0],
@@ -88,7 +101,10 @@ class FencedBlockPreprocessor(Preprocessor):
 
                     code = highliter.hilite()
                 else:
-                    code = self.CODE_WRAP % (lang,
+                    attributes = ''
+                    if classes:
+                        attributes = ' class="'+' '.join(classes)+'"'
+                    code = self.CODE_WRAP % (attributes,
                                              self._escape(m.group('code')))
 
                 placeholder = self.markdown.htmlStash.store(code, safe=True)


### PR DESCRIPTION
For instance the Rust documentation (reference.md) uses markdown that specifies CSS classes for fenced code, like ```{.classa .classb} which produces unbalanced fenced code currently. This should fix it so those classes are parsed and added to the resulting HTML, and the fenced code isn't made unbalanced.

Also removed that LANG_TAG substitution, since assuming the name of the class attribute in HTML to be "class" is pretty safe to make, plus not all CSS classes are only for specifying language highlighting.

No syntax errors in python2.7, python3.4 or pypy3
