### PR TITLE
Remove deprecated support for Extension args.

### DIFF
--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -5,7 +5,6 @@ Extensions
 
 from __future__ import unicode_literals
 from ..util import parseBoolValue
-import warnings
 
 
 class Extension(object):
@@ -20,34 +19,8 @@ class Extension(object):
     # if a default is not set here.
     config = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         """ Initiate Extension and set up configs. """
-
-        # check for configs arg for backward compat.
-        # (there only ever used to be one so we use arg[0])
-        if len(args):
-            if args[0] is not None:
-                self.setConfigs(args[0])
-            warnings.warn('Extension classes accepting positional args is '
-                          'pending Deprecation. Each setting should be '
-                          'passed into the Class as a keyword. Positional '
-                          'args are deprecated and will raise '
-                          'an error in version 2.7. See the Release Notes for '
-                          'Python-Markdown version 2.6 for more info.',
-                          DeprecationWarning)
-        # check for configs kwarg for backward compat.
-        if 'configs' in kwargs.keys():
-            if kwargs['configs'] is not None:
-                self.setConfigs(kwargs.pop('configs', {}))
-            warnings.warn('Extension classes accepting a dict on the single '
-                          'keyword "config" is pending Deprecation. Each '
-                          'setting should be passed into the Class as a '
-                          'keyword directly. The "config" keyword is '
-                          'deprecated and raise an error in '
-                          'version 2.7. See the Release Notes for '
-                          'Python-Markdown version 2.6 for more info.',
-                          DeprecationWarning)
-        # finally, use kwargs
         self.setConfigs(kwargs)
 
     def getConfig(self, key, default=''):

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -90,5 +90,5 @@ class AbbrPattern(Pattern):
         return abbr
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return AbbrExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return AbbrExtension(**kwargs)

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -92,5 +92,5 @@ class AdmonitionProcessor(BlockProcessor):
         return klass, title
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return AdmonitionExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return AdmonitionExtension(**kwargs)

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -168,5 +168,5 @@ class AttrListExtension(Extension):
         )
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return AttrListExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return AttrListExtension(**kwargs)

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -227,7 +227,7 @@ class HiliteTreeprocessor(Treeprocessor):
 class CodeHiliteExtension(Extension):
     """ Add source code hilighting to markdown codeblocks. """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         # define default configs
         self.config = {
             'linenums': [None,
@@ -249,7 +249,7 @@ class CodeHiliteExtension(Extension):
                              'Default: True']
             }
 
-        super(CodeHiliteExtension, self).__init__(*args, **kwargs)
+        super(CodeHiliteExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):
         """ Add HilitePostprocessor to Markdown instance. """
@@ -260,5 +260,5 @@ class CodeHiliteExtension(Extension):
         md.registerExtension(self)
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return CodeHiliteExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return CodeHiliteExtension(**kwargs)

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -111,5 +111,5 @@ class DefListExtension(Extension):
                                       '>ulist')
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return DefListExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return DefListExtension(**kwargs)

--- a/markdown/extensions/extra.py
+++ b/markdown/extensions/extra.py
@@ -50,10 +50,9 @@ extensions = [
 class ExtraExtension(Extension):
     """ Add various extensions to Markdown class."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         """ config is a dumb holder which gets passed to actual ext later. """
-        self.config = kwargs.pop('configs', {})
-        self.config.update(kwargs)
+        self.config = kwargs
 
     def extendMarkdown(self, md, md_globals):
         """ Register extension instances. """
@@ -68,8 +67,8 @@ class ExtraExtension(Extension):
             r'^(p|h[1-6]|li|dd|dt|td|th|legend|address)$', re.IGNORECASE)
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return ExtraExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return ExtraExtension(**kwargs)
 
 
 class MarkdownInHtmlProcessor(BlockProcessor):

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -109,5 +109,5 @@ class FencedBlockPreprocessor(Preprocessor):
         return txt
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return FencedCodeExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return FencedCodeExtension(**kwargs)

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -35,7 +35,7 @@ RE_REF_ID = re.compile(r'(fnref)(\d+)')
 class FootnoteExtension(Extension):
     """ Footnote Extension. """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         """ Setup configs. """
 
         self.config = {
@@ -56,7 +56,7 @@ class FootnoteExtension(Extension):
                  "of the backlink. %d will be replaced by the "
                  "footnote number."]
         }
-        super(FootnoteExtension, self).__init__(*args, **kwargs)
+        super(FootnoteExtension, self).__init__(**kwargs)
 
         # In multiple invocations, emit links that don't get tangled.
         self.unique_prefix = 0
@@ -426,6 +426,6 @@ class FootnotePostprocessor(Postprocessor):
         return text.replace(NBSP_PLACEHOLDER, "&#160;")
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
+def makeExtension(**kwargs):  # pragma: no cover
     """ Return an instance of the FootnoteExtension """
-    return FootnoteExtension(*args, **kwargs)
+    return FootnoteExtension(**kwargs)

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -74,5 +74,5 @@ class MetaPreprocessor(Preprocessor):
         return lines
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return MetaExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return MetaExtension(**kwargs)

--- a/markdown/extensions/nl2br.py
+++ b/markdown/extensions/nl2br.py
@@ -31,5 +31,5 @@ class Nl2BrExtension(Extension):
         md.inlinePatterns.add('nl', br_tag, '_end')
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return Nl2BrExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return Nl2BrExtension(**kwargs)

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -51,5 +51,5 @@ class SaneListExtension(Extension):
         md.parser.blockprocessors['ulist'] = SaneUListProcessor(md.parser)
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return SaneListExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return SaneListExtension(**kwargs)

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -37,5 +37,5 @@ class SmartEmphasisExtension(Extension):
         )
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return SmartEmphasisExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return SmartEmphasisExtension(**kwargs)

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -168,7 +168,7 @@ class SubstituteTextPattern(HtmlPattern):
 
 
 class SmartyExtension(Extension):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.config = {
             'smart_quotes': [True, 'Educate quotes'],
             'smart_angled_quotes': [False, 'Educate angled quotes'],
@@ -176,7 +176,7 @@ class SmartyExtension(Extension):
             'smart_ellipses': [True, 'Educate ellipses'],
             'substitutions': [{}, 'Overwrite default substitutions'],
         }
-        super(SmartyExtension, self).__init__(*args, **kwargs)
+        super(SmartyExtension, self).__init__(**kwargs)
         self.substitutions = dict(substitutions)
         self.substitutions.update(self.getConfig('substitutions', default={}))
 
@@ -264,5 +264,5 @@ class SmartyExtension(Extension):
         md.ESCAPED_CHARS.extend(['"', "'"])
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return SmartyExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return SmartyExtension(**kwargs)

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -223,5 +223,5 @@ class TableExtension(Extension):
                                       '<hashheader')
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return TableExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return TableExtension(**kwargs)

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -265,7 +265,7 @@ class TocExtension(Extension):
 
     TreeProcessorClass = TocTreeprocessor
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.config = {
             "marker": ['[TOC]',
                        'Text to find and replace with Table of Contents - '
@@ -286,7 +286,7 @@ class TocExtension(Extension):
             'separator': ['-', 'Word separator. Defaults to "-".']
         }
 
-        super(TocExtension, self).__init__(*args, **kwargs)
+        super(TocExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):
         md.registerExtension(self)
@@ -304,5 +304,5 @@ class TocExtension(Extension):
         self.md.toc = ''
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return TocExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return TocExtension(**kwargs)

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -31,7 +31,7 @@ def build_url(label, base, end):
 
 class WikiLinkExtension(Extension):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.config = {
             'base_url': ['/', 'String to append to beginning or URL.'],
             'end_url': ['/', 'String to append to end of URL.'],
@@ -39,7 +39,7 @@ class WikiLinkExtension(Extension):
             'build_url': [build_url, 'Callable formats URL from label.'],
         }
 
-        super(WikiLinkExtension, self).__init__(*args, **kwargs)
+        super(WikiLinkExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):
         self.md = md
@@ -85,5 +85,5 @@ class WikiLinks(Pattern):
         return base_url, end_url, html_class
 
 
-def makeExtension(*args, **kwargs):  # pragma: no cover
-    return WikiLinkExtension(*args, **kwargs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return WikiLinkExtension(**kwargs)


### PR DESCRIPTION
In the past Markdown used to pass extension config settings to the
Extension class via a positional argument named `config`. That was
deprecated in 2.6 in favor of using keyword arguments (`**kwargs`).
Support has been completely dropped. Only keyword arguments are
accepted.