### PR TITLE
Fix HTML parse with empty lines

### DIFF
--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -258,7 +258,13 @@ class HtmlBlockPreprocessor(Preprocessor):
             else:
                 items.append(block)
 
-                right_tag, data_index = self._get_right_tag(left_tag, 0, block)
+                # Need to evaluate all items so we can calculate relative to the left index.
+                right_tag, data_index = self._get_right_tag(left_tag, left_index, ''.join(items))
+                # Adjust data_index: relative to items -> relative to last block
+                prev_block_length = 0
+                for item in items[:-1]:
+                    prev_block_length += len(item)
+                data_index -= prev_block_length
 
                 if self._equal_tags(left_tag, right_tag):
                     # if find closing tag

--- a/tests/misc/html.html
+++ b/tests/misc/html.html
@@ -8,6 +8,17 @@
 Html with various attributes.
 </div>
 
+<div>
+    <div>
+        Div with a blank line
+
+        in the middle.
+    </div>
+    <div>
+        This gets treated as HTML.
+    </div>
+</div>
+
 <p>And of course <script>blah</script>.</p>
 <p><a href="script&gt;stuff&lt;/script">this <script>link</a></p>
 <p>Some funky <x\]> inline stuff with markdown escaping syntax.</p>

--- a/tests/misc/html.txt
+++ b/tests/misc/html.txt
@@ -11,6 +11,17 @@ Now some <arbitrary>arbitrary tags</arbitrary>.
 Html with various attributes.
 </div>
 
+<div>
+    <div>
+        Div with a blank line
+
+        in the middle.
+    </div>
+    <div>
+        This gets treated as HTML.
+    </div>
+</div>
+
 And of course <script>blah</script>.
 
 [this <script>link](<script>stuff</script>)


### PR DESCRIPTION
If both open and close was not found in first block, additional blocks
were evaluated without context of previous blocks.  The algorithm needs
to evaluate a buffer with the left bracket present.  So feed in all
items and get the right bracket, then adjust the data_index to be
relative to the last block. Ref: #452