### PR TITLE
Add customize option for code wrapper, escape spesial chars and lang tag

### DIFF
--- a/docs/extensions/fenced_code_blocks.txt
+++ b/docs/extensions/fenced_code_blocks.txt
@@ -73,6 +73,30 @@ The above will output:
 
 [GitHub]: http://github.github.com/github-flavored-markdown/
 
+### Customize code wrapper ###
+If you want to change the tags wrapping the code, enter `code_wrap` and
+`lang_tag` options. You can also disable escaping special symbols with the
+option `escape`. The following text:
+
+    ```bash
+    some 'code'<br>
+    ```
+
+Processed code with the following parameters:
+
+    ext_conf = {'fenced_code': {
+                                'escape': False,
+                                'code_wrap': '<wrap %s>%s</wrap>',
+                                'lang_tag': 'language"%s"'
+                                }
+                }
+    print markdown.markdown(md, extensions=['fenced_code'],
+                                extension_configs=ext_conf)
+
+The above will output:
+
+    <wrap language"bash">some 'code'<br></wrap>
+
 ### Emphasized Lines ###
 
 If you would like to have your fenced code blocks highlighted with the 


### PR DESCRIPTION
These options allow you to use the module for generating html with a specific syntax of code block. For example, the generation of the page to confluence:
```
>>> import markdown
>>> txt = """some text
... ```bash
... some code
... ```
... Title:
... 
... 1. first
... 2. second
... """
>>> ext_conf = {'fenced_code': {
...                             'escape': False,
...                             'code_wrap': '<ac:structured-macro ac:name="code">%s<ac:plain-text-body><![CDATA[%s]]></ac:plain-text-body></ac:structured-macro>',
...                             'lang_tag': '<ac:parameter ac:name="language">%s</ac:parameter>'
...                             }
...             }
>>> markdown.markdown(txt, extensions=['fenced_code'], enable_attributes=True, extension_configs=ext_conf)
u'<p>some text</p>\n<p><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:plain-text-body><![CDATA[some code\n]]></ac:plain-text-body></ac:structured-macro></p>\n<p>Title:</p>\n<ol>\n<li>first</li>\n<li>second</li>\n</ol>'
>>>
```
The Atlassian confluence used its formatting [macros](https://confluence.atlassian.com/conf53/confluence-storage-format-for-macros-411108832.html).

The result page:
![confluence_page](https://cloud.githubusercontent.com/assets/8326634/21189238/1bdb1efc-c22f-11e6-91c1-ed2585e0801c.png)
