### PR TITLE
Emphasis treat newlines as whitespace

### DIFF
--- a/docs/change_log/release-3.1.md
+++ b/docs/change_log/release-3.1.md
@@ -31,6 +31,7 @@ The following new features have been included in the release:
 
 The following bug fixes are included in the 3.1 release:
 
+* Emphasis patterns now recognize newline characters as whitespace (#783).
 * Version format had been updated to be PEP 440 compliant (#736).
 * Block level elements are defined per instance, not as class attributes
   (#731).

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -144,7 +144,7 @@ REFERENCE_RE = LINK_RE
 IMAGE_REFERENCE_RE = IMAGE_LINK_RE
 
 # stand-alone * or _
-NOT_STRONG_RE = r'((^| )(\*|_)( |$))'
+NOT_STRONG_RE = r'((^|\s)(\*|_)(\s|$))'
 
 # <http://www.123.com>
 AUTOLINK_RE = r'<((?:[Ff]|[Hh][Tt])[Tt][Pp][Ss]?://[^>]*)>'

--- a/tests/test_syntax/inline/test_emphasis.py
+++ b/tests/test_syntax/inline/test_emphasis.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+Python Markdown
+
+A Python implementation of John Gruber's Markdown.
+
+Documentation: https://python-markdown.github.io/
+GitHub: https://github.com/Python-Markdown/markdown/
+PyPI: https://pypi.org/project/Markdown/
+
+Started by Manfred Stienstra (http://www.dwerg.net/).
+Maintained for a few years by Yuri Takhteyev (http://www.freewisdom.org).
+Currently maintained by Waylan Limberg (https://github.com/waylan),
+Dmitry Shachnev (https://github.com/mitya57) and Isaac Muse (https://github.com/facelessuser).
+
+Copyright 2007-2019 The Python Markdown Project (v. 1.7 and later)
+Copyright 2004, 2005, 2006 Yuri Takhteyev (v. 0.2-1.6b)
+Copyright 2004 Manfred Stienstra (the original version)
+
+License: BSD (see LICENSE.md for details).
+"""
+
+from markdown.test_tools import TestCase
+
+
+class TestNotEmphasis(TestCase):
+
+    def test_standalone_asterisk(self):
+        self.assertMarkdownRenders(
+            '*',
+            '<p>*</p>'
+        )
+
+    def test_standalone_understore(self):
+        self.assertMarkdownRenders(
+            '_',
+            '<p>_</p>'
+        )
+
+    def test_standalone_asterisk_in_text(self):
+        self.assertMarkdownRenders(
+            'foo * bar',
+            '<p>foo * bar</p>'
+        )
+
+    def test_standalone_understore_in_text(self):
+        self.assertMarkdownRenders(
+            'foo _ bar',
+            '<p>foo _ bar</p>'
+        )
+
+    def test_standalone_asterisks_in_text(self):
+        self.assertMarkdownRenders(
+            'foo * bar * baz',
+            '<p>foo * bar * baz</p>'
+        )
+
+    def test_standalone_understores_in_text(self):
+        self.assertMarkdownRenders(
+            'foo _ bar _ baz',
+            '<p>foo _ bar _ baz</p>'
+        )
+
+    def test_standalone_asterisks_with_newlines(self):
+        self.assertMarkdownRenders(
+            'foo\n* bar *\nbaz',
+            '<p>foo\n* bar *\nbaz</p>'
+        )
+
+    def test_standalone_understores_with_newlines(self):
+        self.assertMarkdownRenders(
+            'foo\n_ bar _\nbaz',
+            '<p>foo\n_ bar _\nbaz</p>'
+        )
+
+    def test_standalone_asterisks_at_end(self):
+        self.assertMarkdownRenders(
+            'foo * bar *',
+            '<p>foo * bar *</p>'
+        )
+
+    def test_standalone_understores_at_begin_end(self):
+        self.assertMarkdownRenders(
+            '_ bar _',
+            '<p>_ bar _</p>'
+        )


### PR DESCRIPTION
All whitespace characters should be treated the same by inline patterns.
Previoulsy, emphasis patterns were only accounting for spaces, but not
other whitepsace characters such as newlines. Fixes #783.