### PR TITLE
Fix for bad id whitespace collapsing in references

### DIFF
--- a/docs/change_log/release-3.1.md
+++ b/docs/change_log/release-3.1.md
@@ -35,3 +35,4 @@ The following bug fixes are included in the 3.1 release:
 * Block level elements are defined per instance, not as class attributes
   (#731).
 * Double escaping of block code has been eliminated (#725).
+* Problems with newlines in references has been fixed (#742).

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -617,7 +617,7 @@ class ImageInlineProcessor(LinkInlineProcessor):
 
 class ReferenceInlineProcessor(LinkInlineProcessor):
     """ Match to a stored reference and return link element. """
-    NEWLINE_CLEANUP_RE = re.compile(r'[ ]?\n', re.MULTILINE)
+    NEWLINE_CLEANUP_RE = re.compile(r'\s+', re.MULTILINE)
 
     RE_LINK = re.compile(r'\s?\[([^\]]*)\]', re.DOTALL | re.UNICODE)
 

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -134,3 +134,23 @@ class TestAdvancedLinks(TestCase):
             '[title](http://example.com/?a=1&#x26;b=2)',
             '<p><a href="http://example.com/?a=1&#x26;b=2">title</a></p>'
         )
+
+    def test_reference_newlines(self):
+        """Test reference id whitespace cleanup."""
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                Two things:
+
+                 - I would like to tell you about the [code of
+                   conduct][] we are using in this project.
+                 - Only one in fact.
+
+                [code of conduct]: https://github.com/Python-Markdown/markdown/blob/master/CODE_OF_CONDUCT.md
+                """
+            ),
+            '<p>Two things:</p>\n<ul>\n<li>I would like to tell you about the '
+            '<a href="https://github.com/Python-Markdown/markdown/blob/master/CODE_OF_CONDUCT.md">code of\n'
+            '   conduct</a> we are using in this project.</li>\n<li>Only one in fact.</li>\n</ul>'
+        )

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -154,3 +154,20 @@ class TestAdvancedLinks(TestCase):
             '<a href="https://github.com/Python-Markdown/markdown/blob/master/CODE_OF_CONDUCT.md">code of\n'
             '   conduct</a> we are using in this project.</li>\n<li>Only one in fact.</li>\n</ul>'
         )
+
+    def test_reference_across_blocks(self):
+        """Test references across blocks."""
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                I would like to tell you about the [code of
+
+                conduct][] we are using in this project.
+
+                [code of conduct]: https://github.com/Python-Markdown/markdown/blob/master/CODE_OF_CONDUCT.md
+                """
+            ),
+            '<p>I would like to tell you about the [code of</p>\n'
+            '<p>conduct][] we are using in this project.</p>'
+        )


### PR DESCRIPTION
This fixes #742 by generally collapsing all whitespace down to a single space in reference ids opposed to the previous logic of collapsing only newlines preceeded by whitespace.