### PR TITLE
Drop Python 3.4 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
   include:
     - python: '2.7'
       env: TOXENV=py27
-    - python: '3.4'
-      env: TOXENV=py34
-      dist: trusty
     - python: '3.5'
       env: TOXENV=py35
     - python: '3.6'

--- a/docs/change_log/release-3.1.md
+++ b/docs/change_log/release-3.1.md
@@ -2,7 +2,7 @@ title: Release Notes for v3.1
 
 # Python-Markdown 3.1 Release Notes
 
-Python-Markdown version 3.1 supports Python versions 2.7, 3.4, 3.5, 3.6, 3.7,
+Python-Markdown version 3.1 supports Python versions 2.7, 3.5, 3.6, 3.7,
 PyPy and PyPy3.
 
 ## Backwards-incompatible changes
@@ -29,9 +29,9 @@ The following new features have been included in the release:
 
 * A new option for `toc_depth` to set not only the bottom section level,
   but also the top section level. A string consisting of two digits
-  separated by a hyphen in between ("2-5"), defines the top (t) and the
-  bottom (b) (<ht>..<hb>). A single integer still defines the bottom
-  section level (<h1>..<hb>) only. (#787).
+  separated by a hyphen in between (`"2-5"`), defines the top (`t`) and the
+  bottom (`b`) (`<ht>..<hb>`). A single integer still defines the bottom
+  section level (`<h1>..<hb>`) only. (#787).
 
 ## Bug fixes
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     maintainer_email='waylan.limberg@icloud.com',
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=['setuptools >= 36'],
     extras_require={
         'testing': [
@@ -117,7 +117,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3, flake8, checkspelling
+envlist = py27, py35, py36, py37, pypy, pypy3, flake8, checkspelling
 requires = setuptools>=36
 isolated_build = True
 


### PR DESCRIPTION
Python is dropping support for PY3.4 on  2019-03-16. Therefore we are dropping support as well. See #760.