### PR TITLE
Allow hashes to be escaped in headers

### DIFF
--- a/docs/change_log/release-3.1.md
+++ b/docs/change_log/release-3.1.md
@@ -36,3 +36,4 @@ The following bug fixes are included in the 3.1 release:
   (#731).
 * Double escaping of block code has been eliminated (#725).
 * Problems with newlines in references has been fixed (#742).
+* Escaped `#` are now handled in header syntax (#762).

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -445,7 +445,7 @@ class HashHeaderProcessor(BlockProcessor):
     """ Process Hash Headers. """
 
     # Detect a header at start of any line in block
-    RE = re.compile(r'(^|\n)(?P<level>#{1,6})(?P<header>.*?)#*(\n|$)')
+    RE = re.compile(r'(?:^|\n)(?P<level>#{1,6})(?P<header>(?:\\.|[^\\])*?)#*(?:\n|$)')
 
     def test(self, parent, block):
         return bool(self.RE.search(block))

--- a/tests/test_syntax/blocks/test_headers.py
+++ b/tests/test_syntax/blocks/test_headers.py
@@ -708,3 +708,23 @@ class TestHashHeaders(TestCase):
                 """
             )
         )
+
+    def test_escaped_hash(self):
+        self.assertMarkdownRenders(
+            "### H3 \\###",
+            self.dedent(
+                """
+                <h3>H3 #</h3>
+                """
+            )
+        )
+
+    def test_unescaped_hash(self):
+        self.assertMarkdownRenders(
+            "### H3 \\\\###",
+            self.dedent(
+                """
+                <h3>H3 \\</h3>
+                """
+            )
+        )


### PR DESCRIPTION
Adjust pattern to allow for escaped hashes, but take care to not treat
escaped escapes before hashes as escaped hashes. Closes #762.