### PR TITLE
Fix regression of single column tables

### DIFF
--- a/tests/extensions/extra/tables.html
+++ b/tests/extensions/extra/tables.html
@@ -167,7 +167,12 @@ Content Cell | Content Cell
 <th>Second Header</th>
 </tr>
 </thead>
-<tbody></tbody>
+<tbody>
+<tr>
+<td></td>
+<td></td>
+</tr>
+</tbody>
 </table>
 <p>More inline code block tests</p>
 <table>
@@ -376,3 +381,86 @@ Content Cell | Content Cell
 </tr>
 </tbody>
 </table>
+<p>Single column tables</p>
+<table>
+<thead>
+<tr>
+<th>Is a Table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Is a Table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Is a Table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Is a Table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>row</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Is a Table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>row</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Is a Table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>row</td>
+</tr>
+</tbody>
+</table>
+<h2>| Is not a Table</h2>
+<p>| row</p>
+<h2>Is not a Table |</h2>
+<p>row            |</p>
+<p>| Is not a Table
+| --------------
+row</p>
+<p>Is not a Table |
+-------------- |
+row</p>

--- a/tests/extensions/extra/tables.txt
+++ b/tests/extensions/extra/tables.txt
@@ -128,3 +128,42 @@ Should not be code | Should be code
 ------------------ | --------------
 \`Not code\`       | \\`code`
 \\\`Not code\\\`   | \\\\`code`
+
+Single column tables
+
+| Is a Table |
+| ---------- |
+
+| Is a Table
+| ----------
+
+Is a Table |
+---------- |
+
+| Is a Table |
+| ---------- |
+| row        |
+
+| Is a Table
+| ----------
+| row
+
+Is a Table |
+---------- |
+row        |
+
+| Is not a Table
+--------------
+| row
+
+Is not a Table |
+--------------
+row            |
+
+| Is not a Table
+| --------------
+row
+
+Is not a Table |
+-------------- |
+row


### PR DESCRIPTION
Single column tables are valid tables, so add back in the accidentally
removed functionality of allowing single column tables, but with one
exception -- table bodies should not render empty.

As discussed in #539, tables with no bodies are given an empty row.  This affects both single column tables and multi-column alike.

One side note.  PHP extra states that each row should have `|` in single columns.  So I enforce that.  The reason behind this is how they handle the first pipe in a row.  Their consumption logic is a bit different and beyond the scope of this.  I added things like `PIPE_LEFT` etc.  in case we want to address it in the future.  The short is that if the header has a leading pipe, the first pipe is stripped.  If it doesn't have a leading pipe, the pipe is used on that row as plain text.  It isn't described in their spec that I could see, and we didn't support it before, but since it explicitly states you need at least 1 pipe, I enforce that, but leave the possibility to add Extra like pipe consumption enhancements.

