### PR TITLE
Update makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,18 +20,14 @@ install:
 
 .PHONY : deploy
 deploy:
-	python setup.py sdist --manifest-only
-	python setup.py sdist --formats zip,gztar upload
-	mkdocs gh-deploy -r pages -b master
+	python setup.py sdist --formats gztar upload
 
 .PHONY : build
 build:
-	python setup.py sdist --manifest-only
-	python setup.py sdist --formats zip,gztar
+	python setup.py sdist --formats gztar
 
 .PHONY : build-win
 build-win:
-	python setup.py sdist --manifest-only
 	python setup.py bdist_wininst
 
 .PHONY : docs


### PR DESCRIPTION
The sdist command now builds the MANIFEST automatically. No need
to do it manually. Also, PyPI now only accepts one sdist file per
release, so let's not try to upload two.

Also, the docs deploy command does not work right so it's removed.

See #604 for more info.