### PR TITLE
Inline code escape improvement

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -103,7 +103,7 @@ BRK = (
 NOIMG = r'(?<!\!)'
 
 # `e=f()` or ``e=f("`")``
-BACKTICK_RE = r'(?<!\\)(`+)(.+?)(?<!`)\2(?!`)'
+BACKTICK_RE = r'(?:(?<!\\)((?:\\{2})+)(?=`+)|(?<!\\)(`+)(.+?)(?<!`)\3(?!`))'
 
 # \<
 ESCAPE_RE = r'\\(.)'
@@ -302,12 +302,16 @@ class BacktickPattern(Pattern):
     """ Return a `<code>` element containing the matching text. """
     def __init__(self, pattern):
         Pattern.__init__(self, pattern)
-        self.tag = "code"
+        self.ESCAPED_BSLASH = '%s%s%s' % (util.STX, ord('\\'), util.ETX)
+        self.tag = 'code'
 
     def handleMatch(self, m):
-        el = util.etree.Element(self.tag)
-        el.text = util.AtomicString(m.group(3).strip())
-        return el
+        if m.group(4):
+            el = util.etree.Element(self.tag)
+            el.text = util.AtomicString(m.group(4).strip())
+            return el
+        else:
+            return m.group(2).replace('\\\\', self.ESCAPED_BSLASH)
 
 
 class DoubleTagPattern(SimpleTagPattern):

--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -357,3 +357,22 @@ Content Cell | Content Cell
 | ------- || ------- |
 | row1      | row1    |
 | row2      | row2    |</p>
+<p>Test escaped code in Table</p>
+<table>
+<thead>
+<tr>
+<th>Should not be code</th>
+<th>Should be code</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>`Not code`</td>
+<td>\<code>code</code></td>
+</tr>
+<tr>
+<td>\`Not code\`</td>
+<td>\\<code>code</code></td>
+</tr>
+</tbody>
+</table>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -121,3 +121,10 @@ Escaped pipes in format row should not be a table
 | ------- \|| ------- |
 | row1      | row1    |
 | row2      | row2    |
+
+Test escaped code in Table
+
+Should not be code | Should be code
+------------------ | --------------
+\`Not code\`       | \\`code`
+\\\`Not code\\\`   | \\\\`code`

--- a/tests/misc/backtick-escape.html
+++ b/tests/misc/backtick-escape.html
@@ -1,3 +1,4 @@
-<p>\`This should not be in code.\`
-`This also should not be in code.`
+<p>`This should not be in code.`
+\<code>This should be in code.\\</code>
+\`This should not be in code.\`
 `And finally this should not be in code.`</p>

--- a/tests/misc/backtick-escape.txt
+++ b/tests/misc/backtick-escape.txt
@@ -1,3 +1,4 @@
-\\`This should not be in code.\\`
-\`This also should not be in code.\`
+\`This should not be in code.\`
+\\`This should be in code.\\`
+\\\`This should not be in code.\\\`
 \`And finally this should not be in code.`


### PR DESCRIPTION
This aims to have inline code escaping act more as one would expect in relation to how escaping is handled elsewhere.  The best way to explain is by referencing the tests and babelmark https://johnmacfarlane.net/babelmark2/?text=%5C%5C%60code%60.  Python Markdown is 1 of 3 who handle code escaping in (what I view) a non intuitive way.  My personal belief is this buggy logic.  So hopefully this pull will be accepted.

All we are doing is processing the escapes specifically related to code before we handle code.

Now, I realize the old tests were testing for this logic, and I understand why it was easiest to implement it as it was. If the old logic is preferred, I will need to make one more pull to make tables expect code escaping as it currently is.   It should be a *very* easy pull, but I am hoping that *this* pull would be favored over such actions.