### PR TITLE
pyproject.toml: Bump minimal setuptools version to 36.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=36", "wheel"]
+requires = ["setuptools>=36.6", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is the version where `setuptools.build_meta` was introduced.

See https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v3660.

This is a minor correction to #736. There is no need to bump run-time dependency.