### PR TITLE
Simplify namespace support in serializer.

### DIFF
--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -39,6 +39,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from xml.etree.ElementTree import ProcessingInstruction
 from . import util
 ElementTree = util.etree.ElementTree
 QName = util.etree.QName
@@ -46,8 +47,6 @@ if hasattr(util.etree, 'test_comment'):  # pragma: no cover
     Comment = util.etree.test_comment
 else:  # pragma: no cover
     Comment = util.etree.Comment
-PI = util.etree.PI
-ProcessingInstruction = util.etree.ProcessingInstruction
 
 __all__ = ['to_html_string', 'to_xhtml_string']
 
@@ -64,13 +63,6 @@ def _raise_serialization_error(text):  # pragma: no cover
     raise TypeError(
         "cannot serialize %r (type %s)" % (text, type(text).__name__)
         )
-
-
-def _encode(text, encoding):
-    try:
-        return text.encode(encoding, "xmlcharrefreplace")
-    except (TypeError, AttributeError):  # pragma: no cover
-        _raise_serialization_error(text)
 
 
 def _escape_cdata(text):
@@ -181,15 +173,12 @@ def _serialize_html(write, elem, format):
         write(_escape_cdata(elem.tail))
 
 
-def _write_html(root, encoding=None, format="html"):
+def _write_html(root, format="html"):
     assert root is not None
     data = []
     write = data.append
     _serialize_html(write, root, format)
-    if encoding is None:
-        return "".join(data)
-    else:
-        return _encode("".join(data), encoding)
+    return "".join(data)
 
 
 # --------------------------------------------------------------------

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -496,6 +496,35 @@ class testSerializers(unittest.TestCase):
             '<MixedCase>not valid <EMPHASIS>html</EMPHASIS><HR /></MixedCase>'
         )
 
+    def testQName(self):
+        """ Test serialization of QName. """
+        div = markdown.util.etree.Element('div')
+        qname = markdown.util.etree.QName('http://www.w3.org/1998/Math/MathML', 'math')
+        math = markdown.util.etree.SubElement(div, qname)
+        math.set('display', 'block')
+        sem = markdown.util.etree.SubElement(math, 'semantics')
+        msup = markdown.util.etree.SubElement(sem, 'msup')
+        mi = markdown.util.etree.SubElement(msup, 'mi')
+        mi.text = 'x'
+        mn = markdown.util.etree.SubElement(msup, 'mn')
+        mn.text = '2'
+        ann = markdown.util.etree.SubElement(sem, 'annotations')
+        ann.text = 'x^2'
+        self.assertEqual(
+            markdown.serializers.to_xhtml_string(div),
+            '<div>'
+            '<math display="block" xmlns="http://www.w3.org/1998/Math/MathML">'
+            '<semantics>'
+            '<msup>'
+            '<mi>x</mi>'
+            '<mn>2</mn>'
+            '</msup>'
+            '<annotations>x^2</annotations>'
+            '</semantics>'
+            '</math>'
+            '</div>'
+        )
+
     def buildExtension(self):
         """ Build an extension which registers fakeSerializer. """
         def fakeSerializer(elem):


### PR DESCRIPTION
Fixes #679.

I'm still not 100% sure this is the correct approach. But I like the output we get in the included test better than what we got before.