### PR TITLE
docs: Remove references to header_id.md page which no longer exists

### DIFF
--- a/checkspelling.sh
+++ b/checkspelling.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Building docs..."
-mkdocs build
+mkdocs build --strict
 if [ $? -ne 0 ]; then
     exit 1
 fi

--- a/docs/change_log/release-2.1.md
+++ b/docs/change_log/release-2.1.md
@@ -43,7 +43,7 @@ release, there are a few backward-incompatible changes to note:
   you should now set them on the class. See the [Library
   Reference](../reference.md) for the options available.
 
-* If you have been using the [HeaderId](../extensions/header_id.md) extension to
+* If you have been using the HeaderId extension to
   define custom ids on headers, you will want to switch to using the new
   [Attribute List](../extensions/attr_list.md) extension. The HeaderId extension
   now only auto-generates ids on headers which have not already had ids defined.

--- a/docs/change_log/release-2.6.md
+++ b/docs/change_log/release-2.6.md
@@ -142,7 +142,7 @@ explanation of the current behavior.
 
 ### HeaderId Extension Pending Deprecation
 
-The [HeaderId][hid] Extension is pending deprecation and will raise a
+The HeaderId Extension is pending deprecation and will raise a
 **`PendingDeprecationWarning`** in version 2.6. The extension will be deprecated
 in the next release and raise an error in the release after that. Use the [Table
 of Contents][TOC] Extension instead, which offers most of the features of the
@@ -152,8 +152,6 @@ Extension authors who have been using the `slugify` and `unique` functions
 defined in the HeaderId Extension should note that those functions are now
 defined in the Table of Contents extension and should adjust their import
 statements accordingly (`from markdown.extensions.toc import slugify, unique`).
-
-[hid]: ../extensions/header_id.md
 
 ### The `configs` Keyword is Deprecated
 

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -64,7 +64,6 @@ Extension                            | Entry Point    | Dot Notation
 [Smart Strong]: smart_strong.md
 [Admonition]: admonition.md
 [CodeHilite]: code_hilite.md
-[HeaderId]: header_id.md
 [Meta-Data]: meta_data.md
 [New Line to Break]: nl2br.md
 [Sane Lists]: sane_lists.md

--- a/docs/extensions/meta_data.md
+++ b/docs/extensions/meta_data.md
@@ -101,9 +101,6 @@ Compatible Extensions
 The following extensions are currently known to work with the Meta-Data
 extension. The keywords they are known to support are also listed.
 
-* [HeaderId](header_id.md)
-    * `header_level`
-    * `header_forceid`
 * [WikiLinks](wikilinks.md)
     * `wiki_base_url`
     * `wiki_end_url`


### PR DESCRIPTION
It was removed in 11270135194922e0f5cfc739b69fe39f7337a0f9 together with the extension itself.

This fixes the following mkdocs warnings:
```
WARNING -  The page "extensions/index.md" contained a hyperlink to "extensions/header_id.md" which is not listed in the "pages" configuration. 
WARNING -  The page "extensions/meta_data.md" contained a hyperlink to "extensions/header_id.md" which is not listed in the "pages" configuration. 
WARNING -  The page "change_log/release-2.6.md" contained a hyperlink to "extensions/header_id.md" which is not listed in the "pages" configuration. 
WARNING -  The page "change_log/release-2.1.md" contained a hyperlink to "extensions/header_id.md" which is not listed in the "pages" configuration.
```