### PR TITLE
Warnings should cause tests to fail.

### DIFF
--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -202,7 +202,7 @@ class FootnoteExtension(Extension):
             )
             backlink.text = FN_BACKLINK_TEXT
 
-            if li.getchildren():
+            if len(li):
                 node = li[-1]
                 if node.tag == "p":
                     node.text = node.text + NBSP_PLACEHOLDER
@@ -393,7 +393,7 @@ class FootnoteTreeprocessor(Treeprocessor):
             result = self.footnotes.findFootnotesPlaceholder(root)
             if result:
                 child, parent, isText = result
-                ind = parent.getchildren().index(child)
+                ind = list(parent).index(child)
                 if isText:
                     parent.remove(child)
                     parent.insert(ind, footnotesDiv)

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -272,8 +272,8 @@ class InlineProcessor(Treeprocessor):
     def __build_ancestors(self, parent, parents):
         """Build the ancestor list."""
         ancestors = []
-        while parent:
-            if parent:
+        while parent is not None:
+            if parent is not None:
                 ancestors.append(parent.tag.lower())
             parent = self.parent_map.get(parent)
         ancestors.reverse()
@@ -303,7 +303,7 @@ class InlineProcessor(Treeprocessor):
         # to ensure we don't have the user accidentally change it on us.
         tree_parents = [] if ancestors is None else ancestors[:]
 
-        self.parent_map = dict((c, p) for p in tree.getiterator() for c in p)
+        self.parent_map = dict((c, p) for p in tree.iter() for c in p)
         stack = [(tree, tree_parents)]
 
         while stack:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import os
 import markdown
 import codecs
 import difflib
+import warnings
 try:
     import nose
 except ImportError as e:
@@ -179,4 +180,10 @@ def generate_all():
 
 
 def run():
+    # Warnings should cause tests to fail...
+    warnings.simplefilter('error')
+    # Except for the warnings that shouldn't
+    warnings.filterwarnings('default', category=PendingDeprecationWarning)
+    warnings.filterwarnings('default', category=DeprecationWarning, module='markdown')
+
     nose.main(addplugins=[HtmlOutput(), Markdown()])


### PR DESCRIPTION
Related to #618.

Although, I don't see that this any offers any value. Mostly doing this for later reference.

Note that this change does not force the use of the pure Python Elementtree lib. But in my testing, even when doing so, there was no difference. 