### PR TITLE
Correctly handle overlapping raw HTML matches

### DIFF
--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -81,9 +81,12 @@ class RawHtmlPostprocessor(Postprocessor):
 
         if replacements:
             pattern = re.compile("|".join(re.escape(k) for k in replacements))
-            text = pattern.sub(lambda m: replacements[m.group(0)], text)
+            processed_text = pattern.sub(lambda m: replacements[m.group(0)], text)
 
-        return text
+        if processed_text == text:
+            return processed_text
+        else:
+            return self.run(processed_text)
 
     def isblocklevel(self, html):
         m = re.match(r'^\<\/?([^ >]+)', html)


### PR DESCRIPTION
Should sufficiently fix https://github.com/Python-Markdown/markdown/issues/458.
Instead of rewriting the raw HTML substitution logic I chose to run it recursively until the output is equal to the previous input.

With kinds regards,
Philip Trauner

(and let me know if I missed something 😅 )