### PR TITLE
Add missing comma in HTML_EMPTY

### DIFF
--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -52,7 +52,7 @@ ProcessingInstruction = util.etree.ProcessingInstruction
 __all__ = ['to_html_string', 'to_xhtml_string']
 
 HTML_EMPTY = ("area", "base", "basefont", "br", "col", "frame", "hr",
-              "img", "input", "isindex", "link", "meta" "param")
+              "img", "input", "isindex", "link", "meta", "param")
 
 try:
     HTML_EMPTY = set(HTML_EMPTY)


### PR DESCRIPTION
Because of the missing comma, the last two tags in the list, `meta` and `param` are interpreted as a single string literal `"metaparam"`, so the serializer fails to correctly produce empty elements for `<meta>` and `<param>` tags.