### PR TITLE
Fix hr recursion issue

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -493,15 +493,16 @@ class HRProcessor(BlockProcessor):
 
     def run(self, parent, blocks):
         block = blocks.pop(0)
+        match = self.match
         # Check for lines in block before hr.
-        prelines = block[:self.match.start()].rstrip('\n')
+        prelines = block[:match.start()].rstrip('\n')
         if prelines:
             # Recursively parse lines before hr so they get parsed first.
             self.parser.parseBlocks(parent, [prelines])
         # create hr
         util.etree.SubElement(parent, 'hr')
         # check for lines in block after hr.
-        postlines = block[self.match.end():].lstrip('\n')
+        postlines = block[match.end():].lstrip('\n')
         if postlines:
             # Add lines after hr to master blocks for later parsing.
             blocks.insert(0, postlines)

--- a/tests/misc/blockquote-hr.html
+++ b/tests/misc/blockquote-hr.html
@@ -14,3 +14,12 @@ Even a lazy line.</p>
 <hr />
 <p>The last line.</p>
 </blockquote>
+<p>foo</p>
+<blockquote>
+<p>bar</p>
+<hr />
+</blockquote>
+<hr />
+<blockquote>
+<p>baz</p>
+</blockquote>

--- a/tests/misc/blockquote-hr.txt
+++ b/tests/misc/blockquote-hr.txt
@@ -19,3 +19,9 @@ Even a lazy line.
 > ---
 
 > The last line.
+
+foo
+> bar
+> ***
+---
+> baz


### PR DESCRIPTION
HRProcessor tried to access a member variable after recursively calling
itself.  In certain situations HRProcessor will try to access its
member variable containing its match, but it will not be the same match
that call in the stack expected.  This is easily fixed by storing the
match locally *before* doing any recursive work. Ref: #531.