### PR TITLE
Py3 regex deprecations

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -391,7 +391,7 @@ class OListProcessor(BlockProcessor):
                 # Check first item for the start index
                 if not items and self.TAG == 'ol':
                     # Detect the integer value of first list item
-                    INTEGER_RE = re.compile('(\d+)')
+                    INTEGER_RE = re.compile(r'(\d+)')
                     self.STARTSWITH = INTEGER_RE.match(m.group(1)).group()
                 # Append to the list
                 items.append(m.group(3))

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -140,7 +140,7 @@ REFERENCE_RE = NOIMG + BRK + r'\s?\[([^\]]*)\]'
 SHORT_REF_RE = NOIMG + r'\[([^\]]+)\]'
 
 # ![alt text][2]
-IMAGE_REFERENCE_RE = r'\!' + BRK + '\s?\[([^\]]*)\]'
+IMAGE_REFERENCE_RE = r'\!' + BRK + r'\s?\[([^\]]*)\]'
 
 # stand-alone * or _
 NOT_STRONG_RE = r'((^| )(\*|_)( |$))'
@@ -170,7 +170,7 @@ def dequote(string):
         return string
 
 
-ATTR_RE = re.compile("\{@([^\}]*)=([^\}]*)}")  # {@id=123}
+ATTR_RE = re.compile(r"\{@([^\}]*)=([^\}]*)}")  # {@id=123}
 
 
 def handleAttributes(text, parent):
@@ -351,7 +351,7 @@ class HtmlPattern(Pattern):
                 try:
                     return self.markdown.serializer(value)
                 except:
-                    return '\%s' % value
+                    return r'\%s' % value
 
         return util.INLINE_PLACEHOLDER_RE.sub(get_stash, text)
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -102,7 +102,7 @@ class AndSubstitutePostprocessor(Postprocessor):
 class UnescapePostprocessor(Postprocessor):
     """ Restore escaped chars """
 
-    RE = re.compile('%s(\d+)%s' % (util.STX, util.ETX))
+    RE = re.compile(r'%s(\d+)%s' % (util.STX, util.ETX))
 
     def unescape(self, m):
         return util.int2str(int(m.group(1)))


### PR DESCRIPTION
Python tolerates invalid escape sequences in regexp:

[py.warnings] [WARNING] [...]/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/blockprocessors.py:394: DeprecationWarning: invalid escape sequence \d

[py.warnings] [WARNING] [...]/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/inlinepatterns.py:143: DeprecationWarning: invalid escape sequence \s

[py.warnings] [WARNING] [...]/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/inlinepatterns.py:173: DeprecationWarning: invalid escape sequence \{

[py.warnings] [WARNING] [...]/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/inlinepatterns.py:354: DeprecationWarning: invalid escape sequence \%

[py.warnings] [WARNING] [...]/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/postprocessors.py:105: DeprecationWarning: invalid escape sequence \d