### PR TITLE
allow a custom css class to be applied on anchorlinks and permalinks

### DIFF
--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -162,6 +162,9 @@ The following options are provided to configure the output:
     the link text. When set to a string, the provided string is used as the link
     text.
 
+* **`permalink_class`**:
+    CSS class(es) used for the link. Default to `headerlink`.
+
 * **`baselevel`**:
     Base level for headers. Defaults to `1`.
 

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -154,6 +154,9 @@ The following options are provided to configure the output:
 * **`anchorlink`**:
     Set to `True` to cause all headers to link to themselves. Default is `False`.
 
+* **`anchorlink_class`**:
+    CSS class(es) used for the link. Defaults to `toclink`.
+
 * **`permalink`**:
     Set to `True` or a string to generate permanent links at the end of each header.
     Useful with Sphinx style sheets.
@@ -163,7 +166,7 @@ The following options are provided to configure the output:
     text.
 
 * **`permalink_class`**:
-    CSS class(es) used for the link. Default to `headerlink`.
+    CSS class(es) used for the link. Defaults to `headerlink`.
 
 * **`baselevel`**:
     Base level for headers. Defaults to `1`.

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -257,7 +257,7 @@ class TocTreeprocessor(Treeprocessor):
 
                 if self.use_anchors:
                     self.add_anchor(el, el.attrib["id"])
-                if self.use_permalinks:
+                if self.use_permalinks is not False:
                     self.add_permalink(el, el.attrib["id"])
 
         toc_tokens = nest_toc_tokens(toc_tokens)

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -134,6 +134,7 @@ class TocTreeprocessor(Treeprocessor):
         self.use_permalinks = parseBoolValue(config["permalink"], False)
         if self.use_permalinks is None:
             self.use_permalinks = config["permalink"]
+        self.permalink_class = config["permalink_class"]
         self.header_rgx = re.compile("[Hh][123456]")
         self.toc_depth = config["toc_depth"]
 
@@ -190,7 +191,7 @@ class TocTreeprocessor(Treeprocessor):
                           if self.use_permalinks is True
                           else self.use_permalinks)
         permalink.attrib["href"] = "#" + elem_id
-        permalink.attrib["class"] = "headerlink"
+        permalink.attrib["class"] = self.permalink_class
         permalink.attrib["title"] = "Permanent link"
         c.append(permalink)
 
@@ -290,6 +291,9 @@ class TocExtension(Extension):
             "permalink": [0,
                           "True or link text if a Sphinx-style permalink should "
                           "be added - Defaults to False"],
+            "permalink_class": ['headerlink',
+                                'CSS class(es) used for the link. '
+                                'Defaults to "headerlink"'],
             "baselevel": ['1', 'Base level for headers.'],
             "slugify": [slugify,
                         "Function to generate anchors based on header text - "

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -131,6 +131,7 @@ class TocTreeprocessor(Treeprocessor):
         self.slugify = config["slugify"]
         self.sep = config["separator"]
         self.use_anchors = parseBoolValue(config["anchorlink"])
+        self.anchorlink_class = config["anchorlink_class"]
         self.use_permalinks = parseBoolValue(config["permalink"], False)
         if self.use_permalinks is None:
             self.use_permalinks = config["permalink"]
@@ -177,7 +178,7 @@ class TocTreeprocessor(Treeprocessor):
         anchor = etree.Element("a")
         anchor.text = c.text
         anchor.attrib["href"] = "#" + elem_id
-        anchor.attrib["class"] = "toclink"
+        anchor.attrib["class"] = self.anchorlink_class
         c.text = ""
         for elem in c:
             anchor.append(elem)
@@ -288,6 +289,9 @@ class TocExtension(Extension):
             "anchorlink": [False,
                            "True if header should be a self link - "
                            "Defaults to False"],
+            "anchorlink_class": ['toclink',
+                                 'CSS class(es) used for the link. '
+                                 'Defaults to "toclink"'],
             "permalink": [0,
                           "True or link text if a Sphinx-style permalink should "
                           "be added - Defaults to False"],

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -888,6 +888,30 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '</h1>'                                                         # noqa
         )
 
+    def testAnchorLinkWithCustomClass(self):
+        """ Test TOC Anchorlink with a custom CSS class. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(anchorlink=True, anchorlink_class="custom")]
+        )
+        text = '# Header 1\n\n## Header *2*'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header-1"><a class="custom" href="#header-1">Header 1</a></h1>\n'
+            '<h2 id="header-2"><a class="custom" href="#header-2">Header <em>2</em></a></h2>'
+        )
+
+    def testAnchorLinkWithCustomClasses(self):
+        """ Test TOC Anchorlink with custom CSS classes. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(anchorlink=True, anchorlink_class="custom1 custom2")]
+        )
+        text = '# Header 1\n\n## Header *2*'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header-1"><a class="custom1 custom2" href="#header-1">Header 1</a></h1>\n'
+            '<h2 id="header-2"><a class="custom1 custom2" href="#header-2">Header <em>2</em></a></h2>'
+        )
+
     def testPermalink(self):
         """ Test TOC Permalink. """
         md = markdown.Markdown(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -930,6 +930,20 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '</h1>'                                                                                          # noqa
         )
 
+    def testPermalinkWithEmptyText(self):
+        """ Test TOC Permalink with empty text. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink="")]
+        )
+        text = '# Header'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header">'                                                      # noqa
+                'Header'                                                            # noqa
+                '<a class="headerlink" href="#header" title="Permanent link"></a>'  # noqa
+            '</h1>'                                                                 # noqa
+        )
+
     def testPermalinkWithCustomClass(self):
         """ Test TOC Permalink with a custom CSS class. """
         md = markdown.Markdown(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -930,6 +930,34 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '</h1>'                                                                                          # noqa
         )
 
+    def testPermalinkWithCustomClass(self):
+        """ Test TOC Permalink with a custom CSS class. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink=True, permalink_class="custom")]
+        )
+        text = '# Header'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header">'                                                        # noqa
+                'Header'                                                              # noqa
+                '<a class="custom" href="#header" title="Permanent link">&para;</a>'  # noqa
+            '</h1>'                                                                   # noqa
+        )
+
+    def testPermalinkWithCustomClasses(self):
+        """ Test TOC Permalink with custom CSS classes. """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(permalink=True, permalink_class="custom1 custom2")]
+        )
+        text = '# Header'
+        self.assertEqual(
+            md.convert(text),
+            '<h1 id="header">'                                                                 # noqa
+                'Header'                                                                       # noqa
+                '<a class="custom1 custom2" href="#header" title="Permanent link">&para;</a>'  # noqa
+            '</h1>'                                                                            # noqa
+        )
+
     def testTitle(self):
         """ Test TOC Title. """
         md = markdown.Markdown(


### PR DESCRIPTION
This pull request follows on #771 that I closed because it is no longer relevant.

The goal is to allow a custom css class to be applied on permalinks as suggested by @waylan in the original pull request (I unfortunately did not see your answer during my last changes).

It perfectly fulfills my need with font-awesome. Indeed, there is no need for an extra tag and it seems semantically better to apply `fa-` classes to a link that has a title attribute.
So I added the same keyword logic "_class" for the anchorlinks, for that matter.

I fixed the case that if the permalink is an empty string, it is treated as `False` and thus disabled. I guess this is the expected behavior when I look at [this line](https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/toc.py#L135), could you confirm ?

I hope this pull request can be merged as is, I remain available if changes need to be made.