### PR TITLE
Admonition: add the possibility to specify additional CSS classes names

### DIFF
--- a/docs/extensions/admonition.txt
+++ b/docs/extensions/admonition.txt
@@ -51,6 +51,18 @@ will render:
     <p>...</p>
     </div>
 
+You can also provide additional CSS class names by separating them using space characters. For instance:
+
+    !!! danger highlight blink "Don't try this at home"
+        ...
+
+will render:
+
+    <div class="admonition danger highlight blink">
+    <p class="admonition-title">Don't try this at home</p>
+    <p>...</p>
+    </div>
+
 If you don't want a title, use a blank string `""`:
 
     !!! important ""

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -41,7 +41,7 @@ class AdmonitionProcessor(BlockProcessor):
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'
-    RE = re.compile(r'(?:^|\n)!!!\ ?([\w\-]+(?:\.[\w\-]+)*)(?:\ "(.*?)")?')
+    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+(?:\.[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
 
     def test(self, parent, block):
         sibling = self.lastChild(parent)

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -41,7 +41,7 @@ class AdmonitionProcessor(BlockProcessor):
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'
-    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+)(?: +"(.*?)")? *(?:\n|$)')
+    RE = re.compile(r'(?:^|\n)!!!\ ?([\w\-]+(?:\.[\w\-]+)*)(?:\ "(.*?)")?')
 
     def test(self, parent, block):
         sibling = self.lastChild(parent)
@@ -80,11 +80,12 @@ class AdmonitionProcessor(BlockProcessor):
 
     def get_class_and_title(self, match):
         klass, title = match.group(1).lower(), match.group(2)
+        klass = klass.replace('.', ' ')
         if title is None:
             # no title was provided, use the capitalized classname as title
             # e.g.: `!!! note` will render
             # `<p class="admonition-title">Note</p>`
-            title = klass.capitalize()
+            title = klass.split(' ', 1)[0].capitalize()
         elif title == '':
             # an explicit blank title should not be rendered
             # e.g.: `!!! warning ""` will *not* render `p` with a title

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -42,6 +42,7 @@ class AdmonitionProcessor(BlockProcessor):
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'
     RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
+    RE_SPACES = re.compile('  +')
 
     def test(self, parent, block):
         sibling = self.lastChild(parent)
@@ -80,7 +81,7 @@ class AdmonitionProcessor(BlockProcessor):
 
     def get_class_and_title(self, match):
         klass, title = match.group(1).lower(), match.group(2)
-        klass = re.sub(' +', ' ', klass)
+        klass = self.RE_SPACES.sub(' ', klass)
         if title is None:
             # no title was provided, use the capitalized classname as title
             # e.g.: `!!! note` will render
@@ -95,3 +96,4 @@ class AdmonitionProcessor(BlockProcessor):
 
 def makeExtension(*args, **kwargs):
     return AdmonitionExtension(*args, **kwargs)
+

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -41,7 +41,7 @@ class AdmonitionProcessor(BlockProcessor):
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'
-    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+(?:\.[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
+    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
 
     def test(self, parent, block):
         sibling = self.lastChild(parent)
@@ -80,7 +80,6 @@ class AdmonitionProcessor(BlockProcessor):
 
     def get_class_and_title(self, match):
         klass, title = match.group(1).lower(), match.group(2)
-        klass = klass.replace('.', ' ')
         if title is None:
             # no title was provided, use the capitalized classname as title
             # e.g.: `!!! note` will render

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -96,4 +96,3 @@ class AdmonitionProcessor(BlockProcessor):
 
 def makeExtension(*args, **kwargs):
     return AdmonitionExtension(*args, **kwargs)
-

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -80,6 +80,7 @@ class AdmonitionProcessor(BlockProcessor):
 
     def get_class_and_title(self, match):
         klass, title = match.group(1).lower(), match.group(2)
+        klass = re.sub(' +', ' ', klass)
         if title is None:
             # no title was provided, use the capitalized classname as title
             # e.g.: `!!! note` will render

--- a/tests/extensions/admonition.html
+++ b/tests/extensions/admonition.html
@@ -26,6 +26,15 @@
 <p>For something completely different.</p>
 <p>You can also use a custom CSS class name.</p>
 </div>
+<div class="admonition class1 class2 class3">
+<p class="admonition-title">And now...</p>
+<p>For something completely different.</p>
+<p>Several class names can be separated by space chars.</p>
+</div>
+<div class="admonition note anotherclass">
+<p class="admonition-title">Note</p>
+<p>The default title is the capitalized first class name.</p>
+</div>
 <div class="admonition tip">
 <p>An explicitly empty string prevents the title from being rendered.</p>
 </div>

--- a/tests/extensions/admonition.txt
+++ b/tests/extensions/admonition.txt
@@ -25,6 +25,14 @@ Not part of an Admonition!
 
     You can also use a custom CSS class name.
 
+!!! class1 class2    class3 "And now..."
+    For something completely different.
+
+    Several class names can be separated by space chars.
+
+!!! note anotherclass
+    The default title is the capitalized first class name.
+
 !!! tip ""
     An explicitly empty string prevents the title from being rendered.
 


### PR DESCRIPTION
Hi,
I read about the feature freeze in the other pull requests, so feel free to tell me if there is a better location to propose this patch.

I need to be able to add additional classes to admonition, typically to make some box floating on the right while keeping the other ones in full width. I don't think there is a way to make the Admonition extension to work with the Attribute List to achieve this, so I updated Admonition to add this feature.

Additional CSS classes names can now be appended to the admonition name using dots as a separator.

The following markdown:

    !!!note.floatright
        This is a floating note.

Now generates the following HTML code:

    <div class="admonition note floatright">
        <p class="admonition-title">Note</p>
        <p>This is a floating note.</p>
    </div>

Dots are currently invalid in admonition names and break the admonition box, so I think it is safe to assume that this change should not cause any compatibility issue as nobody should be already using such dotted syntax or expect any particular behavior, and dots are already used as class names separator in CSS files so this syntax seems natural to me.