### PR TITLE
Nesting <pre> in <code> blocks instead

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -243,10 +243,10 @@ class CodeBlockProcessor(BlockProcessor):
             )
         else:
             # This is a new codeblock. Create the elements and insert text.
-            pre = util.etree.SubElement(parent, 'pre')
-            code = util.etree.SubElement(pre, 'code')
+            code = util.etree.SubElement(parent, 'pre')
+            pre = util.etree.SubElement(code, 'code')
             block, theRest = self.detab(block)
-            code.text = util.AtomicString('%s\n' % block.rstrip())
+            pre.text = util.AtomicString('%s\n' % block.rstrip())
         if theRest:
             # This block contained unindented line(s) after the first indented
             # line. Insert these lines as the first block of the master blocks


### PR DESCRIPTION
When I make a markdown message in the form of 4-space indent. 

```
    <4 spaces>test
```

The output is shown in the form of 

```
    <pre><code>test</code></pre>
```

This breaks some tagging in the wikimedia editor which I am using. (Quite an old version.). It interprets the nested code  tag as `<code>`

Simply inverting this should make it work again.
