### PR TITLE
autodirection extension 

### DIFF
--- a/markdown/extensions/autodirection.py
+++ b/markdown/extensions/autodirection.py
@@ -1,0 +1,37 @@
+"""
+AutoDirection Extension for Python-Markdown
+===========================================
+
+Add dir="auto" attribute to paragraphs,
+Tthis will help browser to set text direction based on the content
+
+See <https://Python-Markdown.github.io/extensions/autodirection>
+for documentation.
+
+All changes Copyright 2019 The Python Markdown Project
+
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
+
+"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from . import Extension
+from ..treeprocessors import Treeprocessor
+
+
+class AutoDirectionTreeprocessor(Treeprocessor):
+    def run(self, root):
+        blocks = root.iter('p')
+        for block in blocks:
+            block.set('dir', 'auto')
+
+
+class AutoDirectionExtension(Extension):
+    def extendMarkdown(self, md):
+        autodirection = AutoDirectionTreeprocessor(md)
+        md.treeprocessors.register(autodirection, 'autodirection', 50)
+        md.registerExtension(self)
+
+
+def makeExtension(**kwargs):  # pragma: no cover
+    return AutoDirectionExtension(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         ],
         # Register the built in extensions
         'markdown.extensions': [
+            'autodirection = markdown.extensions.autodirection:AutoDirectionExtension',
             'abbr = markdown.extensions.abbr:AbbrExtension',
             'admonition = markdown.extensions.admonition:AdmonitionExtension',
             'attr_list = markdown.extensions.attr_list:AttrListExtension',

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1108,3 +1108,15 @@ Must not be confused with 'ndash'  (--) ... >>
 is the &sbquo;mdash&lsquo;: \u2014
 Must not be confused with &sbquo;ndash&lsquo;  (\u2013) \u2026 ]</p>"""
         self.assertEqual(self.md.convert(text), correct)
+
+
+class TestAutoDirection(unittest.TestCase):
+    def setUp(self):
+        self.md = markdown.Markdown(extensions=['autodirection'])
+
+    def testSimple(self):
+        text = "This is a test"
+        self.assertEqual(
+            self.md.convert(text),
+            '<p dir="auto">This is a test</p>'
+        )


### PR DESCRIPTION
This will add `dir=auto` attribute to each paragraph, it will tell browser to set the direction of paragraph based on the content, this extension will be helpful for users who write right to left text within markdown file

input:

    Text

output:

    <p dir="auto">Text</p>

note that it's just an initial commit, just wanted to know if it's acceptable to be added into this repo, and be informed of other necessary changes