### PR TITLE
Feature ancestry

### DIFF
--- a/.spell-dict
+++ b/.spell-dict
@@ -103,6 +103,7 @@ traceback
 Tredinnick
 Treeprocessor
 Treeprocessors
+tuple
 tuples
 unordered
 untrusted

--- a/docs/extensions/api.txt
+++ b/docs/extensions/api.txt
@@ -53,7 +53,7 @@ A pseudo example:
 Inline Patterns {: #inlinepatterns }
 ------------------------------------
 
-Inline Patterns implement the inline HTML element syntax for Markdown such as
+Inline Patterns implement the inline HTML element syntax for Markdown such as 
 `*emphasis*` or `[links](http://example.com)`. Pattern objects should be 
 instances of classes that inherit from `markdown.inlinepatterns.Pattern` or 
 one of its children. Each pattern object uses a single regular expression and 
@@ -68,11 +68,9 @@ must have the following methods:
     Accepts a match object and returns an ElementTree element of a plain 
     Unicode string.
 
-* **`getExcludes()`**: 
-
-    Returns an array of tag names that are undesirable ancestors. The pattern 
-    should not match if it would cause the content to be a descendant of one 
-    of the tag names in the list.
+Also, Inline Patterns can define the property `ANCESTOR_EXCLUDES` with either 
+a list or tuple of undesirable ancestors. The pattern should not match if it 
+would cause the content to be a descendant of one of the defined tag names.
 
 Note that any regular expression returned by `getCompiledRegExp` must capture
 the whole block. Therefore, they should all start with `r'^(.*?)'` and end

--- a/docs/extensions/api.txt
+++ b/docs/extensions/api.txt
@@ -71,7 +71,7 @@ must have the following methods:
 * **`getExcludes()`**: 
 
     Returns an array of tag names that are undesirable ancestors. The pattern 
-    should not match if it would cause the content to be a decendent of one 
+    should not match if it would cause the content to be a descendant of one 
     of the tag names in the list.
 
 Note that any regular expression returned by `getCompiledRegExp` must capture

--- a/docs/extensions/api.txt
+++ b/docs/extensions/api.txt
@@ -68,6 +68,12 @@ must have the following methods:
     Accepts a match object and returns an ElementTree element of a plain 
     Unicode string.
 
+* **`getExcludes()`**: 
+
+    Returns an array of tag names that are undesirable ancestors. The pattern 
+    should not match if it would cause the content to be a decendent of one 
+    of the tag names in the list.
+
 Note that any regular expression returned by `getCompiledRegExp` must capture
 the whole block. Therefore, they should all start with `r'^(.*?)'` and end
 with `r'(.*?)!'`. When using the default `getCompiledRegExp()` method 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -207,6 +207,10 @@ class Pattern(object):
         if markdown_instance:
             self.markdown = markdown_instance
 
+    def getExcludes(self):
+        """Get tag to exclude."""
+        return []
+
     def getCompiledRegExp(self):
         """ Return a compiled regular expression. """
         return self.compiled_re

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -189,6 +189,8 @@ The pattern classes
 class Pattern(object):
     """Base class that inline patterns subclass. """
 
+    ANCESTOR_EXCLUDES = tuple()
+
     def __init__(self, pattern, markdown_instance=None):
         """
         Create an instant of an inline pattern.
@@ -206,10 +208,6 @@ class Pattern(object):
         self.safe_mode = False
         if markdown_instance:
             self.markdown = markdown_instance
-
-    def getExcludes(self):
-        """Get tag to exclude."""
-        return []
 
     def getCompiledRegExp(self):
         """ Return a compiled regular expression. """

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -251,12 +251,12 @@ class InlineProcessor(Treeprocessor):
                 # We need to process current node too
                 for child in [node] + list(node):
                     if not isString(node):
-                        self.ancestors.append(child.tag.lower())
                         if child.text:
+                            self.ancestors.append(child.tag.lower())
                             child.text = self.__handleInline(
                                 child.text, patternIndex + 1
                             )
-                        self.ancestors.pop()
+                            self.ancestors.pop()
                         if child.tail:
                             child.tail = self.__handleInline(
                                 child.tail, patternIndex
@@ -313,10 +313,10 @@ class InlineProcessor(Treeprocessor):
 
             insertQueue = []
             for child in currElement:
-                self.ancestors.append(child.tag.lower())
                 if child.text and not isinstance(
                     child.text, util.AtomicString
                 ):
+                    self.ancestors.append(child.tag.lower())
                     text = child.text
                     child.text = None
                     lst = self.__processPlaceholders(
@@ -326,7 +326,7 @@ class InlineProcessor(Treeprocessor):
                         self.parent_map[l[0]] = child
                     stack += lst
                     insertQueue.append((child, lst))
-                self.ancestors.pop()
+                    self.ancestors.pop()
                 if child.tail:
                     tail = self.__handleInline(child.tail)
                     dumby = util.etree.Element('d')

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -231,7 +231,8 @@ class InlineProcessor(Treeprocessor):
         Returns: String with placeholders instead of ElementTree elements.
 
         """
-        for exclude in pattern.getExcludes():
+
+        for exclude in pattern.ANCESTOR_EXCLUDES:
             if exclude.lower() in self.ancestors:
                 return data, False, 0
 

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -778,9 +778,7 @@ class TestAncestorExclusion(unittest.TestCase):
     class AncestorExample(markdown.inlinepatterns.SimpleTagPattern):
         """ Ancestor Test. """
 
-        def getExcludes(self):
-            """ Tags to exclude. """
-            return ['a']
+        ANCESTOR_EXCLUDES = ('a',)
 
         def handleMatch(self, m):
             """ Handle match. """


### PR DESCRIPTION
Feature adds the ability for an inline pattern to define a list of ancestor tag names that should be avoided.  If a pattern would create a descendant of one of the listed tag names, the pattern will not match. 