### PR TITLE
Add failing toc test for double inline code

### DIFF
--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -775,8 +775,23 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '<h2 id="header-2"><a class="toclink" href="#header-2">Header <em>2</em></a></h2>'
         )
 
-    def testAnchorLinkWithInlineCode(self):
-        """ Test TOC Anchorlink with inline code. """
+    def testAnchorLinkWithSingleInlineCode(self):
+        """ Test TOC Anchorlink with single inline code. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(anchorlink=True)]
+        )
+        text = '# This is `code`.'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="this-is-code">'                        # noqa
+                '<a class="toclink" href="#this-is-code">'  # noqa
+                    'This is <code>code</code>.'            # noqa
+                '</a>'                                      # noqa
+            '</h1>'                                         # noqa
+        )
+
+    def testAnchorLinkWithDoubleInlineCode(self):
+        """ Test TOC Anchorlink with double inline code. """
         md = markdown.Markdown(
             extensions=[markdown.extensions.toc.TocExtension(anchorlink=True)]
         )
@@ -804,8 +819,22 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '</h1>'                                                                       # noqa
         )
 
-    def testPermalinkWithInlineCode(self):
-        """ Test TOC Permalink with inline code. """
+    def testPermalinkWithSingleInlineCode(self):
+        """ Test TOC Permalink with single inline code. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink=True)]
+        )
+        text = '# This is `code`.'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="this-is-code">'                                                            # noqa
+                'This is <code>code</code>.'                                                    # noqa
+                '<a class="headerlink" href="#this-is-code" title="Permanent link">&para;</a>'  # noqa
+            '</h1>'                                                                             # noqa
+        )
+
+    def testPermalinkWithDoubleInlineCode(self):
+        """ Test TOC Permalink with double inline code. """
         md = markdown.Markdown(
             extensions=[markdown.extensions.toc.TocExtension(permalink=True)]
         )

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -790,6 +790,34 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '</h1>'                                                         # noqa
         )
 
+    def testPermalink(self):
+        """ Test TOC Permalink. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink=True)]
+        )
+        text = '# Header'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header">'                                                            # noqa
+                'Header'                                                                  # noqa
+                '<a class="headerlink" href="#header" title="Permanent link">&para;</a>'  # noqa
+            '</h1>'                                                                       # noqa
+        )
+
+    def testPermalinkWithInlineCode(self):
+        """ Test TOC Permalink with inline code. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink=True)]
+        )
+        text = '# This is `code` and `this` too.'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="this-is-code-and-this-too">'                                                            # noqa
+                'This is <code>code</code> and <code>this</code> too.'                                       # noqa
+                '<a class="headerlink" href="#this-is-code-and-this-too" title="Permanent link">&para;</a>'  # noqa
+            '</h1>'                                                                                          # noqa
+        )
+
     def testTitle(self):
         """ Test TOC Title. """
         md = markdown.Markdown(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -775,6 +775,21 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '<h2 id="header-2"><a class="toclink" href="#header-2">Header <em>2</em></a></h2>'
         )
 
+    def testAnchorLinkWithInlineCode(self):
+        """ Test TOC Anchorlink with inline code. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(anchorlink=True)]
+        )
+        text = '# This is `code` and `this` too.'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="this-is-code-and-this-too">'                           # noqa
+                '<a class="toclink" href="#this-is-code-and-this-too">'     # noqa
+                    'This is <code>code</code> and <code>this</code> too.'  # noqa
+                '</a>'                                                      # noqa
+            '</h1>'                                                         # noqa
+        )
+
     def testTitle(self):
         """ Test TOC Title. """
         md = markdown.Markdown(


### PR DESCRIPTION
noticed this strange behavior here:

http://www.django-rest-framework.org/topics/3.0-announcement/#the-data-and-query_params-properties

so here is a failing testcase.

**data**

``` markdown
# This is `code` and `this` too.
```

**genetated**

``` html
<h1 id="this-is-code-and-this-too"><code>this</code> too.<a class="toclink" href="#this-is-code-and-this-too">This is <code>code</code> and </a></h1>
```

**expected**

``` html
<h1 id="this-is-code-and-this-too"><a class="toclink" href="#this-is-code-and-this-too">This is <code>code</code> and <code>this</code> too.</a></h1>
```
