### PR TITLE
Make admonition classname and classname-title configurable

### DIFF
--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -39,9 +39,12 @@ class AdmonitionExtension(Extension):
 
 class AdmonitionProcessor(BlockProcessor):
 
-    CLASSNAME = 'admonition'
-    CLASSNAME_TITLE = 'admonition-title'
     RE = re.compile(r'(?:^|\n)!!!\ ?([\w\-]+)(?:\ "(.*?)")?')
+
+    def __init__(self, parser, classname='admonition', classname_title='admonition-title'):
+        self.CLASSNAME = classname
+        self.CLASSNAME_TITLE = classname_title
+        BlockProcessor.__init__(self, parser)
 
     def test(self, parent, block):
         sibling = self.lastChild(parent)


### PR DESCRIPTION
Making classname and classname-title configurable will make the usage of admonition more easy with mkdocs and templates with class names already defined for admonitions.
