### PR TITLE
Precision regarding 'html_block' and EscapeHtml

### DIFF
--- a/docs/release-2.6.txt
+++ b/docs/release-2.6.txt
@@ -41,13 +41,16 @@ raw HTML, then that can be accomplished through an extension which removes HTML 
 
     class EscapeHtml(Extension):
         def extendMarkdown(self, md, md_globals):
-        del md.preprocessors['html_block']
-        del md.inlinePatterns['html']
+            del md.preprocessors['html_block']
+            del md.inlinePatterns['html']
 
     html = markdown.markdown(text, extensions=[EscapeHtml()])
 
 As the HTML would not be parsed with the above Extension, then the serializer will
 escape the raw HTML, which is exactly what happens now when `safe_mode="escape"`.
+
+Please note that above ``EscapeHtml`` extension does not work with the ``extra``
+extension as it depends on the ``html_block`` preprocessor.
 
 [Bleach]: https://bleach.readthedocs.io/
 


### PR DESCRIPTION
I noticed that the `extra` extension set doesn't work with the `EscapeHtml` example in the release notes and made a remark about this.

I'm not sure if the `extra` should be fixed because of this or if it's an inherent decision from the way things are supposed to work with this set of extensions.

Also added some missing indentation.