### PR TITLE
Automatically register extension.

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -185,6 +185,8 @@ class Markdown(object):
                 ext = self.build_extension(ext, configs.get(ext, {}))
             if isinstance(ext, Extension):
                 ext.extendMarkdown(self, globals())
+                if ext not in self.registeredExtensions:
+                    self.registeredExtensions.append(ext)
                 logger.debug(
                     'Successfully loaded extension "%s.%s".'
                     % (ext.__class__.__module__, ext.__class__.__name__)


### PR DESCRIPTION
It doesn't seem necessary to require the extension to register itself when it can be done automatically. Calling the registration method manually makes it easy to forget (e.g., the meta extension) thus not allowing the list to be inspected by other extensions that may require an extension.