### PR TITLE
All Markdown instances are now 'md'.

### DIFF
--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -44,10 +44,16 @@ class BlockParser:
     looping through them and creating an ElementTree object.
     """
 
-    def __init__(self, markdown):
+    def __init__(self, md):
         self.blockprocessors = util.Registry()
         self.state = State()
-        self.markdown = markdown
+        self.md = md
+
+    @property
+    @util.deprecated("Use 'md' instead.")
+    def markdown(self):
+        # TODO: remove this later
+        return self.md
 
     def parseDocument(self, lines):
         """ Parse a markdown document into an ElementTree.

--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -66,7 +66,7 @@ class BlockParser:
 
         """
         # Create a ElementTree from the lines
-        self.root = util.etree.Element(self.markdown.doc_tag)
+        self.root = util.etree.Element(self.md.doc_tag)
         self.parseChunk(self.root, '\n'.join(lines))
         return util.etree.ElementTree(self.root)
 

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -51,7 +51,7 @@ class BlockProcessor(object):
 
     def __init__(self, parser):
         self.parser = parser
-        self.tab_length = parser.markdown.tab_length
+        self.tab_length = parser.md.tab_length
 
     def lastChild(self, parent):
         """ Return the last child of an etree element. """
@@ -365,7 +365,7 @@ class OListProcessor(BlockProcessor):
             # This is a new list so create parent with appropriate tag.
             lst = util.etree.SubElement(parent, self.TAG)
             # Check if a custom start integer is set
-            if not self.parser.markdown.lazy_ol and self.STARTSWITH != '1':
+            if not self.parser.md.lazy_ol and self.STARTSWITH != '1':
                 lst.attrib['start'] = self.STARTSWITH
 
         self.parser.state.set('list')

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -22,9 +22,9 @@ from .blockparser import BlockParser
 logger = logging.getLogger('MARKDOWN')
 
 
-def build_block_parser(md_instance, **kwargs):
+def build_block_parser(md, **kwargs):
     """ Build the default block parser used by Markdown. """
-    parser = BlockParser(md_instance)
+    parser = BlockParser(md)
     parser.blockprocessors.register(EmptyBlockProcessor(parser), 'empty', 100)
     parser.blockprocessors.register(ListIndentProcessor(parser), 'indent', 90)
     parser.blockprocessors.register(CodeBlockProcessor(parser), 'code', 80)

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -51,7 +51,7 @@ class AbbrPreprocessor(Preprocessor):
             if m:
                 abbr = m.group('abbr').strip()
                 title = m.group('title').strip()
-                self.markdown.inlinePatterns.register(
+                self.md.inlinePatterns.register(
                     AbbrInlineProcessor(self._generate_pattern(abbr), title), 'abbr-%s' % abbr, 2
                 )
                 # Preserve the line to prevent raw HTML indexing issue.

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -212,10 +212,10 @@ class HiliteTreeprocessor(Treeprocessor):
                     css_class=self.config['css_class'],
                     style=self.config['pygments_style'],
                     noclasses=self.config['noclasses'],
-                    tab_length=self.markdown.tab_length,
+                    tab_length=self.md.tab_length,
                     use_pygments=self.config['use_pygments']
                 )
-                placeholder = self.markdown.htmlStash.store(code.hilite())
+                placeholder = self.md.htmlStash.store(code.hilite())
                 # Clear codeblock in etree instance
                 block.clear()
                 # Change to p element which will later

--- a/markdown/extensions/extra.py
+++ b/markdown/extensions/extra.py
@@ -96,7 +96,7 @@ class MarkdownInHtmlProcessor(BlockProcessor):
                  block[nest_index[-1][1]:], True)                      # nest
 
     def run(self, parent, blocks, tail=None, nest=False):
-        self._tag_data = self.parser.markdown.htmlStash.tag_data
+        self._tag_data = self.parser.md.htmlStash.tag_data
 
         self.parser.blockprocessors.tag_counter += 1
         tag = self._tag_data[self.parser.blockprocessors.tag_counter]

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -55,7 +55,7 @@ class FencedBlockPreprocessor(Preprocessor):
 
         # Check for code hilite extension
         if not self.checked_for_codehilite:
-            for ext in self.markdown.registeredExtensions:
+            for ext in self.md.registeredExtensions:
                 if isinstance(ext, CodeHiliteExtension):
                     self.codehilite_conf = ext.config
                     break
@@ -90,7 +90,7 @@ class FencedBlockPreprocessor(Preprocessor):
                     code = self.CODE_WRAP % (lang,
                                              self._escape(m.group('code')))
 
-                placeholder = self.markdown.htmlStash.store(code)
+                placeholder = self.md.htmlStash.store(code)
                 text = '%s\n%s\n%s' % (text[:m.start()],
                                        placeholder,
                                        text[m.end():])

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -73,7 +73,7 @@ class MetaPreprocessor(Preprocessor):
                 else:
                     lines.insert(0, line)
                     break  # no meta data - done
-        self.markdown.Meta = meta
+        self.md.Meta = meta
         return lines
 
 

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -85,7 +85,7 @@ from __future__ import unicode_literals
 from . import Extension
 from ..inlinepatterns import HtmlInlineProcessor, HTML_RE
 from ..treeprocessors import InlineProcessor
-from ..util import Registry
+from ..util import Registry, deprecated
 
 
 # Constants for quote education.
@@ -151,11 +151,17 @@ HTML_STRICT_RE = HTML_RE + r'(?!\>)'
 
 
 class SubstituteTextPattern(HtmlInlineProcessor):
-    def __init__(self, pattern, replace, markdown_instance):
+    def __init__(self, pattern, replace, md):
         """ Replaces matches with some text. """
         HtmlInlineProcessor.__init__(self, pattern)
         self.replace = replace
-        self.markdown = markdown_instance
+        self.md = md
+
+    @property
+    @deprecated("Use 'md' instead.")
+    def markdown(self):
+        # TODO: remove this later
+        return self.md
 
     def handleMatch(self, m, data):
         result = ''

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -169,7 +169,7 @@ class SubstituteTextPattern(HtmlInlineProcessor):
             if isinstance(part, int):
                 result += m.group(part)
             else:
-                result += self.markdown.htmlStash.store(part)
+                result += self.md.htmlStash.store(part)
         return result, m.start(0), m.end(0)
 
 

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -219,8 +219,8 @@ class TocTreeprocessor(Treeprocessor):
 
         build_etree_ul(toc_list, div)
 
-        if 'prettify' in self.markdown.treeprocessors:
-            self.markdown.treeprocessors['prettify'].run(div)
+        if 'prettify' in self.md.treeprocessors:
+            self.md.treeprocessors['prettify'].run(div)
 
         return div
 
@@ -241,7 +241,7 @@ class TocTreeprocessor(Treeprocessor):
 
                 # Do not override pre-existing ids
                 if "id" not in el.attrib:
-                    innertext = stashedHTML2text(text, self.markdown)
+                    innertext = stashedHTML2text(text, self.md)
                     el.attrib["id"] = unique(self.slugify(innertext, self.sep), used_ids)
 
                 toc_tokens.append({
@@ -260,10 +260,10 @@ class TocTreeprocessor(Treeprocessor):
             self.replace_marker(doc, div)
 
         # serialize and attach to markdown instance.
-        toc = self.markdown.serializer(div)
-        for pp in self.markdown.postprocessors:
+        toc = self.md.serializer(div)
+        for pp in self.md.postprocessors:
             toc = pp.run(toc)
-        self.markdown.toc = toc
+        self.md.toc = toc
 
 
 class TocExtension(Extension):

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -51,31 +51,31 @@ except ImportError:  # pragma: no cover
     import htmlentitydefs as entities
 
 
-def build_inlinepatterns(md_instance, **kwargs):
+def build_inlinepatterns(md, **kwargs):
     """ Build the default set of inline patterns for Markdown. """
     inlinePatterns = util.Registry()
     inlinePatterns.register(BacktickInlineProcessor(BACKTICK_RE), 'backtick', 190)
-    inlinePatterns.register(EscapeInlineProcessor(ESCAPE_RE, md_instance), 'escape', 180)
-    inlinePatterns.register(ReferenceInlineProcessor(REFERENCE_RE, md_instance), 'reference', 170)
-    inlinePatterns.register(LinkInlineProcessor(LINK_RE, md_instance), 'link', 160)
-    inlinePatterns.register(ImageInlineProcessor(IMAGE_LINK_RE, md_instance), 'image_link', 150)
+    inlinePatterns.register(EscapeInlineProcessor(ESCAPE_RE, md), 'escape', 180)
+    inlinePatterns.register(ReferenceInlineProcessor(REFERENCE_RE, md), 'reference', 170)
+    inlinePatterns.register(LinkInlineProcessor(LINK_RE, md), 'link', 160)
+    inlinePatterns.register(ImageInlineProcessor(IMAGE_LINK_RE, md), 'image_link', 150)
     inlinePatterns.register(
-        ImageReferenceInlineProcessor(IMAGE_REFERENCE_RE, md_instance), 'image_reference', 140
+        ImageReferenceInlineProcessor(IMAGE_REFERENCE_RE, md), 'image_reference', 140
     )
     inlinePatterns.register(
-        ShortReferenceInlineProcessor(REFERENCE_RE, md_instance), 'short_reference', 130
+        ShortReferenceInlineProcessor(REFERENCE_RE, md), 'short_reference', 130
     )
-    inlinePatterns.register(AutolinkInlineProcessor(AUTOLINK_RE, md_instance), 'autolink', 120)
-    inlinePatterns.register(AutomailInlineProcessor(AUTOMAIL_RE, md_instance), 'automail', 110)
+    inlinePatterns.register(AutolinkInlineProcessor(AUTOLINK_RE, md), 'autolink', 120)
+    inlinePatterns.register(AutomailInlineProcessor(AUTOMAIL_RE, md), 'automail', 110)
     inlinePatterns.register(SubstituteTagInlineProcessor(LINE_BREAK_RE, 'br'), 'linebreak', 100)
-    inlinePatterns.register(HtmlInlineProcessor(HTML_RE, md_instance), 'html', 90)
-    inlinePatterns.register(HtmlInlineProcessor(ENTITY_RE, md_instance), 'entity', 80)
+    inlinePatterns.register(HtmlInlineProcessor(HTML_RE, md), 'html', 90)
+    inlinePatterns.register(HtmlInlineProcessor(ENTITY_RE, md), 'entity', 80)
     inlinePatterns.register(SimpleTextInlineProcessor(NOT_STRONG_RE), 'not_strong', 70)
     inlinePatterns.register(DoubleTagInlineProcessor(EM_STRONG_RE, 'strong,em'), 'em_strong', 60)
     inlinePatterns.register(DoubleTagInlineProcessor(STRONG_EM_RE, 'em,strong'), 'strong_em', 50)
     inlinePatterns.register(SimpleTagInlineProcessor(STRONG_RE, 'strong'), 'strong', 40)
     inlinePatterns.register(SimpleTagInlineProcessor(EMPHASIS_RE, 'em'), 'emphasis', 30)
-    if md_instance.smart_emphasis:
+    if md.smart_emphasis:
         inlinePatterns.register(SimpleTagInlineProcessor(SMART_EMPHASIS_RE, 'em'), 'emphasis2', 20)
     else:
         inlinePatterns.register(SimpleTagInlineProcessor(EMPHASIS_2_RE, 'em'), 'emphasis2', 20)
@@ -164,7 +164,7 @@ class Pattern(object):  # pragma: no cover
 
     ANCESTOR_EXCLUDES = tuple()
 
-    def __init__(self, pattern, markdown_instance=None):
+    def __init__(self, pattern, md=None):
         """
         Create an instant of an inline pattern.
 
@@ -177,8 +177,13 @@ class Pattern(object):  # pragma: no cover
         self.compiled_re = re.compile(r"^(.*?)%s(.*)$" % pattern,
                                       re.DOTALL | re.UNICODE)
 
-        if markdown_instance:
-            self.markdown = markdown_instance
+        self.md = md
+
+    @property
+    @util.deprecated("Use 'md' instead.")
+    def markdown(self):
+        # TODO: remove this later
+        return self.md
 
     def getCompiledRegExp(self):
         """ Return a compiled regular expression. """
@@ -227,7 +232,7 @@ class InlineProcessor(Pattern):
     efficient and flexible search approach.
     """
 
-    def __init__(self, pattern, markdown_instance=None):
+    def __init__(self, pattern, md=None):
         """
         Create an instant of an inline pattern.
 
@@ -241,8 +246,7 @@ class InlineProcessor(Pattern):
 
         # Api for Markdown to pass safe_mode into instance
         self.safe_mode = False
-        if markdown_instance:
-            self.markdown = markdown_instance
+        self.md = md
 
     def handleMatch(self, m, data):
         """Return a ElementTree element from the given match and the

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -208,7 +208,7 @@ class Pattern(object):  # pragma: no cover
     def unescape(self, text):
         """ Return unescaped text given text with an inline placeholder. """
         try:
-            stash = self.markdown.treeprocessors['inline'].stashed_nodes
+            stash = self.md.treeprocessors['inline'].stashed_nodes
         except KeyError:  # pragma: no cover
             return text
 
@@ -289,7 +289,7 @@ class EscapeInlineProcessor(InlineProcessor):
 
     def handleMatch(self, m, data):
         char = m.group(1)
-        if char in self.markdown.ESCAPED_CHARS:
+        if char in self.md.ESCAPED_CHARS:
             return '%s%s%s' % (util.STX, ord(char), util.ETX), m.start(0), m.end(0)
         else:
             return None, m.start(0), m.end(0)
@@ -391,13 +391,13 @@ class HtmlInlineProcessor(InlineProcessor):
     """ Store raw inline html and return a placeholder. """
     def handleMatch(self, m, data):
         rawhtml = self.unescape(m.group(1))
-        place_holder = self.markdown.htmlStash.store(rawhtml)
+        place_holder = self.md.htmlStash.store(rawhtml)
         return place_holder, m.start(0), m.end(0)
 
     def unescape(self, text):
         """ Return unescaped text given text with an inline placeholder. """
         try:
-            stash = self.markdown.treeprocessors['inline'].stashed_nodes
+            stash = self.md.treeprocessors['inline'].stashed_nodes
         except KeyError:  # pragma: no cover
             return text
 
@@ -406,7 +406,7 @@ class HtmlInlineProcessor(InlineProcessor):
             value = stash.get(id)
             if value is not None:
                 try:
-                    return self.markdown.serializer(value)
+                    return self.md.serializer(value)
                 except Exception:
                     return r'\%s' % value
 
@@ -614,10 +614,10 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
 
         # Clean up linebreaks in id
         id = self.NEWLINE_CLEANUP_RE.sub(' ', id)
-        if id not in self.markdown.references:  # ignore undefined refs
+        if id not in self.md.references:  # ignore undefined refs
             return None, m.start(0), end
 
-        href, title = self.markdown.references[id]
+        href, title = self.md.references[id]
 
         return self.makeTag(href, title, text), m.start(0), end
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -51,13 +51,13 @@ class RawHtmlPostprocessor(Postprocessor):
     def run(self, text):
         """ Iterate over html stash and restore html. """
         replacements = OrderedDict()
-        for i in range(self.markdown.htmlStash.html_counter):
-            html = self.markdown.htmlStash.rawHtmlBlocks[i]
+        for i in range(self.md.htmlStash.html_counter):
+            html = self.md.htmlStash.rawHtmlBlocks[i]
             if self.isblocklevel(html):
                 replacements["<p>%s</p>" %
-                             (self.markdown.htmlStash.get_placeholder(i))] = \
+                             (self.md.htmlStash.get_placeholder(i))] = \
                     html + "\n"
-            replacements[self.markdown.htmlStash.get_placeholder(i)] = html
+            replacements[self.md.htmlStash.get_placeholder(i)] = html
 
         if replacements:
             pattern = re.compile("|".join(re.escape(k) for k in replacements))

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -15,10 +15,10 @@ from . import util
 import re
 
 
-def build_postprocessors(md_instance, **kwargs):
+def build_postprocessors(md, **kwargs):
     """ Build the default postprocessors for Markdown. """
     postprocessors = util.Registry()
-    postprocessors.register(RawHtmlPostprocessor(md_instance), 'raw_html', 30)
+    postprocessors.register(RawHtmlPostprocessor(md), 'raw_html', 30)
     postprocessors.register(AndSubstitutePostprocessor(), 'amp_substitute', 20)
     postprocessors.register(UnescapePostprocessor(), 'unescape', 10)
     return postprocessors

--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -12,12 +12,12 @@ from . import util
 import re
 
 
-def build_preprocessors(md_instance, **kwargs):
+def build_preprocessors(md, **kwargs):
     """ Build the default set of preprocessors used by Markdown. """
     preprocessors = util.Registry()
-    preprocessors.register(NormalizeWhitespace(md_instance), 'normalize_whitespace', 30)
-    preprocessors.register(HtmlBlockPreprocessor(md_instance), 'html_block', 20)
-    preprocessors.register(ReferencePreprocessor(md_instance), 'reference', 10)
+    preprocessors.register(NormalizeWhitespace(md), 'normalize_whitespace', 30)
+    preprocessors.register(HtmlBlockPreprocessor(md), 'html_block', 20)
+    preprocessors.register(ReferencePreprocessor(md), 'reference', 10)
     return preprocessors
 
 

--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -49,7 +49,7 @@ class NormalizeWhitespace(Preprocessor):
         source = '\n'.join(lines)
         source = source.replace(util.STX, "").replace(util.ETX, "")
         source = source.replace("\r\n", "\n").replace("\r", "\n") + "\n\n"
-        source = source.expandtabs(self.markdown.tab_length)
+        source = source.expandtabs(self.md.tab_length)
         source = re.sub(r'(?<=\n) +\n', '\n', source)
         return source.split('\n')
 
@@ -166,7 +166,7 @@ class HtmlBlockPreprocessor(Preprocessor):
                     self._stringindex_to_listindex(data_index, items[i:]) + i
                 if 'markdown' in attrs.keys():
                     items[i] = items[i][left_index:]  # remove opening tag
-                    placeholder = self.markdown.htmlStash.store_tag(
+                    placeholder = self.md.htmlStash.store_tag(
                         left_tag, attrs, i + 1, right_listindex + 1)
                     items.insert(i, placeholder)
                     if len(items) - right_listindex <= 1:  # last nest, no tail
@@ -178,7 +178,7 @@ class HtmlBlockPreprocessor(Preprocessor):
                         right_listindex -= 1
                     if right_listindex <= i:
                         right_listindex = i + 1
-                    placeholder = self.markdown.htmlStash.store('\n\n'.join(
+                    placeholder = self.md.htmlStash.store('\n\n'.join(
                         items[i:right_listindex]))
                     del items[i:right_listindex]
                     items.insert(i, placeholder)
@@ -231,12 +231,12 @@ class HtmlBlockPreprocessor(Preprocessor):
                             and self._equal_tags(left_tag, right_tag):
                         if self.markdown_in_raw and 'markdown' in attrs.keys():
                             block = block[left_index:-len(right_tag) - 2]
-                            new_blocks.append(self.markdown.htmlStash.
+                            new_blocks.append(self.md.htmlStash.
                                               store_tag(left_tag, attrs, 0, 2))
                             new_blocks.extend([block])
                         else:
                             new_blocks.append(
-                                self.markdown.htmlStash.store(block.strip()))
+                                self.md.htmlStash.store(block.strip()))
                         continue
                     else:
                         # if is block level tag and is not complete
@@ -246,7 +246,7 @@ class HtmlBlockPreprocessor(Preprocessor):
                             in_tag = True
                         else:
                             new_blocks.append(
-                                self.markdown.htmlStash.store(block.strip())
+                                self.md.htmlStash.store(block.strip())
                             )
                         continue
 
@@ -280,18 +280,18 @@ class HtmlBlockPreprocessor(Preprocessor):
                             right_index = len(items) + 3
                         else:
                             right_index = len(items) + 2
-                        new_blocks.append(self.markdown.htmlStash.store_tag(
+                        new_blocks.append(self.md.htmlStash.store_tag(
                             left_tag, attrs, 0, right_index))
-                        placeholderslen = len(self.markdown.htmlStash.tag_data)
+                        placeholderslen = len(self.md.htmlStash.tag_data)
                         new_blocks.extend(
                             self._nested_markdown_in_html(items))
-                        nests = len(self.markdown.htmlStash.tag_data) - \
+                        nests = len(self.md.htmlStash.tag_data) - \
                             placeholderslen
-                        self.markdown.htmlStash.tag_data[-1 - nests][
+                        self.md.htmlStash.tag_data[-1 - nests][
                             'right_index'] += nests - 2
                     else:
                         new_blocks.append(
-                            self.markdown.htmlStash.store('\n\n'.join(items)))
+                            self.md.htmlStash.store('\n\n'.join(items)))
                     items = []
 
         if items:
@@ -303,16 +303,16 @@ class HtmlBlockPreprocessor(Preprocessor):
                 else:
                     right_index = len(items) + 2
                 new_blocks.append(
-                    self.markdown.htmlStash.store_tag(
+                    self.md.htmlStash.store_tag(
                         left_tag, attrs, 0, right_index))
-                placeholderslen = len(self.markdown.htmlStash.tag_data)
+                placeholderslen = len(self.md.htmlStash.tag_data)
                 new_blocks.extend(self._nested_markdown_in_html(items))
-                nests = len(self.markdown.htmlStash.tag_data) - placeholderslen
-                self.markdown.htmlStash.tag_data[-1 - nests][
+                nests = len(self.md.htmlStash.tag_data) - placeholderslen
+                self.md.htmlStash.tag_data[-1 - nests][
                     'right_index'] += nests - 2
             else:
                 new_blocks.append(
-                    self.markdown.htmlStash.store('\n\n'.join(items)))
+                    self.md.htmlStash.store('\n\n'.join(items)))
             new_blocks.append('\n')
 
         new_text = "\n\n".join(new_blocks)
@@ -343,7 +343,7 @@ class ReferencePreprocessor(Preprocessor):
                     if tm:
                         lines.pop(0)
                         t = tm.group(2) or tm.group(3) or tm.group(4)
-                self.markdown.references[id] = (link, t)
+                self.md.references[id] = (link, t)
                 # Preserve the line to prevent raw HTML indexing issue.
                 # https://github.com/Python-Markdown/markdown/issues/584
                 new_text.append('')

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -4,11 +4,11 @@ from . import util
 from . import inlinepatterns
 
 
-def build_treeprocessors(md_instance, **kwargs):
+def build_treeprocessors(md, **kwargs):
     """ Build the default treeprocessors for Markdown. """
     treeprocessors = util.Registry()
-    treeprocessors.register(InlineProcessor(md_instance), 'inline', 20)
-    treeprocessors.register(PrettifyTreeprocessor(md_instance), 'prettify', 10)
+    treeprocessors.register(InlineProcessor(md), 'inline', 20)
+    treeprocessors.register(PrettifyTreeprocessor(md), 'prettify', 10)
     return treeprocessors
 
 
@@ -51,9 +51,15 @@ class InlineProcessor(Treeprocessor):
         self.__placeholder_length = 4 + len(self.__placeholder_prefix) \
                                       + len(self.__placeholder_suffix)
         self.__placeholder_re = util.INLINE_PLACEHOLDER_RE
-        self.markdown = md
+        self.md = md
         self.inlinePatterns = md.inlinePatterns
         self.ancestors = []
+
+    @property
+    @util.deprecated("Use 'md' instead.")
+    def markdown(self):
+        # TODO: remove this later
+        return self.md
 
     def __makePlaceholder(self, type):
         """ Generate a placeholder """

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import re
 import sys
 from collections import namedtuple
+from functools import wraps
 import warnings
 
 
@@ -118,6 +119,25 @@ def parseBoolValue(value, fail_on_errors=True, preserve_none=False):
         raise ValueError('Cannot parse bool value: %r' % value)
 
 
+def deprecated(message):
+    """
+    Raise a DeprecationWarning when wrapped function/method is called.
+
+    Borrowed from https://stackoverflow.com/a/48632082/866026
+    """
+    def deprecated_decorator(func):
+        @wraps(func)
+        def deprecated_func(*args, **kwargs):
+            warnings.warn(
+                "'{}' is deprecated. {}".format(func.__name__, message),
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+            return func(*args, **kwargs)
+        return deprecated_func
+    return deprecated_decorator
+
+
 """
 MISC AUXILIARY CLASSES
 =============================================================================
@@ -130,9 +150,14 @@ class AtomicString(text_type):
 
 
 class Processor(object):
-    def __init__(self, markdown_instance=None):
-        if markdown_instance:
-            self.markdown = markdown_instance
+    def __init__(self, md=None):
+        self.md = md
+
+    @property
+    @deprecated("Use 'md' instead.")
+    def markdown(self):
+        # TODO: remove this later
+        return self.md
 
 
 class HtmlStash(object):


### PR DESCRIPTION
Previously, instances of the Markdown class were represented as any one of 'md', 'md_instance', or 'markdown'. This inconsistency made it difficult when developing extensions, or just maintaining the existing code. Now, all instances are consistently represented as 'md'.

The old attributes on class instances still exist, but raise a DeprecationWarning when accessed. Also on classes where the instance was optional, the attribute always exists now and is simply None if no instance was provided (previously the attribute wouldn't exist).

The first commit makes the changes to the API but does not change the code which uses that API. All tests pass with many DeprecationWarnings being raised. The second commit updates the code to use the new API and DeprecationWarnings are no longer raised.

This is a re-implementation of a1aa1b6b from the md3 branch, with the backward compatible support added.
