### PR TITLE
allow html as permalink

### DIFF
--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -160,7 +160,7 @@ The following options are provided to configure the output:
 
     When set to `True` the paragraph symbol (&para; or "`&para;`") is used as
     the link text. When set to a string, the provided string is used as the link
-    text.
+    text. When set to an `etree.Element`, the provided instance is used as a link child.
 
 * **`baselevel`**:
     Base level for headers. Defaults to `1`.

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -186,9 +186,13 @@ class TocTreeprocessor(Treeprocessor):
 
     def add_permalink(self, c, elem_id):
         permalink = etree.Element("a")
-        permalink.text = ("%spara;" % AMP_SUBSTITUTE
-                          if self.use_permalinks is True
-                          else self.use_permalinks)
+        content = ("%spara;" % AMP_SUBSTITUTE
+                   if self.use_permalinks is True
+                   else self.use_permalinks)
+        if content.startswith("<") and content.endswith(">"):
+            permalink.append(etree.fromstring(content))
+        else:
+            permalink.text = content
         permalink.attrib["href"] = "#" + elem_id
         permalink.attrib["class"] = "headerlink"
         permalink.attrib["title"] = "Permanent link"

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -132,7 +132,7 @@ class TocTreeprocessor(Treeprocessor):
         self.sep = config["separator"]
         self.use_anchors = parseBoolValue(config["anchorlink"])
         self.use_permalinks = parseBoolValue(config["permalink"], False)
-        if self.use_permalinks is None:
+        if self.use_permalinks is None or isinstance(config["permalink"], etree.Element):
             self.use_permalinks = config["permalink"]
         self.header_rgx = re.compile("[Hh][123456]")
         self.toc_depth = config["toc_depth"]
@@ -186,13 +186,12 @@ class TocTreeprocessor(Treeprocessor):
 
     def add_permalink(self, c, elem_id):
         permalink = etree.Element("a")
-        content = ("%spara;" % AMP_SUBSTITUTE
-                   if self.use_permalinks is True
-                   else self.use_permalinks)
-        if content.startswith("<") and content.endswith(">"):
-            permalink.append(etree.fromstring(content))
+        if isinstance(self.use_permalinks, etree.Element):
+            permalink.append(self.use_permalinks)
         else:
-            permalink.text = content
+            permalink.text = ("%spara;" % AMP_SUBSTITUTE
+                              if self.use_permalinks is True
+                              else self.use_permalinks)
         permalink.attrib["href"] = "#" + elem_id
         permalink.attrib["class"] = "headerlink"
         permalink.attrib["title"] = "Permanent link"
@@ -260,7 +259,7 @@ class TocTreeprocessor(Treeprocessor):
 
                 if self.use_anchors:
                     self.add_anchor(el, el.attrib["id"])
-                if self.use_permalinks:
+                if self.use_permalinks or isinstance(self.use_permalinks, etree.Element):
                     self.add_permalink(el, el.attrib["id"])
 
         toc_tokens = nest_toc_tokens(toc_tokens)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -902,6 +902,23 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '</h1>'                                                                       # noqa
         )
 
+    def testPermalinkWithEtreeElement(self):
+        """ Test TOC Permalink with etree Element. """
+        from markdown.util import etree
+        element = etree.Element("span")
+        element.text = "&para;"
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink=element)]
+        )
+        text = '# Header'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header">'                                                                         # noqa
+                'Header'                                                                               # noqa
+                '<a class="headerlink" href="#header" title="Permanent link"><span>&para;</span></a>'  # noqa
+            '</h1>'                                                                                    # noqa
+        )
+
     def testPermalinkWithSingleInlineCode(self):
         """ Test TOC Permalink with single inline code. """
         md = markdown.Markdown(


### PR DESCRIPTION
I wanted to use a Font-Awesome icon as permalink for a project. So I defined TOC permalink as follows: `<i class="fas fa-link"></i>`. Currently, `TocTreeprocessor.add_permalink` treats permalink content as an `etree.Element` text, so the html tag will be escaped.

This patch aim to allows both text and html.