### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/release-2.5.txt
+++ b/docs/release-2.5.txt
@@ -59,7 +59,7 @@ Backwards-incompatible Changes
 	As the HTML would not be parsed with the above Extension, then the serializer will
 	escape the raw HTML, which is exactly what happens now when `safe_mode="escape"`.
 
-[Bleach]: http://bleach.readthedocs.org/
+[Bleach]: https://bleach.readthedocs.io/
 
 * Positional arguments on the `markdown.Markdown()` are pending deprecation as are
   all except the `text` argument on the `markdown.markdown()` wrapper function.

--- a/docs/release-2.6.txt
+++ b/docs/release-2.6.txt
@@ -49,7 +49,7 @@ raw HTML, then that can be accomplished through an extension which removes HTML 
 As the HTML would not be parsed with the above Extension, then the serializer will
 escape the raw HTML, which is exactly what happens now when `safe_mode="escape"`.
 
-[Bleach]: http://bleach.readthedocs.org/
+[Bleach]: https://bleach.readthedocs.io/
 
 ### Positional Arguments Deprecated
 
@@ -256,7 +256,7 @@ Test coverage has been improved including running [flake8]. While those changes
 will not directly effect end users, the code is being better tested which will 
 benefit everyone.
 
-[flake8]: http://flake8.readthedocs.org/en/latest/
+[flake8]: https://flake8.readthedocs.io/en/latest/
 
 Various bug fixes have been made.  See the
 [commit log](https://github.com/waylan/Python-Markdown/commits/master)

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -137,7 +137,7 @@ class Markdown(object):
         if 'safe_mode' in kwargs:
             warnings.warn('"safe_mode" is deprecated in Python-Markdown. '
                           'Use an HTML sanitizer (like '
-                          'Bleach http://bleach.readthedocs.org/) '
+                          'Bleach https://bleach.readthedocs.io/) '
                           'if you are parsing untrusted markdown text. '
                           'See the 2.6 release notes for more info',
                           DeprecationWarning)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
