### PR TITLE
Deprecate md_globals from extension API.

### DIFF
--- a/markdown/core.py
+++ b/markdown/core.py
@@ -113,7 +113,7 @@ class Markdown(object):
             if isinstance(ext, util.string_type):
                 ext = self.build_extension(ext, configs.get(ext, {}))
             if isinstance(ext, Extension):
-                ext.extendMarkdown(self, globals())
+                ext._extendMarkdown(self)
                 logger.debug(
                     'Successfully loaded extension "%s.%s".'
                     % (ext.__class__.__module__, ext.__class__.__name__)

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -21,6 +21,7 @@ License: BSD (see LICENSE.md for details).
 """
 
 from __future__ import unicode_literals
+import warnings
 from ..util import parseBoolValue
 
 
@@ -71,7 +72,22 @@ class Extension(object):
         for key, value in items:
             self.setConfig(key, value)
 
-    def extendMarkdown(self, md, md_globals):
+    def _extendMarkdown(self, *args):
+        """ Private wrapper around extendMarkdown. """
+        md = args[0]
+        try:
+            self.extendMarkdown(md)
+        except TypeError:
+            # Must be a 2.x extension. Pass in a dumby md_globals.
+            self.extendMarkdown(md, {})
+            warnings.warn(
+                "The 'md_globals' parameter of '{0}.{1}.extendMarkdown' is "
+                "deprecated.".format(self.__class__.__module__, self.__class__.__name__),
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+
+    def extendMarkdown(self, md):
         """
         Add the various proccesors and patterns to the Markdown Instance.
 

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -31,7 +31,7 @@ ABBR_REF_RE = re.compile(r'[*]\[(?P<abbr>[^\]]*)\][ ]?:\s*(?P<title>.*)')
 class AbbrExtension(Extension):
     """ Abbreviation Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Insert AbbrPreprocessor before ReferencePreprocessor. """
         md.preprocessors.register(AbbrPreprocessor(md), 'abbr', 12)
 

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -28,7 +28,7 @@ import re
 class AdmonitionExtension(Extension):
     """ Admonition extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add Admonition to Markdown instance. """
         md.registerExtension(self)
 

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -162,7 +162,7 @@ class AttrListTreeprocessor(Treeprocessor):
 
 
 class AttrListExtension(Extension):
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.treeprocessors.register(AttrListTreeprocessor(md), 'attr_list', 8)
 
 

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -251,7 +251,7 @@ class CodeHiliteExtension(Extension):
 
         super(CodeHiliteExtension, self).__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add HilitePostprocessor to Markdown instance. """
         hiliter = HiliteTreeprocessor(md)
         hiliter.config = self.getConfigs()

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -101,7 +101,7 @@ class DefListIndentProcessor(ListIndentProcessor):
 class DefListExtension(Extension):
     """ Add definition lists to Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add an instance of DefListProcessor to BlockParser. """
         md.parser.blockprocessors.register(DefListIndentProcessor(md.parser), 'defindent', 85)
         md.parser.blockprocessors.register(DefListProcessor(md.parser), 'deflist', 25)

--- a/markdown/extensions/extra.py
+++ b/markdown/extensions/extra.py
@@ -53,7 +53,7 @@ class ExtraExtension(Extension):
         """ config is a dumb holder which gets passed to actual ext later. """
         self.config = kwargs
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Register extension instances. """
         md.registerExtensions(extensions, self.config)
         # Turn on processing of markdown text within raw html

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -25,7 +25,7 @@ import re
 
 class FencedCodeExtension(Extension):
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add FencedBlockPreprocessor to the Markdown instance. """
         md.registerExtension(self)
 

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -65,7 +65,7 @@ class FootnoteExtension(Extension):
 
         self.reset()
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add pieces to Markdown. """
         md.registerExtension(self)
         self.parser = md.parser

--- a/markdown/extensions/legacy_attrs.py
+++ b/markdown/extensions/legacy_attrs.py
@@ -60,7 +60,7 @@ class LegacyAttrs(Treeprocessor):
 
 
 class LegacyAttrExtension(Extension):
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.treeprocessors.register(LegacyAttrs(md), 'legacyattrs', 15)
 
 

--- a/markdown/extensions/legacy_em.py
+++ b/markdown/extensions/legacy_em.py
@@ -22,7 +22,7 @@ STRONG_RE = r'(\*{2}|_{2})(.+?)\1'
 class LegacyEmExtension(Extension):
     """ Add legacy_em extension to Markdown class."""
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Modify inline patterns. """
         md.inlinePatterns.register(SimpleTagInlineProcessor(STRONG_RE, 'strong'), 'strong', 40)
         md.inlinePatterns.register(SimpleTagInlineProcessor(EMPHASIS_RE, 'em'), 'emphasis', 30)

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -34,7 +34,7 @@ END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
 class MetaExtension (Extension):
     """ Meta-Data extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add MetaPreprocessor to Markdown instance. """
         md.registerExtension(self)
         self.md = md

--- a/markdown/extensions/nl2br.py
+++ b/markdown/extensions/nl2br.py
@@ -26,7 +26,7 @@ BR_RE = r'\n'
 
 class Nl2BrExtension(Extension):
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         br_tag = SubstituteTagInlineProcessor(BR_RE, 'br')
         md.inlinePatterns.register(br_tag, 'nl', 5)
 

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -46,7 +46,7 @@ class SaneUListProcessor(UListProcessor):
 class SaneListExtension(Extension):
     """ Add sane lists to Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Override existing Processors. """
         md.parser.blockprocessors.register(SaneOListProcessor(md.parser), 'olist', 40)
         md.parser.blockprocessors.register(SaneUListProcessor(md.parser), 'ulist', 30)

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -241,7 +241,7 @@ class SmartyExtension(Extension):
         )
         self._addPatterns(md, patterns, 'quotes', 30)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         configs = self.getConfigs()
         self.inlinePatterns = Registry()
         if configs['smart_ellipses']:

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -214,7 +214,7 @@ class TableProcessor(BlockProcessor):
 class TableExtension(Extension):
     """ Add tables to Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add an instance of TableProcessor to BlockParser. """
         if '|' not in md.ESCAPED_CHARS:
             md.ESCAPED_CHARS.append('|')

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -296,7 +296,7 @@ class TocExtension(Extension):
 
         super(TocExtension, self).__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.registerExtension(self)
         self.md = md
         self.reset()

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -41,7 +41,7 @@ class WikiLinkExtension(Extension):
 
         super(WikiLinkExtension, self).__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         self.md = md
 
         # append to end of inline patterns

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -682,7 +682,7 @@ class testSerializers(unittest.TestCase):
             return '<div><p>foo</p></div>'
 
         class registerFakeSerializer(markdown.extensions.Extension):
-            def extendMarkdown(self, md, md_globals):
+            def extendMarkdown(self, md):
                 md.output_formats['fake'] = fakeSerializer
 
         return registerFakeSerializer()
@@ -962,7 +962,7 @@ class TestAncestorExclusion(unittest.TestCase):
 
             self.config = {}
 
-        def extendMarkdown(self, md, md_globals):
+        def extendMarkdown(self, md):
             """Modify inline patterns."""
 
             pattern = r'(\+)([^\+]+)\1'


### PR DESCRIPTION
In the past, most of the config was defined using globals. Today all of 
the config is held on the class instance. Therefore, the `md_globals` 
parameter is no longer necessary.

This is an smoother transition than 17b16a2e in the md3 branch.

The first commit alters the API but not the code using the API. The tests pass with multiple DeprecationWarnings. The second commit alters the code using the API and eliminates the DeprecationWarnings.