### PR TITLE
Upped version to 2.6.10

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -1,7 +1,9 @@
-title:      Change Log
+title: Change Log
 
 Python-Markdown Change Log
 =========================
+
+Dec 7, 2017: Released version 2.6.10 (a documentation update).
 
 Aug 17, 2017: Released version 2.6.9 (a bug-fix release).
 

--- a/markdown/__version__.py
+++ b/markdown/__version__.py
@@ -5,7 +5,7 @@
 # (major, minor, micro, alpha/beta/rc/final, #)
 # (1, 1, 2, 'alpha', 0) => "1.1.2.dev"
 # (1, 2, 0, 'beta', 2) => "1.2b2"
-version_info = (2, 6, 9, 'final', 0)
+version_info = (2, 6, 10, 'final', 0)
 
 
 def _get_version():

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ use_directory_urls: true
 theme:
   name: nature
   icon: py.png
-  release: 2.6.9
+  release: 2.6.10
   issue_tracker: https://github.com/Python-Markdown/markdown/issues
 
 pages:


### PR DESCRIPTION
This version was released to force PyPI to point to the new docs location.
Closes #601. The old PyPI hosted docs can be deleted after this.