### PR TITLE
Ensure block elements are defined per instance

### DIFF
--- a/markdown/core.py
+++ b/markdown/core.py
@@ -52,18 +52,6 @@ class Markdown(object):
         'xhtml':  to_xhtml_string,
     }
 
-    block_level_elements = [
-        # Elements which are invalid to wrap in a `<p>` tag.
-        # See http://w3c.github.io/html/grouping-content.html#the-p-element
-        'address', 'article', 'aside', 'blockquote', 'details', 'div', 'dl',
-        'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
-        'h4', 'h5', 'h6', 'header', 'hr', 'main', 'menu', 'nav', 'ol', 'p', 'pre',
-        'section', 'table', 'ul',
-        # Other elements which Markdown should not be mucking up the contents of.
-        'canvas', 'dd', 'dt', 'group', 'iframe', 'li', 'math', 'noscript', 'output',
-        'progress', 'script', 'style', 'tbody', 'td', 'th', 'thead', 'tr', 'video'
-    ]
-
     def __init__(self, **kwargs):
         """
         Creates a new Markdown instance.
@@ -87,6 +75,18 @@ class Markdown(object):
 
         self.ESCAPED_CHARS = ['\\', '`', '*', '_', '{', '}', '[', ']',
                               '(', ')', '>', '#', '+', '-', '.', '!']
+
+        self.block_level_elements = [
+            # Elements which are invalid to wrap in a `<p>` tag.
+            # See http://w3c.github.io/html/grouping-content.html#the-p-element
+            'address', 'article', 'aside', 'blockquote', 'details', 'div', 'dl',
+            'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
+            'h4', 'h5', 'h6', 'header', 'hr', 'main', 'menu', 'nav', 'ol', 'p', 'pre',
+            'section', 'table', 'ul',
+            # Other elements which Markdown should not be mucking up the contents of.
+            'canvas', 'dd', 'dt', 'group', 'iframe', 'li', 'math', 'noscript', 'output',
+            'progress', 'script', 'style', 'tbody', 'td', 'th', 'thead', 'tr', 'video'
+        ]
 
         self.registeredExtensions = []
         self.docType = ""

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -942,6 +942,18 @@ class TestEscapeAppend(unittest.TestCase):
         self.assertEqual('|' not in md2.ESCAPED_CHARS, True)
 
 
+class TestBlockAppend(unittest.TestCase):
+    """ Tests block kHTML append. """
+
+    def testBlockAppend(self):
+        """ Test that appended escapes are only in the current instance. """
+        md = markdown.Markdown()
+        md.block_level_elements.append('test')
+        self.assertEqual('test' in md.block_level_elements, True)
+        md2 = markdown.Markdown()
+        self.assertEqual('test' not in md2.block_level_elements, True)
+
+
 class TestAncestorExclusion(unittest.TestCase):
     """ Tests exclusion of tags in ancestor list. """
 


### PR DESCRIPTION
Block level elements should be defined per instance, not as base class variables. Ref #730 