### PR TITLE
Fix find footnote placeholder to recurse

### DIFF
--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -96,7 +96,9 @@ class FootnoteExtension(Extension):
                 if child.tail:
                     if child.tail.find(self.getConfig("PLACE_MARKER")) > -1:
                         return child, element, False
-                finder(child)
+                child_res = finder(child)
+                if child_res is not None:
+                    return child_res
             return None
 
         res = finder(root)

--- a/tests/extensions/extra/footnote_placeholder_depth.html
+++ b/tests/extensions/extra/footnote_placeholder_depth.html
@@ -1,0 +1,13 @@
+<blockquote>
+<blockquote>
+<div class="footnote">
+<hr />
+<ol>
+<li id="fn:1">
+<p>A Footnote.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote" title="Jump back to footnote 1 in the text">&#8617;</a></p>
+</li>
+</ol>
+</div>
+<p>Some text with a footnote<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup>.</p>
+</blockquote>
+</blockquote>

--- a/tests/extensions/extra/footnote_placeholder_depth.txt
+++ b/tests/extensions/extra/footnote_placeholder_depth.txt
@@ -1,0 +1,5 @@
+>> ///Footnotes Go Here///
+>>
+>> Some text with a footnote[^1].
+
+[^1]: A Footnote.


### PR DESCRIPTION
The footnotes extension actually didn't recurse correctly when looking for the place marker. If it wasn't a child of the root element it would traverse and find the place marker but still return None in the `finder` function.
