### PR TITLE
adding toc_height to exclude upper headings, proposal for #786 and #637

### DIFF
--- a/docs/change_log/release-3.1.md
+++ b/docs/change_log/release-3.1.md
@@ -27,6 +27,12 @@ The following new features have been included in the release:
   not valid in HTML5. The `refs` and `backrefs` classes already exist and
   serve the same purpose (#723).
 
+* A new option for `toc_depth` to set not only the bottom section level,
+  but also the top section level. A string consisting of two digits
+  separated by a hyphen in between ("2-5"), defines the top (t) and the
+  bottom (b) (<ht>..<hb>). A single integer still defines the bottom
+  section level (<h1>..<hb>) only. (#787).
+
 ## Bug fixes
 
 The following bug fixes are included in the 3.1 release:

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -199,8 +199,8 @@ The following options are provided to configure the output:
 * **`toc_depth`**
     Define the range of section levels to include in the Table of Contents.
     A single integer (b) defines the bottom section level (<h1>..<hb>) only.
-    Two digits separated by a hyphen in between (```2-5```), define the
-    top (t) and the bottom (b) (<ht>..<hb>). Defaults to `6` (bottom).
+    A string consisting of two digits separated by a hyphen in between ("2-5"),
+    define the top (t) and the bottom (b) (<ht>..<hb>). Defaults to `6` (bottom).
 
     When used with conjunction with `baselevel`, this parameter will not
     take the fitted hierarchy from `baselevel` into account. That is, if

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -196,21 +196,16 @@ The following options are provided to configure the output:
 * **`separator`**:
     Word separator. Character which replaces white space in id. Defaults to "`-`".
 
-* **`toc_height`**
-    Define the highest section level "n" (`<hn>` to `<h6>`, where `1 <= n <= 6`)
-    to include in the Table of Contents. Section levels above are omitted.
-    Defaults to `1`.
+* **`toc_depth`**
+    Define the range of section levels to include in the Table of Contents.
+    A single integer (b) defines the bottom section level (<h1>..<hb>) only.
+    Two digits seperated by a hyphen in between (```2-5```), define the
+    top (t) and the bottom (b) (<ht>..<hb>). Defaults to `6` (bottom).
 
     When used with conjunction with `baselevel`, this parameter will not
-    take the fitted hierarchy from `baselevel` into account.
-    If you set `baselevel` to 3 and `toc_height` to 2, the *first* headline
-    will be `<h3>` and so still included in the Table of Contents. To exclude
-    this first level, you have to set `toc_height` to 4.
-
-* **`toc_depth`**
-    Define up to which section level "n" (`<h1>` to `<hn>`, where `1 <= n <= 6`)
-    to include in the Table of Contents. Defaults to `6`.
-
-    When used with conjunction with `baselevel` this parameter will limit the
-    resulting (adjusted) heading. That is, if both `toc_depth` and `baselevel`
-    are 3, then only the highest level will be present in the table.
+    take the fitted hierarchy from `baselevel` into account. That is, if
+    both `toc_depth` and `baselevel` are 3, then only the highest level
+    will be present in the table. If you set `baselevel` to 3 and
+    `toc_depth` to '2-6', the *first* headline will be `<h3>` and so still
+    included in the Table of Contents. To exclude this first level, you
+    have to set `toc_depth` to '4-6'.

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -196,6 +196,14 @@ The following options are provided to configure the output:
 * **`separator`**:
     Word separator. Character which replaces white space in id. Defaults to "`-`".
 
+* **`toc_height`**
+    Define from to which section level "n" (`<hn>` to `<h6>`, where `1 <= n <= 6`)
+    to include in the Table of Contents. Defaults to `1`.
+
+    When used with conjunction with `baselevel` this parameter will not follow.
+    To exclude the first level, you have to add the count of `baselevel` to
+    `toc_height`.
+
 * **`toc_depth`**
     Define up to which section level "n" (`<h1>` to `<hn>`, where `1 <= n <= 6`)
     to include in the Table of Contents. Defaults to `6`.

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -199,7 +199,7 @@ The following options are provided to configure the output:
 * **`toc_depth`**
     Define the range of section levels to include in the Table of Contents.
     A single integer (b) defines the bottom section level (<h1>..<hb>) only.
-    Two digits seperated by a hyphen in between (```2-5```), define the
+    Two digits separated by a hyphen in between (```2-5```), define the
     top (t) and the bottom (b) (<ht>..<hb>). Defaults to `6` (bottom).
 
     When used with conjunction with `baselevel`, this parameter will not

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -197,12 +197,15 @@ The following options are provided to configure the output:
     Word separator. Character which replaces white space in id. Defaults to "`-`".
 
 * **`toc_height`**
-    Define from to which section level "n" (`<hn>` to `<h6>`, where `1 <= n <= 6`)
-    to include in the Table of Contents. Defaults to `1`.
+    Define the highest section level "n" (`<hn>` to `<h6>`, where `1 <= n <= 6`)
+    to include in the Table of Contents. Section levels above are omitted.
+    Defaults to `1`.
 
-    When used with conjunction with `baselevel` this parameter will not follow.
-    To exclude the first level, you have to add the count of `baselevel` to
-    `toc_height`.
+    When used with conjunction with `baselevel`, this parameter will not
+    take the fitted hierarchy from `baselevel` into account.
+    If you set `baselevel` to 3 and `toc_height` to 2, the *first* headline
+    will be `<h3>` and so still included in the Table of Contents. To exclude
+    this first level, you have to set `toc_height` to 4.
 
 * **`toc_depth`**
     Define up to which section level "n" (`<h1>` to `<hn>`, where `1 <= n <= 6`)

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -298,8 +298,8 @@ class TocExtension(Extension):
                         "Defaults to the headerid ext's slugify function."],
             'separator': ['-', 'Word separator. Defaults to "-".'],
             "toc_height": [1,
-                          "Define from to which section level n (<hn>..<h6>) to "
-                          "include in the TOC"],
+                           "Define from to which section level n (<hn>..<h6>) to "
+                           "include in the TOC"],
             "toc_depth": [6,
                           "Define up to which section level n (<h1>..<hn>) to "
                           "include in the TOC"]

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -298,8 +298,8 @@ class TocExtension(Extension):
                         "Defaults to the headerid ext's slugify function."],
             'separator': ['-', 'Word separator. Defaults to "-".'],
             "toc_height": [1,
-                           "Define from to which section level n (<hn>..<h6>) to "
-                           "include in the TOC"],
+                           "Define the highest section level n (<hn>..<h6>) to"
+                           "include in the TOC. Section levels above are omitted."],
             "toc_depth": [6,
                           "Define up to which section level n (<h1>..<hn>) to "
                           "include in the TOC"]

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -135,12 +135,11 @@ class TocTreeprocessor(Treeprocessor):
         if self.use_permalinks is None:
             self.use_permalinks = config["permalink"]
         self.header_rgx = re.compile("[Hh][123456]")
-        self.toc_depth = config["toc_depth"]
-        if type(self.toc_depth) is not int:
-            self.toc_top, self.toc_bottom = self.toc_depth.split('-')
+        if isinstance(config["toc_depth"], basestring) and '-' in config["toc_depth"]:
+            self.toc_top, self.toc_bottom = [int(x) for x in config["toc_depth"].split('-')]
         else:
             self.toc_top = 1
-            self.toc_bottom = self.toc_depth
+            self.toc_bottom = int(config["toc_depth"])
 
     def iterparent(self, node):
         ''' Iterator wrapper to get allowed parent and child all at once. '''
@@ -240,7 +239,7 @@ class TocTreeprocessor(Treeprocessor):
         for el in doc.iter():
             if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
                 self.set_level(el)
-                if int(el.tag[-1]) < int(self.toc_top) or int(el.tag[-1]) > int(self.toc_bottom):
+                if int(el.tag[-1]) < self.toc_top or int(el.tag[-1]) > self.toc_bottom:
                     continue
                 text = ''.join(el.itertext()).strip()
 

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -135,6 +135,7 @@ class TocTreeprocessor(Treeprocessor):
         if self.use_permalinks is None:
             self.use_permalinks = config["permalink"]
         self.header_rgx = re.compile("[Hh][123456]")
+        self.toc_height = config["toc_height"]
         self.toc_depth = config["toc_depth"]
 
     def iterparent(self, node):
@@ -235,7 +236,8 @@ class TocTreeprocessor(Treeprocessor):
         for el in doc.iter():
             if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
                 self.set_level(el)
-                if int(el.tag[-1]) > int(self.toc_depth):
+                if int(el.tag[-1]) < int(self.toc_height) or int(el.tag[-1]) > int(self.toc_depth):
+
                     continue
                 text = ''.join(el.itertext()).strip()
 
@@ -295,6 +297,9 @@ class TocExtension(Extension):
                         "Function to generate anchors based on header text - "
                         "Defaults to the headerid ext's slugify function."],
             'separator': ['-', 'Word separator. Defaults to "-".'],
+            "toc_height": [1,
+                          "Define from to which section level n (<hn>..<h6>) to "
+                          "include in the TOC"],
             "toc_depth": [6,
                           "Define up to which section level n (<h1>..<hn>) to "
                           "include in the TOC"]

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -137,7 +137,10 @@ class TocTreeprocessor(Treeprocessor):
         self.header_rgx = re.compile("[Hh][123456]")
         self.toc_depth = config["toc_depth"]
         if type(self.toc_depth) is not int:
-            self.toc_depth = self.toc_depth.split('-')
+            self.toc_top, self.toc_bottom = self.toc_depth.split('-')
+        else:
+            self.toc_top = 1
+            self.toc_bottom = self.toc_depth
 
     def iterparent(self, node):
         ''' Iterator wrapper to get allowed parent and child all at once. '''
@@ -237,18 +240,8 @@ class TocTreeprocessor(Treeprocessor):
         for el in doc.iter():
             if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
                 self.set_level(el)
-                try:
-                    if int(el.tag[-1]) > int(self.toc_depth):
-                        continue
-                except TypeError:
-                    pass
-                try:
-                    if int(el.tag[-1]) < int(self.toc_depth[0]) or int(el.tag[-1]) > int(self.toc_depth[1]):
-                        continue
-                except TypeError:
-                    pass
-                except ValueError:
-                    pass
+                if int(el.tag[-1]) < int(self.toc_top) or int(el.tag[-1]) > int(self.toc_bottom):
+                    continue
                 text = ''.join(el.itertext()).strip()
 
                 # Do not override pre-existing ids

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -301,12 +301,12 @@ class TocExtension(Extension):
                         "Defaults to the headerid ext's slugify function."],
             'separator': ['-', 'Word separator. Defaults to "-".'],
             "toc_depth": [6,
-                          "Define the range of section levels to include in"
-                          "the Table of Contents. A single integer (b) defines"
-                          "the bottom section level (<h1>..<hb>) only."
-                          "Two digits separated by a hyphen in between"
-                          " (```2-5```), define the top (t) and the bottom (b)"
-                          " (<ht>..<hb>). Defaults to `6` (bottom)."],
+                          'Define the range of section levels to include in'
+                          'the Table of Contents. A single integer (b) defines'
+                          'the bottom section level (<h1>..<hb>) only.'
+                          'A string consisting of two digits separated by a hyphen'
+                          'in between ("2-5"), define the top (t) and the'
+                          'bottom (b) (<ht>..<hb>). Defaults to `6` (bottom).'],
         }
 
         super(TocExtension, self).__init__(**kwargs)

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -235,7 +235,7 @@ class TocTreeprocessor(Treeprocessor):
         for el in doc.iter():
             if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
                 self.set_level(el)
-                if type( self.toc_depth ) != int:
+                if type(self.toc_depth) != int:
                     toc_top, toc_bottom = self.toc_depth.split('-')
                 else:
                     toc_top = 1

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -135,7 +135,6 @@ class TocTreeprocessor(Treeprocessor):
         if self.use_permalinks is None:
             self.use_permalinks = config["permalink"]
         self.header_rgx = re.compile("[Hh][123456]")
-        self.toc_height = config["toc_height"]
         self.toc_depth = config["toc_depth"]
 
     def iterparent(self, node):
@@ -236,8 +235,12 @@ class TocTreeprocessor(Treeprocessor):
         for el in doc.iter():
             if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
                 self.set_level(el)
-                if int(el.tag[-1]) < int(self.toc_height) or int(el.tag[-1]) > int(self.toc_depth):
-
+                if type( self.toc_depth ) != int:
+                    toc_top, toc_bottom = self.toc_depth.split('-')
+                else:
+                    toc_top = 1
+                    toc_bottom = self.toc_depth
+                if int(el.tag[-1]) < int(toc_top) or int(el.tag[-1]) > int(toc_bottom):
                     continue
                 text = ''.join(el.itertext()).strip()
 
@@ -297,12 +300,13 @@ class TocExtension(Extension):
                         "Function to generate anchors based on header text - "
                         "Defaults to the headerid ext's slugify function."],
             'separator': ['-', 'Word separator. Defaults to "-".'],
-            "toc_height": [1,
-                           "Define the highest section level n (<hn>..<h6>) to"
-                           "include in the TOC. Section levels above are omitted."],
             "toc_depth": [6,
-                          "Define up to which section level n (<h1>..<hn>) to "
-                          "include in the TOC"]
+                          "Define the range of section levels to include in"
+                          "the Table of Contents. A single integer (b) defines"
+                          "the bottom section level (<h1>..<hb>) only."
+                          "Two digits seperated by a hyphen in between"
+                          " (```2-5```), define the top (t) and the bottom (b)"
+                          " (<ht>..<hb>). Defaults to `6` (bottom)."],
         }
 
         super(TocExtension, self).__init__(**kwargs)

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -136,6 +136,8 @@ class TocTreeprocessor(Treeprocessor):
             self.use_permalinks = config["permalink"]
         self.header_rgx = re.compile("[Hh][123456]")
         self.toc_depth = config["toc_depth"]
+        if type(self.toc_depth) is not int:
+            self.toc_depth = self.toc_depth.split('-')
 
     def iterparent(self, node):
         ''' Iterator wrapper to get allowed parent and child all at once. '''
@@ -235,13 +237,18 @@ class TocTreeprocessor(Treeprocessor):
         for el in doc.iter():
             if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
                 self.set_level(el)
-                if type(self.toc_depth) != int:
-                    toc_top, toc_bottom = self.toc_depth.split('-')
-                else:
-                    toc_top = 1
-                    toc_bottom = self.toc_depth
-                if int(el.tag[-1]) < int(toc_top) or int(el.tag[-1]) > int(toc_bottom):
-                    continue
+                try:
+                    if int(el.tag[-1]) > int(self.toc_depth):
+                        continue
+                except TypeError:
+                    pass
+                try:
+                    if int(el.tag[-1]) < int(self.toc_depth[0]) or int(el.tag[-1]) > int(self.toc_depth[1]):
+                        continue
+                except TypeError:
+                    pass
+                except ValueError:
+                    pass
                 text = ''.join(el.itertext()).strip()
 
                 # Do not override pre-existing ids

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -135,7 +135,7 @@ class TocTreeprocessor(Treeprocessor):
         if self.use_permalinks is None:
             self.use_permalinks = config["permalink"]
         self.header_rgx = re.compile("[Hh][123456]")
-        if isinstance(config["toc_depth"], basestring) and '-' in config["toc_depth"]:
+        if isinstance(config["toc_depth"], string_type) and '-' in config["toc_depth"]:
             self.toc_top, self.toc_bottom = [int(x) for x in config["toc_depth"].split('-')]
         else:
             self.toc_top = 1

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -304,7 +304,7 @@ class TocExtension(Extension):
                           "Define the range of section levels to include in"
                           "the Table of Contents. A single integer (b) defines"
                           "the bottom section level (<h1>..<hb>) only."
-                          "Two digits seperated by a hyphen in between"
+                          "Two digits separated by a hyphen in between"
                           " (```2-5```), define the top (t) and the bottom (b)"
                           " (<ht>..<hb>). Defaults to `6` (bottom)."],
         }

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1021,10 +1021,10 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '<h1 id="toc"><em>[TOC]</em></h1>'          # noqa
         )
 
-    def testMinLevel(self):
+    def testMinMaxLevel(self):
         """ Test toc_height setting """
         md = markdown.Markdown(
-            extensions=[markdown.extensions.toc.TocExtension(toc_height=3)]
+            extensions=[markdown.extensions.toc.TocExtension(toc_depth='3-4')]
         )
         text = '# Header 1 not in TOC\n\n## Header 2 not in TOC\n\n### Header 3\n\n####Header 4'
         self.assertEqual(
@@ -1076,10 +1076,10 @@ class TestTOC(TestCaseWithAssertStartsWith):
 
         self.assertNotIn("Header 3", md.toc)
 
-    def testMinLevelwithBaseLevel(self):
+    def testMinMaxLevelwithBaseLevel(self):
         """ Test toc_height setting together with baselevel """
         md = markdown.Markdown(
-            extensions=[markdown.extensions.toc.TocExtension(toc_height=4,
+            extensions=[markdown.extensions.toc.TocExtension(toc_depth='4-6',
                                                              baselevel=3)]
         )
         text = '# First Header\n\n## Second Level\n\n### Third Level'

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1024,22 +1024,23 @@ class TestTOC(TestCaseWithAssertStartsWith):
     def testMinLevel(self):
         """ Test toc_height setting """
         md = markdown.Markdown(
-            extensions=[markdown.extensions.toc.TocExtension(toc_height=2)]
+            extensions=[markdown.extensions.toc.TocExtension(toc_height=3)]
         )
-        text = '# Header 1 not in TOC\n\n## Header 2\n\n###Header 3'
+        text = '# Header 1 not in TOC\n\n## Header 2 not in TOC\n\n### Header 3\n\n####Header 4'
         self.assertEqual(
             md.convert(text),
             '<h1>Header 1 not in TOC</h1>\n'
-            '<h2 id="header-2">Header 2</h2>\n'
-            '<h3 id="header-3">Header 3</h3>'
+            '<h2>Header 2 not in TOC</h2>\n'
+            '<h3 id="header-3">Header 3</h3>\n'
+            '<h4 id="header-4">Header 4</h4>'
         )
         self.assertEqual(
             md.toc,
             '<div class="toc">\n'
               '<ul>\n'                                             # noqa
-                '<li><a href="#header-2">Header 2</a>'             # noqa
+                '<li><a href="#header-3">Header 3</a>'             # noqa
                   '<ul>\n'                                         # noqa
-                    '<li><a href="#header-3">Header 3</a></li>\n'  # noqa
+                    '<li><a href="#header-4">Header 4</a></li>\n'  # noqa
                   '</ul>\n'                                        # noqa
                 '</li>\n'                                          # noqa
               '</ul>\n'                                            # noqa

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1021,6 +1021,33 @@ class TestTOC(TestCaseWithAssertStartsWith):
             '<h1 id="toc"><em>[TOC]</em></h1>'          # noqa
         )
 
+    def testMinLevel(self):
+        """ Test toc_height setting """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(toc_height=2)]
+        )
+        text = '# Header 1 not in TOC\n\n## Header 2\n\n###Header 3'
+        self.assertEqual(
+            md.convert(text),
+            '<h1>Header 1 not in TOC</h1>\n'
+            '<h2 id="header-2">Header 2</h2>\n'
+            '<h3 id="header-3">Header 3</h3>'
+        )
+        self.assertEqual(
+            md.toc,
+            '<div class="toc">\n'
+              '<ul>\n'                                             # noqa
+                '<li><a href="#header-2">Header 2</a>'             # noqa
+                  '<ul>\n'                                         # noqa
+                    '<li><a href="#header-3">Header 3</a></li>\n'  # noqa
+                  '</ul>\n'                                        # noqa
+                '</li>\n'                                          # noqa
+              '</ul>\n'                                            # noqa
+            '</div>\n'
+        )
+
+        self.assertNotIn("Header 1", md.toc)
+
     def testMaxLevel(self):
         """ Test toc_depth setting """
         md = markdown.Markdown(
@@ -1047,6 +1074,33 @@ class TestTOC(TestCaseWithAssertStartsWith):
         )
 
         self.assertNotIn("Header 3", md.toc)
+
+    def testMinLevelwithBaseLevel(self):
+        """ Test toc_height setting together with baselevel """
+        md = markdown.Markdown(
+            extensions=[markdown.extensions.toc.TocExtension(toc_height=4,
+                                                             baselevel=3)]
+        )
+        text = '# First Header\n\n## Second Level\n\n### Third Level'
+        self.assertEqual(
+            md.convert(text),
+            '<h3>First Header</h3>\n'
+            '<h4 id="second-level">Second Level</h4>\n'
+            '<h5 id="third-level">Third Level</h5>'
+        )
+        self.assertEqual(
+            md.toc,
+            '<div class="toc">\n'
+              '<ul>\n'                                                  # noqa
+                '<li><a href="#second-level">Second Level</a>'          # noqa
+                  '<ul>\n'                                              # noqa
+                    '<li><a href="#third-level">Third Level</a></li>\n' # noqa
+                  '</ul>\n'                                             # noqa
+                '</li>\n'                                               # noqa
+              '</ul>\n'                                                 # noqa
+            '</div>\n'
+        )
+        self.assertNotIn("First Header", md.toc)
 
     def testMaxLevelwithBaseLevel(self):
         """ Test toc_depth setting together with baselevel """


### PR DESCRIPTION
I added a new config value toc_height. Using an array for _toc_depth_  seems to me very unlikely. 


## test local

```
~/devel/markdown$ python3 -m unittest discover tests
... 550 tests in 1.259s
OK (skipped=71)

```