### PR TITLE
Fix infinite loop #430

### DIFF
--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -178,10 +178,11 @@ class HtmlBlockPreprocessor(Preprocessor):
                 else:  # raw html
                     if len(items) - right_listindex <= 1:  # last element
                         right_listindex -= 1
-                    offset = 1 if i == right_listindex else 0
+                    if right_listindex <= i:
+                        right_listindex = i + 1
                     placeholder = self.markdown.htmlStash.store('\n\n'.join(
-                        items[i:right_listindex + offset]))
-                    del items[i:right_listindex + offset]
+                        items[i:right_listindex]))
+                    del items[i:right_listindex]
                     items.insert(i, placeholder)
         return items
 

--- a/tests/extensions/extra/raw-html.html
+++ b/tests/extensions/extra/raw-html.html
@@ -42,3 +42,8 @@ Raw html blocks may also be nested.
 <p>Markdown is <em>still</em> active here.</p>
 </div>
 <p>Markdown is <em>active again</em> here.</p>
+<div>
+<p>foo bar</p>
+<p><em>bar</em>
+</p>
+</div>

--- a/tests/extensions/extra/raw-html.txt
+++ b/tests/extensions/extra/raw-html.txt
@@ -65,3 +65,9 @@ Markdown is *still* active here.
 </div>
 
 Markdown is *active again* here.
+
+<div markdown=1>
+foo bar
+
+<em>bar</em>
+</div>


### PR DESCRIPTION
This should fix the remaining corner cases that can cause infinite
loops.  Previous iterations did not account for scenarios where the
“end” index was less than the “start” index.  If the “end” index is
ever less than or equal to the “start” index, the “end” will be
adjusted to to be “start” + 1 allow the full range to be extracted and
replaced.
