### PR TITLE
Test case for nested paragraph in list

### DIFF
--- a/tests/basic/list-nested-paragraph.html
+++ b/tests/basic/list-nested-paragraph.html
@@ -1,0 +1,11 @@
+<ul>
+<li>
+<p>This is a list</p>
+<p>This is a nested multi-line content</p>
+<p>Another nested paragraph in the same
+  list item</p>
+<p>And yet another one</p>
+</li>
+<li>That item is simple</li>
+<li>So is that one</li>
+</ul>

--- a/tests/basic/list-nested-paragraph.txt
+++ b/tests/basic/list-nested-paragraph.txt
@@ -1,0 +1,11 @@
+* This is a list
+
+      This is a nested multi-line content
+
+      Another nested paragraph in the same
+      list item
+
+      And yet another one
+
+* That item is simple
+* So is that one


### PR DESCRIPTION
When doing a nested paragraph in a list element, the first following list item has a nested paragraph, but not the other ones.

I've added a test case to cover the expected output and I'm currently getting the following diff:
```
-<li>That item is simple</li>
+<li>
+<p>That item is simple</p>
+</li>
```

I noticed this when looking at a [recent DRF release note](http://www.django-rest-framework.org/topics/release-notes/#374), where the output feels a bit weird.

Not sure yet how to fix it though... I'll keep digging for a bit.