### PR TITLE
Fix 'IndentationError' in release-2.6 document

### DIFF
--- a/docs/change_log/release-2.6.md
+++ b/docs/change_log/release-2.6.md
@@ -46,8 +46,8 @@ from markdown.extensions import Extension
 
 class EscapeHtml(Extension):
     def extendMarkdown(self, md, md_globals):
-    del md.preprocessors['html_block']
-    del md.inlinePatterns['html']
+        del md.preprocessors['html_block']
+        del md.inlinePatterns['html']
 
 html = markdown.markdown(text, extensions=[EscapeHtml()])
 ```


### PR DESCRIPTION
Hi, I found and corrected an error in the sample implementation of `EscapeHtml` in release-2.6 changelog document.