### PR TITLE
Fully remove YAML support (to make it easier for third party extensions to take over the job)

### DIFF
--- a/docs/extensions/meta_data.txt
+++ b/docs/extensions/meta_data.txt
@@ -23,7 +23,7 @@ This extension is included in the standard Markdown library.
 Syntax
 ------
 
-Meta-data consists of a series of keywords and values defined at the beginning 
+Meta-data consists of a series of keywords and values defined at the beginning
 of a markdown document like this:
 
     Title:   My Document
@@ -31,27 +31,21 @@ of a markdown document like this:
     Authors: Waylan Limberg
              John Doe
     Date:    October 2, 2007
-    blank-value: 
+    blank-value:
     base_url: http://example.com
 
     This is the first paragraph of the document.
 
-The keywords are case-insensitive and may consist of letters, numbers, 
-underscores and dashes and must end with a colon. The values consist of 
+The keywords are case-insensitive and may consist of letters, numbers,
+underscores and dashes and must end with a colon. The values consist of
 anything following the colon on the line and may even be blank.
 
 If a line is indented by 4 or more spaces, that line is assumed to be an
 additional line of the value for the previous keyword. A keyword may have as
-many lines as desired. 
+many lines as desired.
 
 The first blank line ends all meta-data for the document. Therefore, the first
 line of a document must not be blank.
-
-Alternatively, You may use YAML style deliminators to mark the start and/or end
-of your meta-data. When doing so, the first line of your document must be `---`.
-The meta-data ends at the first blank line or the first line containing an end
-deliminator (either `---` or `...`), whichever comes first. Even though YAML
-deliminators are supported, meta-data is not parsed as YAML.
 
 All meta-data is stripped from the document prior to any further processing
 by Markdown.
@@ -65,7 +59,7 @@ as the name of the extension.
 Accessing the Meta-Data
 -----------------------
 
-The meta-data is made available as a python Dict in the `Meta` attribute of an 
+The meta-data is made available as a python Dict in the `Meta` attribute of an
 instance of the Markdown class. For example, using the above document:
 
     >>> md = markdown.Markdown(extensions = ['markdown.extensions.meta'])
@@ -85,10 +79,10 @@ instance of the Markdown class. For example, using the above document:
     'base_url' : ['http://example.com']
     }
 
-Note that the keys are all lowercase and the values consist of a list of 
-strings where each item is one line for that key. This way, one could preserve 
-line breaks if desired. Or the items could be joined where appropriate. No 
-assumptions are made regarding the data. It is simply passed as found to the 
+Note that the keys are all lowercase and the values consist of a list of
+strings where each item is one line for that key. This way, one could preserve
+line breaks if desired. Or the items could be joined where appropriate. No
+assumptions are made regarding the data. It is simply passed as found to the
 `Meta` attribute.
 
 Perhaps the meta-data could be passed into a template system, or used by
@@ -98,7 +92,7 @@ the developer.
 Compatible Extensions
 ---------------------
 
-The following extensions are currently known to work with the Meta-Data 
+The following extensions are currently known to work with the Meta-Data
 extension. The keywords they are known to support are also listed.
 
 * [HeaderId](header_id.html)
@@ -108,4 +102,3 @@ extension. The keywords they are known to support are also listed.
     * `wiki_base_url`
     * `wiki_end_url`
     * `wiki_html_class`
-

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -27,8 +27,6 @@ log = logging.getLogger('MARKDOWN')
 # Global Vars
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
 META_MORE_RE = re.compile(r'^[ ]{4,}(?P<value>.*)')
-BEGIN_RE = re.compile(r'^-{3}(\s.*)?')
-END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
 
 
 class MetaExtension (Extension):
@@ -48,13 +46,11 @@ class MetaPreprocessor(Preprocessor):
         """ Parse Meta-Data and store in Markdown.Meta. """
         meta = {}
         key = None
-        if lines and BEGIN_RE.match(lines[0]):
-            lines.pop(0)
         while lines:
             line = lines.pop(0)
             m1 = META_RE.match(line)
-            if line.strip() == '' or END_RE.match(line):
-                break  # blank line or end of YAML header - done
+            if line.strip() == '':
+                break  # blank line - done
             if m1:
                 key = m1.group('key').lower().strip()
                 value = m1.group('value').strip()
@@ -70,7 +66,10 @@ class MetaPreprocessor(Preprocessor):
                 else:
                     lines.insert(0, line)
                     break  # no meta data - done
-        self.markdown.Meta = meta
+        if hasattr(self.markdown, 'Meta'):
+            self.markdown.Meta.update(meta)
+        else:
+            self.markdown.Meta = meta
         return lines
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,8 @@ try:
     import tidylib
 except ImportError:
     tidylib = None
+except OSError:
+    tidylib = None
 try:
     import yaml
 except ImportError as e:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -470,26 +470,21 @@ The body. This is paragraph one.'''
             }
         )
 
-    def testYamlMetaData(self):
-        """ Test metadata specified as simple YAML. """
+    def testDoNotAcceptYamlMetaData(self):
+        """ Do not parse metadata specified as YAML anymore. """
 
         text = '''---
-Title: A Test Doc.
-Author: [Waylan Limberg, John Doe]
+Foo: Bar
 Blank_Data:
 ---
 
 The body. This is paragraph one.'''
         self.assertEqual(
             self.md.convert(text),
-            '<p>The body. This is paragraph one.</p>'
+            '<hr />\n<p>Foo: Bar\nBlank_Data:</p>\n<hr />\n<p>The body. This is paragraph one.</p>'
         )
         self.assertEqual(
-            self.md.Meta, {
-                'author': ['[Waylan Limberg, John Doe]'],
-                'blank_data': [''],
-                'title': ['A Test Doc.']
-            }
+            self.md.Meta, {}
         )
 
     def testMissingMetaData(self):


### PR DESCRIPTION
YAML support was added and then again removed from the "meta" extension -- since YAML metadata could, should and is be(ing) provided by an additional third party extension. However, the "meta" extension is still parsing metadata that looks like YAML (starting and ending with '---'), but without actually parsing the YAML correctly. This is not only misleading, but also makes it hard for "normal" metadata and YAML-formatted metadata and the corresponding extensions to co-exist (because the "meta" extension consumes the metadata that is supposed to be consumed by the YAML metadata extension).

This pull request provides:
1. Full removal of pseudo-YAML capabilities from the "meta" extension (+ updated doc)
2. The "meta" extension does not assume anymore to be the only extension to write to the `markdown.Meta` attribute, but respects values another extension might already have put there
3. Two lines I had to add to `tests/__init__.py` to make tests work on my machine

Hope this helps. Let me know if you have any suggestions. :)
