### PR TITLE
Support for <main> tag in raw HTML to suppress an extra <p> tag.

### DIFF
--- a/markdown/util.py
+++ b/markdown/util.py
@@ -32,7 +32,7 @@ BLOCK_LEVEL_ELEMENTS = re.compile(
     "|hr|hr/|style|li|dt|dd|thead|tbody"
     "|tr|th|td|section|footer|header|group|figure"
     "|figcaption|aside|article|canvas|output"
-    "|progress|video|nav)$",
+    "|progress|video|nav|main)$",
     re.IGNORECASE
 )
 # Placeholders


### PR DESCRIPTION
When using the [HTML5 `<main>` tag](https://www.w3.org/WebPlatform/docs/html51/grouping-content.html#the-main-element) as raw HTML in my Markdown file, an extra `<p>` tag was output.

For example:
`<main>...some HTML</main>`

turned into:
`<p><main>...some HTML</main></p>`

The `<p>` tag ended up creating extra space above the main content.

I added "main" to the BLOCK_LEVEL_ELEMENTS constant in markdown/util.py and this seemed to work well.  The `<main>` tag is recognized and the extra `<p>` tag is suppressed.

Might this be useful for others?