### PR TITLE
linenums support for inline option

### DIFF
--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -249,6 +249,8 @@ class CodeHiliteExtension(Extension):
                              'Default: True']
             }
 
+        if kwargs.get('linenums') == 'inline':
+            self.config['linenums'][0] = kwargs['linenums']
         super(CodeHiliteExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):


### PR DESCRIPTION
Signed-off-by: lightxue <bkmgtp@gmail.com>

`linenums` in codehilite only supports 3 options now:

* None
* True
* False

In fact, in pygments, `linenos` supports a string option: `inline`。

https://github.com/nex3/pygments/blob/df106dc8c0ff67fdc6369265f6cb4e6832698792/pygments/formatters/html.py#L352-L359