### PR TITLE
Removed dependency on re.Scanner for compatability with IronPython.

### DIFF
--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -24,6 +24,7 @@ from ..treeprocessors import Treeprocessor
 from ..util import isBlockLevel
 import re
 
+
 def _handle_double_quote(t):
     k, v = t.split('=')
     return k, v.strip('"')
@@ -45,22 +46,25 @@ def _handle_word(t):
         return 'id', t[1:]
     return t, t
 
+
 # Simplified replacement class of re.Scanner that appears in Cython,
 # but not IronPython.
 class InternalScanner:
-    # * Create a regex string that matches each phrase as a seperate 
-    #   group. 
-    # * Create an array of action functions. 
-    # * The index of each phrase's match group, is equal to the index 
+    # * Create a regex string that matches each phrase as a seperate
+    #   group.
+    # * Create an array of action functions.
+    # * The index of each phrase's match group, is equal to the index
     #   of the corresponding action in the action array.
     def __init__(self, lexicon):
         self.actions = []
         regex_string = ""
         for (phrase, action) in lexicon:
-            if(regex_string != ""): regex_string += "|"
+            if(regex_string != ""):
+                regex_string += "|"
             regex_string += "(" + phrase + ")"
             self.actions.append(action)
         self.regex = re.compile(regex_string)
+
     # Search each found match.
     # Find the match group .
     # Perform the corresponding action.
@@ -71,15 +75,15 @@ class InternalScanner:
             num = -1
             for (group) in match.groups():
                 num += 1
-                if(group != None and self.actions[num] != None):
+                if(group is not None and self.actions[num] is not None):
                     result.append(self.actions[num](group))
-        return result            
+        return result
 
 _scanner = InternalScanner([
     (r'[^ ]+=".*?"', _handle_double_quote),
     (r"[^ ]+='.*?'", _handle_single_quote),
     (r'[^ ]+=[^ =]+', _handle_key_value),
-    (r'\=[^ ]+', None), # Ignore the case '=foo'.
+    (r'\=[^ ]+', None),  # Ignore the case '=foo'.
     (r'[^ =]+', _handle_word),
     (r' ', None)
 ])


### PR DESCRIPTION
Hi, I am trying to get python-markdown working on IronPython. One issue is the dependency on re.Scanner in the attribute list extension, as this is not implemented in IronPython. I have removed this dependency and replaced it with a simplified class defined within the file.

I have tried copying CPythons re.Scanner class, but this does not play nice with IronPython. Therefore, I have implemented a class that tries to achieve the same as re.Scanner, that I have defined in attr_list.py. I have had to add another phrase-action pair, so that the case '=foo' is ignored by the new class. 

I have also removed the scanner arguments from the action functions, as I do not know what these are for and my replacement class does not use them.

I cannot see any other differences in behavior to the original. All tests pass using CPython and the number of failures has gone from 23 to 9 in IronPython, and none are by caused by attr_list.py.

Cheers
