### PR TITLE
Simplify output_formats to html and xhtml.

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -172,19 +172,10 @@ __output_format__{: #output_format }:
 
     Supported formats are:
 
-    * `"xhtml1"`: Outputs XHTML 1.x. **Default**.
-    * `"xhtml5"`: Outputs XHTML style tags of HTML 5
-    * `"xhtml"`: Outputs latest supported version of XHTML (currently XHTML 1.1).
-    * `"html4"`: Outputs HTML 4
-    * `"html5"`: Outputs HTML style tags of HTML 5
-    * `"html"`: Outputs latest supported version of HTML (currently HTML 4).
+    * `"xhtml"`: Outputs XHTML style tags. **Default**.
+    * `"html5"`: Outputs HTML style tags.
 
     The values can be in either lowercase or uppercase.
-
-    !!! warning
-        It is suggested that the more specific formats (`"xhtml1"`, `"html5"`, &
-        `"html4"`) be used as the more general formats (`"xhtml"` or `"html"`) may
-        change in the future if it makes sense at that time.
 
 __tab_length__{: #tab_length }:
 

--- a/markdown/__main__.py
+++ b/markdown/__main__.py
@@ -37,8 +37,8 @@ def parse_options(args=None, values=None):
     parser.add_option("-e", "--encoding", dest="encoding",
                       help="Encoding for input and output files.",)
     parser.add_option("-o", "--output_format", dest="output_format",
-                      default='xhtml1', metavar="OUTPUT_FORMAT",
-                      help="'xhtml1' (default), 'html4' or 'html5'.")
+                      default='xhtml', metavar="OUTPUT_FORMAT",
+                      help="Use output format 'xhtml' (default) or 'html'.")
     parser.add_option("-n", "--no_lazy_ol", dest="lazy_ol",
                       action='store_false', default=True,
                       help="Observe number of first item of ordered lists.")

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -26,7 +26,6 @@ class Markdown(object):
     doc_tag = "div"     # Element used to wrap document - later removed
 
     option_defaults = {
-        'html_replacement_text': '[HTML_REMOVED]',
         'tab_length':            4,
         'enable_attributes':     True,
         'smart_emphasis':        True,
@@ -35,11 +34,7 @@ class Markdown(object):
 
     output_formats = {
         'html':   to_html_string,
-        'html4':  to_html_string,
-        'html5':  to_html_string,
         'xhtml':  to_xhtml_string,
-        'xhtml1': to_xhtml_string,
-        'xhtml5': to_xhtml_string,
     }
 
     def __init__(self, **kwargs):
@@ -55,17 +50,8 @@ class Markdown(object):
             no class is specified, then a `makeExtension` function is called within the specified module.
         * extension_configs: Configuration settings for extensions.
         * output_format: Format of output. Supported formats are:
-            * "xhtml1": Outputs XHTML 1.x. Default.
-            * "xhtml5": Outputs XHTML style tags of HTML 5
-            * "xhtml": Outputs latest supported version of XHTML
-              (currently XHTML 1.1).
-            * "html4": Outputs HTML 4
-            * "html5": Outputs HTML style tags of HTML 5
-            * "html": Outputs latest supported version of HTML
-              (currently HTML 4).
-            Note that it is suggested that the more specific formats ("xhtml1"
-            and "html4") be used as "xhtml" or "html" may change in the future
-            if it makes sense at that time.
+            * "xhtml": Outputs XHTML style tags. Default.
+            * "html": Outputs HTML style tags.
         * tab_length: Length of tabs in the source. Default: 4
         * enable_attributes: Enable the conversion of attributes. Default: True
         * smart_emphasis: Treat `_connected_words_` intelligently Default: True
@@ -90,7 +76,7 @@ class Markdown(object):
         self.htmlStash = util.HtmlStash()
         self.registerExtensions(extensions=kwargs.get('extensions', []),
                                 configs=kwargs.get('extension_configs', {}))
-        self.set_output_format(kwargs.get('output_format', 'xhtml1'))
+        self.set_output_format(kwargs.get('output_format', 'xhtml'))
         self.reset()
 
     def build_parser(self):
@@ -196,7 +182,7 @@ class Markdown(object):
 
     def set_output_format(self, format):
         """ Set the output format for the class instance. """
-        self.output_format = format.lower()
+        self.output_format = format.lower().rstrip('145')  # ignore num
         try:
             self.serializer = self.output_formats[self.output_format]
         except KeyError as e:

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -596,7 +596,7 @@ class TestCliOptionParsing(unittest.TestCase):
             'input': None,
             'output': None,
             'encoding': None,
-            'output_format': 'xhtml1',
+            'output_format': 'xhtml',
             'lazy_ol': True,
             'extensions': [],
             'extension_configs': {},
@@ -646,8 +646,8 @@ class TestCliOptionParsing(unittest.TestCase):
         self.assertEqual(options, self.default_options)
 
     def testOutputFormatOption(self):
-        options, logging_level = parse_options(['-o', 'html5'])
-        self.default_options['output_format'] = 'html5'
+        options, logging_level = parse_options(['-o', 'html'])
+        self.default_options['output_format'] = 'html'
         self.assertEqual(options, self.default_options)
 
     def testNoLazyOlOption(self):


### PR DESCRIPTION
We started with the numbers before HTML5 was a thing and we thought
there might be an XHTML2. Today, we know that all we have are HTML 
style tags and XHTML style tags. Nothing else really matters in the real 
world.

Note that if '(x)html1' '(x)html4' or '(x)html5' are passed in, the
number is stripped/ignored. Users shouldn't need to change their code 
for this.