### PR TITLE
Better handling of backticks

### DIFF
--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -260,8 +260,8 @@ Content Cell | Content Cell
 <table>
 <thead>
 <tr>
-<th>Odd backtics</th>
-<th>Even backtics</th>
+<th>Odd backticks</th>
+<th>Even backticks</th>
 </tr>
 </thead>
 <tbody>

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -256,3 +256,32 @@ Content Cell | Content Cell
 <li>this | should | not</li>
 <li>be | a | table</li>
 </ul>
+<p>Add tests for issue #449</p>
+<table>
+<thead>
+<tr>
+<th>Odd backtics</th>
+<th>Even backtics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>[!\"\#$%&amp;'()*+,\-./:;&lt;=&gt;?@\[\\\]^_`{|}~]</code></td>
+<td><code>[!\"\#$%&amp;'()*+,\-./:;&lt;=&gt;?@\[\\\]^`_`{|}~]</code></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Escapes</th>
+<th>More Escapes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>`\</code></td>
+<td><code>\</code></td>
+</tr>
+</tbody>
+</table>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -83,7 +83,7 @@ Lists are not tables
 
 Add tests for issue #449
 
-Odd backtics | Even backtics
+Odd backticks | Even backticks
 ------------ | -------------
 ``[!\"\#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~]`` | ``[!\"\#$%&'()*+,\-./:;<=>?@\[\\\]^`_`{|}~]``
 

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -80,3 +80,13 @@ Lists are not tables
 
  - this | should | not
  - be | a | table
+
+Add tests for issue #449
+
+Odd backtics | Even backtics
+------------ | -------------
+``[!\"\#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~]`` | ``[!\"\#$%&'()*+,\-./:;<=>?@\[\\\]^`_`{|}~]``
+
+Escapes | More Escapes
+------- | ------
+`` `\`` | `\`


### PR DESCRIPTION
At some point the logic of counting backticks and determining if they
are odd or even was used to parse a row's text into cells.
Unfortunately this approach broke expected code parsing logic in a
table. We essentially traded one bug for another. This fixes table
backtick handling and restores sane backtick logic while preserving
existing fixes. (issue #449)