### PR TITLE
Fix issue with < and > characters (among others) being double-escaped.

### DIFF
--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -76,6 +76,10 @@ class CodeHilite(object):
     def __init__(self, src=None, linenums=None, guess_lang=True,
                  css_class="codehilite", lang=None, style='default',
                  noclasses=False, tab_length=4, hl_lines=None, use_pygments=True):
+
+        # Kind of dirty, but un-escape HTML since we re-escape it anyway.
+        src = src.replace('&amp;', '&').replace('&lt;', '<').replace('&gt;', '>').replace('&quot;', '"')
+
         self.src = src
         self.lang = lang
         self.linenums = linenums

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -250,6 +250,19 @@ class TestCodeHilite(TestCaseWithAssertStartsWith):
             '</code></pre>'
         )
 
+    def testDoubleEscape(self):
+        text = '\t#!Python\n\t>>> test()'
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.codehilite.CodeHiliteExtension(use_pygments=False)]
+        )
+        x = md.convert(text)
+
+        self.assertEqual(
+            md.convert(text),
+            '<pre class="codehilite"><code class="language-python linenums">'
+            '&gt;&gt;&gt; test()</code></pre>'
+        )
+
 
 class TestFencedCode(TestCaseWithAssertStartsWith):
     """ Test fenced_code extension. """


### PR DESCRIPTION
This should fix #725.