### PR TITLE
Fix image titles not following spec

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -130,7 +130,7 @@ LINK_RE = NOIMG + BRK + \
     r'''\(\s*(<.*?>|((?:(?:\(.*?\))|[^\(\)]))*?)\s*((['"])(.*?)\12\s*)?\)'''
 
 # ![alttxt](http://x.com/) or ![alttxt](<http://x.com/>)
-IMAGE_LINK_RE = r'\!' + BRK + r'\s*\((<.*?>|([^")]+"[^"]*"|[^\)]*))\)'
+IMAGE_LINK_RE = r'\!' + BRK + r'\s*\(\s*(<.*?>|([^"\)\s]+\s*"[^"]*"|[^\)\s]*))\s*\)'
 
 # [Google][3]
 REFERENCE_RE = NOIMG + BRK + r'\s?\[([^\]]*)\]'

--- a/tests/misc/image.html
+++ b/tests/misc/image.html
@@ -1,3 +1,5 @@
 <p><img alt="Poster" src="http://humane_man.jpg" title="The most humane man." /></p>
 <p><img alt="Poster" src="http://humane_man.jpg" title="The most humane man." /></p>
 <p><img alt="Blank" src="" /></p>
+<p>![Fail](http://humane man.jpg "The most humane man.")</p>
+<p>![Fail](http://humane man.jpg)</p>

--- a/tests/misc/image.txt
+++ b/tests/misc/image.txt
@@ -6,3 +6,7 @@
 [Poster]:http://humane_man.jpg "The most humane man."
 
 ![Blank]()
+
+![Fail](http://humane man.jpg "The most humane man.")
+
+![Fail](http://humane man.jpg)


### PR DESCRIPTION
Don’t allow spaces in image links.  This was also causing an issue
where any text following a space was treated as a title. Ref #484.
