### PR TITLE
Add .keys() method to Registry.

### DIFF
--- a/markdown/util.py
+++ b/markdown/util.py
@@ -417,6 +417,11 @@ class Registry(object):
         else:
             raise TypeError
 
+    def keys(self):
+        """ Return all stored keys, sorted by decreasing priority. """
+        self._sort()
+        return [x.name for x in self._priority]
+
     def add(self, key, value, location):
         """ Register a key by location. """
         if len(self) == 0:

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -399,6 +399,16 @@ class RegistryTests(unittest.TestCase):
         self.assertEqual(len(r), 2)
         self.assertEqual(list(r), ['b2', 'a'])
 
+    def testGetKeys(self):
+        r = markdown.util.Registry()
+        r.register(Item('a'), 'a', 20)
+        r.register(Item('c'), 'c', 30)
+        r.register(Item('b'), 'b', 10)
+        r.register(Item('d'), 'd', 40)
+        self.assertEqual(r.keys(), ['d', 'c', 'a', 'b'])
+        r.deregister('c')
+        self.assertEqual(r.keys(), ['d', 'a', 'b'])
+
     def testRegistryDeprecatedAdd(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")


### PR DESCRIPTION
Adds a `.keys()` method. This would be useful in cases like:

1. Removing all elements from a registry *except* some. example: https://github.com/zulip/zulip/commit/b7c5ae7bca3990421971e93fbe0ce85f1699f347#diff-237f2d7c30a5fdd38c7f1e2d8f6734eeL1751
2. Potentially reordering a registry object from another module without having to read that code to find out which element is at what priority.
3. Helpful in debugging.