### PR TITLE
Enable tables without headers

### DIFF
--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -52,20 +52,20 @@ class TableProcessor(BlockProcessor):
 
         if '-' in block[0] and set(block[0]) <= set('|:- '):  # no header
             header = None
-            seperator = block[0].strip()
+            separator = block[0].strip()
             rows = [] if len(block) < 2 else block[1:]
         else:
             header = block[0].strip()
-            seperator = block[1].strip()
+            separator = block[1].strip()
             rows = [] if len(block) < 3 else block[2:]
 
         # Get format type (bordered by pipes or not)
         border = False
-        if (header and header.startswith('|')) or seperator.startswith('|'):
+        if (header and header.startswith('|')) or separator.startswith('|'):
             border = True
         # Get alignment of columns
         align = []
-        for c in self._split_row(seperator, border):
+        for c in self._split_row(separator, border):
             c = c.strip()
             if c.startswith(':') and c.endswith(':'):
                 align.append('center')

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -63,26 +63,31 @@ class TableProcessor(BlockProcessor):
         border = False
         if (header and header.startswith('|')) or separator.startswith('|'):
             border = True
-        # Get alignment of columns
-        align = []
-        for c in self._split_row(separator, border):
-            c = c.strip()
-            if c.startswith(':') and c.endswith(':'):
-                align.append('center')
-            elif c.startswith(':'):
-                align.append('left')
-            elif c.endswith(':'):
-                align.append('right')
-            else:
-                align.append(None)
+
+        alignment = self._get_column_alignment(separator, border)
         # Build table
         table = etree.SubElement(parent, 'table')
         if header:
             thead = etree.SubElement(table, 'thead')
-            self._build_row(header, thead, align, border)
+            self._build_row(header, thead, alignment, border)
         tbody = etree.SubElement(table, 'tbody')
         for row in rows:
-            self._build_row(row.strip(), tbody, align, border)
+            self._build_row(row.strip(), tbody, alignment, border)
+
+    def _get_column_alignment(self, separator, border):
+        alignment = []
+        for c in self._split_row(separator, border):
+            c = c.strip()
+            if c.startswith(':') and c.endswith(':'):
+                alignment.append('center')
+            elif c.startswith(':'):
+                alignment.append('left')
+            elif c.endswith(':'):
+                alignment.append('right')
+            else:
+                alignment.append(None)
+
+        return alignment
 
     def _build_row(self, row, parent, align, border):
         """ Given a row of text, build table cells. """

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -64,30 +64,31 @@ class TableProcessor(BlockProcessor):
         if (header and header.startswith('|')) or separator.startswith('|'):
             border = True
 
-        alignment = self._get_column_alignment(separator, border)
+        align = self._get_column_align(separator, border)
+
         # Build table
         table = etree.SubElement(parent, 'table')
         if header:
             thead = etree.SubElement(table, 'thead')
-            self._build_row(header, thead, alignment, border)
+            self._build_row(header, thead, align, border)
         tbody = etree.SubElement(table, 'tbody')
         for row in rows:
-            self._build_row(row.strip(), tbody, alignment, border)
+            self._build_row(row.strip(), tbody, align, border)
 
-    def _get_column_alignment(self, separator, border):
-        alignment = []
+    def _get_column_align(self, separator, border):
+        align = []
         for c in self._split_row(separator, border):
             c = c.strip()
             if c.startswith(':') and c.endswith(':'):
-                alignment.append('center')
+                align.append('center')
             elif c.startswith(':'):
-                alignment.append('left')
+                align.append('left')
             elif c.endswith(':'):
-                alignment.append('right')
+                align.append('right')
             else:
-                alignment.append(None)
+                align.append(None)
 
-        return alignment
+        return align
 
     def _build_row(self, row, parent, align, border):
         """ Given a row of text, build table cells. """

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -50,7 +50,7 @@ class TableProcessor(BlockProcessor):
         """ Parse a table block and build table. """
         block = blocks.pop(0).split('\n')
 
-        if set(block[0]) <= set('|:- '):  # no header
+        if '-' in block[0] and set(block[0]) <= set('|:- '):  # no header
             header = None
             seperator = block[0].strip()
             rows = [] if len(block) < 2 else block[1:]

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -251,6 +251,15 @@ Content Cell | Content Cell
 </tr>
 </tbody>
 </table>
+<p>A table without a header:</p>
+<table>
+<tbody>
+<tr>
+<td>foo</td>
+<td>bar</td>
+</tr>
+</tbody>
+</table>
 <p>Lists are not tables</p>
 <ul>
 <li>this | should | not</li>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -76,6 +76,11 @@ foo | bar
 --- | ---
 foo | (`bar`) and `baz`.
 
+A table without a header:
+
+---|---
+foo|bar
+
 Lists are not tables
 
  - this | should | not


### PR DESCRIPTION
Ruby's `kramdown` allows for creating tables without headers, I think Python's `markdown` should not be worse.

I know that this might not be a part of the standard, but I also think that this is a very useful feature (I need it and I don't want to switch from Pelican to Jekyll just for that).

Please let me know if the code quality is not good enough, I will do my best to improve it.