### PR TITLE
Allow spaces in image url

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -131,7 +131,7 @@ LINK_RE = NOIMG + BRK + \
     r'''\(\s*(<.*?>|((?:(?:\(.*?\))|[^\(\)]))*?)\s*((['"])(.*?)\12\s*)?\)'''
 
 # ![alttxt](http://x.com/) or ![alttxt](<http://x.com/>)
-IMAGE_LINK_RE = r'\!' + BRK + r'\s*\(\s*(<.*?>|([^"\)\s]+\s*"[^"]*"|[^\)\s]*))\s*\)'
+IMAGE_LINK_RE = r'\!' + BRK + r'\s*\(\s*(<.*?>|(?:([^"\)]+)\s*("[^"]*")|[^\)]*))\s*\)'
 
 # [Google][3]
 REFERENCE_RE = NOIMG + BRK + r'\s?\[([^\]]*)\]'
@@ -427,16 +427,21 @@ class ImagePattern(LinkPattern):
     """ Return a img element from the given match. """
     def handleMatch(self, m):
         el = util.etree.Element("img")
-        src_parts = m.group(9).split()
-        if src_parts:
-            src = src_parts[0]
-            if src[0] == "<" and src[-1] == ">":
-                src = src[1:-1]
-            el.set('src', self.sanitize_url(self.unescape(src)))
+        if m.group(11):
+            # Preserving legacy split title logic
+            # which reduced white space (newlines, multiple spaces, etc.)
+            # to a single space.
+            title = ' '.join(m.group(11).split())
+            src = m.group(10).strip()
         else:
-            el.set('src', "")
-        if len(src_parts) > 1:
-            el.set('title', dequote(self.unescape(" ".join(src_parts[1:]))))
+            title = None
+            src = m.group(9).strip()
+        if src and src[0] == "<" and src[-1] == ">":
+            src = src[1:-1]
+        el.set('src', self.sanitize_url(self.unescape(src)))
+
+        if title:
+            el.set('title', dequote(self.unescape(title)))
 
         if self.markdown.enable_attributes:
             truealt = handleAttributes(m.group(2), el)

--- a/tests/misc/image.html
+++ b/tests/misc/image.html
@@ -1,5 +1,5 @@
 <p><img alt="Poster" src="http://humane_man.jpg" title="The most humane man." /></p>
 <p><img alt="Poster" src="http://humane_man.jpg" title="The most humane man." /></p>
 <p><img alt="Blank" src="" /></p>
-<p>![Fail](http://humane man.jpg "The most humane man.")</p>
-<p>![Fail](http://humane man.jpg)</p>
+<p><img alt="Okay" src="http://humane man.jpg" title="The most humane man." /></p>
+<p><img alt="Okay" src="http://humane man.jpg" /></p>

--- a/tests/misc/image.txt
+++ b/tests/misc/image.txt
@@ -7,6 +7,6 @@
 
 ![Blank]()
 
-![Fail](http://humane man.jpg "The most humane man.")
+![Okay](http://humane man.jpg "The most humane man.")
 
-![Fail](http://humane man.jpg)
+![Okay](http://humane man.jpg)


### PR DESCRIPTION
Preserving general pre-existing title output, ensure that image URL can have spaces (ref #590).