### PR TITLE
Fixed regex pattern for attr_list extension

### DIFF
--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -72,7 +72,7 @@ def isheader(elem):
 
 class AttrListTreeprocessor(Treeprocessor):
 
-    BASE_RE = r'\{\:?([^\}]*)\}'
+    BASE_RE = r'\{\:([^\}]*)\}'
     HEADER_RE = re.compile(r'[ ]+%s[ ]*$' % BASE_RE)
     BLOCK_RE = re.compile(r'\n[ ]*%s[ ]*$' % BASE_RE)
     INLINE_RE = re.compile(r'^%s' % BASE_RE)


### PR DESCRIPTION
The given regex pattern is matching "{: ... }" and also "{ ... }" (without the colon). The documentation is not mentioning this possibility and I had problems in inline elements where I use "{ ... }". I think the pattern "{:" is wisely chosen to prevent such a false detection.
