### PR TITLE
Fix lazy ordered list example in documentation

### DIFF
--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -247,8 +247,8 @@ The following options are available on the `markdown.markdown` function:
     If `lazy_ol` is set to `False`, then markdown will output the following
     HTML:
 
-        <ol>
-          <li start="4">Apples</li>
+        <ol start="4">
+          <li>Apples</li>
           <li>Oranges</li>
           <li>Pears</li>
         </ol>


### PR DESCRIPTION
The documentation (http://pythonhosted.org/Markdown/reference.html#markdown) is not accurate when lazy_ol=False parameter is called.

The example shows the 'start' attribute to the first `<li>` tag. However, the attribute is in the `<ol>` tag:

``` python
>>> import markdown
>>> s = """
... 4. Apples
... 5. Oranges
... 6. Pears"""
>>> markdown.markdown(s, lazy_ol=False)
u'<ol start="4">\n<li>Apples</li>\n<li>Oranges</li>\n<li>Pears</li>\n</ol>'
```

The behaviour of the library is the correct one (https://developer.mozilla.org/fr/docs/Web/HTML/Element/ol), so the documentation need to be fixed, not the library.
