### PR TITLE
Add support for additional Admonition classes

### DIFF
--- a/docs/extensions/admonition.md
+++ b/docs/extensions/admonition.md
@@ -72,8 +72,26 @@ results in:
 </div>
 ```
 
-rST suggests the following `types`, but you're free to use whatever you want:
-    attention, caution, danger, error, hint, important, note, tip, warning.
+You can also provide additional CSS class names separated by spaces. The first
+class should be the "type." For example:
+
+```md
+!!! danger highlight blink "Don't try this at home"
+    ...
+```
+
+will render:
+
+```html
+<div class="admonition danger highlight blink">
+<p class="admonition-title">Don't try this at home</p>
+<p>...</p>
+</div>
+```
+
+rST suggests the following "types": `attention`, `caution`, `danger`, `error`,
+`hint`, `important`, `note`, `tip`, and `warning`; however, you're free to use
+whatever you want.
 
 Styling
 -------

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -41,7 +41,8 @@ class AdmonitionProcessor(BlockProcessor):
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'
-    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+)(?: +"(.*?)")? *(?:\n|$)')
+    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
+    RE_SPACES = re.compile('  +')
 
     def test(self, parent, block):
         sibling = self.lastChild(parent)
@@ -80,11 +81,12 @@ class AdmonitionProcessor(BlockProcessor):
 
     def get_class_and_title(self, match):
         klass, title = match.group(1).lower(), match.group(2)
+        klass = self.RE_SPACES.sub(' ', klass)
         if title is None:
             # no title was provided, use the capitalized classname as title
             # e.g.: `!!! note` will render
             # `<p class="admonition-title">Note</p>`
-            title = klass.capitalize()
+            title = klass.split(' ', 1)[0].capitalize()
         elif title == '':
             # an explicit blank title should not be rendered
             # e.g.: `!!! warning ""` will *not* render `p` with a title

--- a/tests/extensions/admonition.html
+++ b/tests/extensions/admonition.html
@@ -26,6 +26,15 @@
 <p>For something completely different.</p>
 <p>You can also use a custom CSS class name.</p>
 </div>
+<div class="admonition class1 class2 class3">
+<p class="admonition-title">And now...</p>
+<p>For something completely different.</p>
+<p>Several class names can be separated by space chars.</p>
+</div>
+<div class="admonition note anotherclass">
+<p class="admonition-title">Note</p>
+<p>The default title is the capitalized first class name.</p>
+</div>
 <div class="admonition tip">
 <p>An explicitly empty string prevents the title from being rendered.</p>
 </div>

--- a/tests/extensions/admonition.txt
+++ b/tests/extensions/admonition.txt
@@ -25,6 +25,14 @@ Not part of an Admonition!
 
     You can also use a custom CSS class name.
 
+!!! class1 class2    class3 "And now..."
+    For something completely different.
+
+    Several class names can be separated by space chars.
+
+!!! note anotherclass
+    The default title is the capitalized first class name.
+
 !!! tip ""
     An explicitly empty string prevents the title from being rendered.
 


### PR DESCRIPTION
Additional CSS classes names can be appended to the admonition name
using spaces as separators.

The following markdown:

    !!! note floatright
        This is a floating note.

Generates the following HTML code:

    <div class="admonition note floatright">
        <p class="admonition-title">Note</p>
        <p>This is a floating note.</p>
    </div>

This is an update to #580 which has been rebased on master and conflicts resolved.