### PR TITLE
Version to 3.0.dev

### DIFF
--- a/markdown/__version__.py
+++ b/markdown/__version__.py
@@ -5,7 +5,7 @@
 # (major, minor, micro, alpha/beta/rc/final, #)
 # (1, 1, 2, 'alpha', 0) => "1.1.2.dev"
 # (1, 2, 0, 'beta', 2) => "1.2b2"
-version_info = (2, 6, 11, 'final', 0)
+version_info = (3, 0, 0, 'alpha', 0)
 
 
 def _get_version():

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ use_directory_urls: true
 theme:
   name: nature
   icon: py.png
-  release: 2.6.11
+  release: 3.0.dev
   issue_tracker: https://github.com/Python-Markdown/markdown/issues
 
 pages:


### PR DESCRIPTION
Development of version 3.0 starts here. Any bugfixes that should be
applied to 2.x should be backported to the 2.6 branch.