### PR TITLE
Fix another issue with attribute lists (with multiple ‘=’ signs)

### DIFF
--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -32,17 +32,17 @@ except AttributeError:  # pragma: no cover
 
 
 def _handle_double_quote(s, t):
-    k, v = t.split('=')
+    k, v = t.split('=', 1)
     return k, v.strip('"')
 
 
 def _handle_single_quote(s, t):
-    k, v = t.split('=')
+    k, v = t.split('=', 1)
     return k, v.strip("'")
 
 
 def _handle_key_value(s, t):
-    return t.split('=')
+    return t.split('=', 1)
 
 
 def _handle_word(s, t):

--- a/tests/extensions/attr_list.html
+++ b/tests/extensions/attr_list.html
@@ -64,5 +64,6 @@ And a <strong class="nest">nested <a class="linky2" href="http://example.com" ti
 <p>No <em>key or value</em></p>
 <p><em>Weirdness</em></p>
 <p><em>More weirdness</em></p>
+<p>This should not cause a <em foo="a=b">crash</em></p>
 <p>Attr_lists do not contain <em>newlines</em>{ foo=bar
 key=value }</p>

--- a/tests/extensions/attr_list.txt
+++ b/tests/extensions/attr_list.txt
@@ -88,5 +88,7 @@ No *key or value*{ = }
 
 *More weirdness*{ === }
 
+This should not cause a *crash*{ foo=a=b }
+
 Attr_lists do not contain *newlines*{ foo=bar
 key=value }


### PR DESCRIPTION
The last commit did not address the issue I mentioned in https://github.com/waylan/Python-Markdown/issues/482#issuecomment-225447813. This pull request fixes it.
