### PR TITLE
have treeprocessors always use the current inlinePatterns

### DIFF
--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -74,7 +74,6 @@ class InlineProcessor(Treeprocessor):
                                       + len(self.__placeholder_suffix)
         self.__placeholder_re = util.INLINE_PLACEHOLDER_RE
         self.md = md
-        self.inlinePatterns = md.inlinePatterns
         self.ancestors = []
 
     @property
@@ -128,9 +127,9 @@ class InlineProcessor(Treeprocessor):
         """
         if not isinstance(data, util.AtomicString):
             startIndex = 0
-            while patternIndex < len(self.inlinePatterns):
+            while patternIndex < len(self.md.inlinePatterns):
                 data, matched, startIndex = self.__applyPattern(
-                    self.inlinePatterns[patternIndex], data, patternIndex, startIndex
+                    self.md.inlinePatterns[patternIndex], data, patternIndex, startIndex
                 )
                 if not matched:
                     patternIndex += 1


### PR DESCRIPTION
This update forces treeprocessor->InlineProcessor to use the current `inlinePatterns`. Before this, `InlineProcessor.inlinePatterns` would always point to the value set initially, even if `Markdown.inlinePatterns` changed. This allows you to register only the processors you want, instead of having to deregister everything, like so...

```
class MyExtension(Extension):
    def extendMarkdown(self, md, md_globals):
        md.inlinePatterns = util.Registry()
        md.inlinePatterns.register(SimpleTagInlineProcessor(STRONG_RE, 'strong'), 'strong', 40)
```