### PR TITLE
Support CodeHilite option use_pygments in fenced_code

### DIFF
--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -81,6 +81,7 @@ class FencedBlockPreprocessor(Preprocessor):
                         guess_lang=self.codehilite_conf['guess_lang'][0],
                         css_class=self.codehilite_conf['css_class'][0],
                         style=self.codehilite_conf['pygments_style'][0],
+                        use_pygments=self.codehilite_conf['use_pygments'][0],
                         lang=(m.group('lang') or None),
                         noclasses=self.codehilite_conf['noclasses'][0],
                         hl_lines=parse_hl_lines(m.group('hl_lines'))

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -375,6 +375,18 @@ line 3
                     '#line 3</code></pre>'
                 )
 
+    def testFencedLanguageAndPygmentsDisabled(self):
+        """ Test if fenced_code honors CodeHilite option use_pygments=False. """
+
+        text = '```python\nfrom __future__ import braces\n```'
+        md = markdown.Markdown(
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(use_pygments=False),
+                'markdown.extensions.fenced_code'
+            ]
+        )
+        self.assertTrue('<code class="language-python">' in md.convert(text))
+
 
 class TestHeaderId(unittest.TestCase):
     """ Test HeaderId Extension. """


### PR DESCRIPTION
Using `markdown.extensions.fenced_code` in combination with `CodeHiliteExtension(use_pygments=False)` does not yield the expected behavior. Pygments is used anyway because the corresponding config item is not copied. This PR adds a test to reproduce this bug and the corresponding fix.
