### PR TITLE
Add ability to specify custom Formatter for Pygments code highlighting

### DIFF
--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -17,6 +17,7 @@ License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import inspect
 from . import Extension
 from ..treeprocessors import Treeprocessor
 
@@ -75,7 +76,8 @@ class CodeHilite(object):
 
     def __init__(self, src=None, linenums=None, guess_lang=True,
                  css_class="codehilite", lang=None, style='default',
-                 noclasses=False, tab_length=4, hl_lines=None, use_pygments=True):
+                 noclasses=False, tab_length=4, hl_lines=None, use_pygments=True,
+                 pygments_formatter='html'):
         self.src = src
         self.lang = lang
         self.linenums = linenums
@@ -86,6 +88,7 @@ class CodeHilite(object):
         self.tab_length = tab_length
         self.hl_lines = hl_lines or []
         self.use_pygments = use_pygments
+        self.pygments_formatter = pygments_formatter
 
     def hilite(self):
         """
@@ -114,12 +117,19 @@ class CodeHilite(object):
                         lexer = get_lexer_by_name('text')
                 except ValueError:
                     lexer = get_lexer_by_name('text')
-            formatter = get_formatter_by_name('html',
-                                              linenos=self.linenums,
-                                              cssclass=self.css_class,
-                                              style=self.style,
-                                              noclasses=self.noclasses,
-                                              hl_lines=self.hl_lines)
+            if inspect.isclass(self.pygments_formatter):
+                formatter = self.pygments_formatter(linenos=self.linenums,
+                                                    cssclass=self.css_class,
+                                                    style=self.style,
+                                                    noclasses=self.noclasses,
+                                                    hl_lines=self.hl_lines)
+            else:
+                formatter = get_formatter_by_name(self.pygments_formatter,
+                                                  linenos=self.linenums,
+                                                  cssclass=self.css_class,
+                                                  style=self.style,
+                                                  noclasses=self.noclasses,
+                                                  hl_lines=self.hl_lines)
             return highlight(self.src, lexer, formatter)
         else:
             # just escape and build markup usable by JS highlighting libs
@@ -213,7 +223,8 @@ class HiliteTreeprocessor(Treeprocessor):
                     style=self.config['pygments_style'],
                     noclasses=self.config['noclasses'],
                     tab_length=self.markdown.tab_length,
-                    use_pygments=self.config['use_pygments']
+                    use_pygments=self.config['use_pygments'],
+                    pygments_formatter=self.config['pygments_formatter']
                 )
                 placeholder = self.markdown.htmlStash.store(code.hilite(),
                                                             safe=True)
@@ -247,7 +258,11 @@ class CodeHiliteExtension(Extension):
             'use_pygments': [True,
                              'Use Pygments to Highlight code blocks. '
                              'Disable if using a JavaScript library. '
-                             'Default: True']
+                             'Default: True'],
+            'pygments_formatter': ['html',
+                                   'Use a specific Formatter for '
+                                   'Pygments Highlighting.'
+                                   'Default: html']
             }
 
         super(CodeHiliteExtension, self).__init__(*args, **kwargs)

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -84,7 +84,8 @@ class FencedBlockPreprocessor(Preprocessor):
                         use_pygments=self.codehilite_conf['use_pygments'][0],
                         lang=(m.group('lang') or None),
                         noclasses=self.codehilite_conf['noclasses'][0],
-                        hl_lines=parse_hl_lines(m.group('hl_lines'))
+                        hl_lines=parse_hl_lines(m.group('hl_lines')),
+                        pygments_formatter=self.codehilite_conf['pygments_formatter'][0]
                     )
 
                     code = highliter.hilite()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -120,6 +120,22 @@ class TestCodeHilite(TestCaseWithAssertStartsWith):
                 '</code></pre>'
             )
 
+    def testCustomFormatter(self):
+        text = '\t# A Code Comment'
+        # Use 'null' formatter (meaning no highlighting)
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.codehilite.CodeHiliteExtension(
+                pygments_formatter='null')])
+        if self.has_pygments:
+            # Pygments can use random lexer here as we did not specify the language
+            self.assertStartsWith('<p># A Code Comment', md.convert(text))
+        else:
+            self.assertEqual(
+                md.convert(text),
+                '<pre class="codehilite"><code># A Code Comment'
+                '</code></pre>'
+            )
+
     def testLinenumsTrue(self):
         text = '\t# A Code Comment'
         md = markdown.Markdown(


### PR DESCRIPTION
In our use of the Python-Markdown library, we discovered the need to be able to use a custom Pygments Formatter class. Pygments supports creating custom formatters, but there wasn't a way to have the `CodeHiliteExtension` utlize them.

I've added `pygments_formatter` as a config option for the `CodeHiliteExtension` class (which is also used by `FencedCodeExtension`). It can take a string, which will be passed to the call to Pygments' `get_formatter_by_name` function. It defaults to 'html', which is what was hard-coded before.

Also, the option can take a reference to a class. This makes it convenient to specify a custom class in code without having to create a separate package for your custom formatter. Usage is something like this:

```
def get_html_from_markdown(value):
    # Use the extra extensions
    from code_samples.code_formatters import MarkdownHtmlFormatter
    return markdown.markdown(value, extensions=[
        'markdown.extensions.extra',
        TocExtension(anchorlink=True),
        CodeHiliteExtension(pygments_formatter=MarkdownHtmlFormatter)])
```

The last line of code demonstrates the usage.

All tests pass (aside from those marked as Skip), including the additional test I added. Let me know if you'd like any modifications.
