### PR TITLE
return converted markdown from markdownFromFile()

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -524,6 +524,6 @@ def markdownFromFile(*args, **kwargs):
                       DeprecationWarning)
 
     md = Markdown(**kwargs)
-    md.convertFile(kwargs.get('input', None),
-                   kwargs.get('output', None),
-                   kwargs.get('encoding', None))
+    return md.convertFile(kwargs.get('input', None),
+                          kwargs.get('output', None),
+                          kwargs.get('encoding', None))


### PR DESCRIPTION
markdownFromFile() function currently doesn't return the converted markdown. Adding return to make the converted markdown available to the caller.
