### PR TITLE
Bump version to 3.0

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,7 +3,7 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
-???, 2018: Released version 3.0 ([Notes](release-3.0.md)).
+Sept 21, 2018: Released version 3.0 ([Notes](release-3.0.md)).
 
 Jan 4, 2018: Released version 2.6.11 (a bug-fix release). Added a new
 `BACKLINK-TITLE` option to the footnote extension so that non-English

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -33,7 +33,7 @@ __all__ = ['Markdown', 'markdown', 'markdownFromFile']
 # (major, minor, micro, alpha/beta/rc/final, #)
 # (1, 1, 2, 'alpha', 0) => "1.1.2.dev"
 # (1, 2, 0, 'beta', 2) => "1.2b2"
-__version_info__ = (3, 0, 0, 'alpha', 0)
+__version_info__ = (3, 0, 0, 'final', 0)
 
 
 def _get_version():  # pragma: no cover


### PR DESCRIPTION
The stuff that we originally wanted to put in 3.0 that is not done is not likely to be done anytime soon. And what we have now is more than enough for a major release. Therefore, let's release it now and get what we have out there for users to benefit from. The stuff we didn't get to can always be a 4.0 (or whatever).