### PR TITLE
Tables should add the escaping of pipes

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -75,9 +75,6 @@ class Markdown(object):
         'xhtml5': to_xhtml_string,
     }
 
-    ESCAPED_CHARS = ['\\', '`', '*', '_', '{', '}', '[', ']',
-                     '(', ')', '>', '#', '+', '-', '.', '!']
-
     def __init__(self, *args, **kwargs):
         """
         Creates a new Markdown instance.
@@ -146,6 +143,9 @@ class Markdown(object):
             warnings.warn('The "html_replacement_text" keyword is '
                           'deprecated along with "safe_mode".',
                           DeprecationWarning)
+
+        self.ESCAPED_CHARS = ['\\', '`', '*', '_', '{', '}', '[', ']',
+                              '(', ')', '>', '#', '+', '-', '.', '!']
 
         self.registeredExtensions = []
         self.docType = ""

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -160,6 +160,8 @@ class TableExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
         """ Add an instance of TableProcessor to BlockParser. """
+        if '|' not in md.ESCAPED_CHARS:
+            md.ESCAPED_CHARS.append('|')
         md.parser.blockprocessors.add('table',
                                       TableProcessor(md.parser),
                                       '<hashheader')

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -285,3 +285,18 @@ Content Cell | Content Cell
 </tr>
 </tbody>
 </table>
+<p>Test escaped pipes</p>
+<table>
+<thead>
+<tr>
+<th>Column1</th>
+<th>Column 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>|</code> |</td>
+<td>Pipes are okay in code and escaped. |</td>
+</tr>
+</tbody>
+</table>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -90,3 +90,9 @@ Odd backticks | Even backticks
 Escapes | More Escapes
 ------- | ------
 `` `\`` | `\`
+
+Test escaped pipes
+
+Column1 | Column 2
+------- | --------
+`|` \| | Pipes are okay in code and escaped. \|

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -758,3 +758,15 @@ PLACE_MARKER= ~~~footnotes~~~
 """
         self.create_config_file(config)
         self.assertRaises(yaml.YAMLError, parse_options, ['-c', self.tempfile])
+
+
+class TestEscapeAppend(unittest.TestCase):
+    """ Tests escape character append. """
+
+    def testAppend(self):
+        """ Test that appended escapes are only in the current instance. """
+        md = markdown.Markdown()
+        md.ESCAPED_CHARS.append('|')
+        self.assertEqual('|' in md.ESCAPED_CHARS, True)
+        md2 = markdown.Markdown()
+        self.assertEqual('|' not in md2.ESCAPED_CHARS, True)


### PR DESCRIPTION
The table extension should have escaped pipes in order to adhere to the
PHP Markdown extra implementation.  In order to properly add escaped
pipes, a bug relating to persisting appended escapes also had to be
patched. Reference: #526