### PR TITLE
Fix double escaping of block code

### DIFF
--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -200,13 +200,20 @@ class CodeHilite(object):
 class HiliteTreeprocessor(Treeprocessor):
     """ Hilight source code in code blocks. """
 
+    def code_unescape(self, text):
+        """Unescape code."""
+        text = text.replace("&amp;", "&")
+        text = text.replace("&lt;", "<")
+        text = text.replace("&gt;", ">")
+        return text
+
     def run(self, root):
         """ Find code blocks and store in htmlStash. """
         blocks = root.iter('pre')
         for block in blocks:
             if len(block) == 1 and block[0].tag == 'code':
                 code = CodeHilite(
-                    block[0].text,
+                    self.code_unescape(block[0].text),
                     linenums=self.config['linenums'],
                     guess_lang=self.config['guess_lang'],
                     css_class=self.config['css_class'],

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -251,6 +251,8 @@ class TestCodeHilite(TestCaseWithAssertStartsWith):
         )
 
     def testDoubleEscape(self):
+        """ Test entity escape logic in indented code blocks. """
+
         text = '\t:::html\n\t<span>This&amp;That</span>'
         md = markdown.Markdown(
             extensions=[markdown.extensions.codehilite.CodeHiliteExtension()]
@@ -430,7 +432,7 @@ line 3
         self.assertTrue('<code class="language-python">' in md.convert(text))
 
     def testFencedLanguageDoubleEscape(self):
-        """ Test if fenced_code honors CodeHilite option use_pygments=False. """
+        """ Test entity escape logic in fences. """
 
         text = '```html\n<span>This&amp;That</span>\n```'
         md = markdown.Markdown(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -250,6 +250,29 @@ class TestCodeHilite(TestCaseWithAssertStartsWith):
             '</code></pre>'
         )
 
+    def testDoubleEscape(self):
+        text = '\t:::html\n\t<span>This&amp;That</span>'
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.codehilite.CodeHiliteExtension()]
+        )
+        if self.has_pygments:
+            self.assertEqual(
+                md.convert(text),
+                '<div class="codehilite"><pre>'
+                '<span></span>'
+                '<span class="p">&lt;</span><span class="nt">span</span><span class="p">&gt;</span>'
+                'This<span class="ni">&amp;amp;</span>That'
+                '<span class="p">&lt;/</span><span class="nt">span</span><span class="p">&gt;</span>'
+                '\n</pre></div>'
+            )
+        else:
+            self.assertEqual(
+                md.convert(text),
+                '<pre class="codehilite"><code class="language-html">'
+                '&lt;span&gt;This&amp;amp;That&lt;/span&gt;'
+                '</code></pre>'
+            )
+
 
 class TestFencedCode(TestCaseWithAssertStartsWith):
     """ Test fenced_code extension. """
@@ -405,6 +428,34 @@ line 3
             ]
         )
         self.assertTrue('<code class="language-python">' in md.convert(text))
+
+    def testFencedLanguageDoubleEscape(self):
+        """ Test if fenced_code honors CodeHilite option use_pygments=False. """
+
+        text = '```html\n<span>This&amp;That</span>\n```'
+        md = markdown.Markdown(
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(),
+                'fenced_code'
+            ]
+        )
+        if self.has_pygments:
+            self.assertEqual(
+                md.convert(text),
+                '<div class="codehilite"><pre>'
+                '<span></span>'
+                '<span class="p">&lt;</span><span class="nt">span</span><span class="p">&gt;</span>'
+                'This<span class="ni">&amp;amp;</span>That'
+                '<span class="p">&lt;/</span><span class="nt">span</span><span class="p">&gt;</span>'
+                '\n</pre></div>'
+            )
+        else:
+            self.assertEqual(
+                md.convert(text),
+                '<pre class="codehilite"><code class="language-html">'
+                '&lt;span&gt;This&amp;amp;That&lt;/span&gt;'
+                '</code></pre>'
+            )
 
 
 class TestMetaData(unittest.TestCase):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -275,6 +275,24 @@ class TestCodeHilite(TestCaseWithAssertStartsWith):
                 '</code></pre>'
             )
 
+    def testHighlightAmps(self):
+        """ Test amp conversion logic. """
+
+        text = '\t:::text\n\t&\n\t&amp;\n\t&amp;amp;'
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.codehilite.CodeHiliteExtension()]
+        )
+        if self.has_pygments:
+            self.assertEqual(
+                md.convert(text),
+                '<div class="codehilite"><pre><span></span>&amp;\n&amp;amp;\n&amp;amp;amp;\n</pre></div>'
+            )
+        else:
+            self.assertEqual(
+                md.convert(text),
+                '<pre class="codehilite"><code class="language-text">&amp;\n&amp;amp;\n&amp;amp;amp;</code></pre>'
+            )
+
 
 class TestFencedCode(TestCaseWithAssertStartsWith):
     """ Test fenced_code extension. """
@@ -457,6 +475,27 @@ line 3
                 '<pre class="codehilite"><code class="language-html">'
                 '&lt;span&gt;This&amp;amp;That&lt;/span&gt;'
                 '</code></pre>'
+            )
+
+    def testFencedAmps(self):
+        """ Test amp conversion. """
+
+        text = '```text\n&\n&amp;\n&amp;amp;\n```'
+        md = markdown.Markdown(
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(),
+                'fenced_code'
+            ]
+        )
+        if self.has_pygments:
+            self.assertEqual(
+                md.convert(text),
+                '<div class="codehilite"><pre><span></span>&amp;\n&amp;amp;\n&amp;amp;amp;\n</pre></div>'
+            )
+        else:
+            self.assertEqual(
+                md.convert(text),
+                '<pre class="codehilite"><code class="language-text">&amp;\n&amp;amp;\n&amp;amp;amp;</code></pre>'
             )
 
 


### PR DESCRIPTION
Ref #725. When post processing code blocks handled by the `code` step, unescape previously escaped entities. Make sure to test both `fenced_code` and `codehilte` to ensure the output of both are the same in relation to entities.