### PR TITLE
Refactor em strong to consolidate code and fix issue #792

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 
 install:
   # NOTE: setuptools needs to be installed explicitly for py34 (trusty).
-  - pip install 'setuptools>=36' 'tox==3.7.0'
+  - pip install 'setuptools>=36' tox
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 
 install:
   # NOTE: setuptools needs to be installed explicitly for py34 (trusty).
-  - pip install 'setuptools>=36' tox
+  - pip install 'setuptools>=36' 'tox==3.7.0'
 
 script:
   - tox

--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -5,6 +5,28 @@ title: Release Notes for v3.2
 Python-Markdown version 3.2 supports Python versions 2.7, 3.5, 3.6, 3.7,
 PyPy and PyPy3.
 
+## Backwards-incompatible changes
+
+## `em` and `strong` inline processor changes
+
+In order to fix issue #792, `em`/`strong` inline processors were refactored. This
+translated into removing many of the existing inline processors that handled this
+logic:
+
+* `em_strong`
+* `strong`
+* `emphasis`
+* `strong2`
+* `emphasis`
+
+These processors were replaced with two new ones:
+
+* `em_strong`
+* `em_strong2`
+
+The [`legacy_em`](../extensions/legacy_em.md) extension was also modified with new,
+refactored logic and simply overrides the `em_strong2` inline processor.
+
 ## Bug fixes
 
 The following bug fixes are included in the 3.2 release:

--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -1,0 +1,12 @@
+title: Release Notes for v3.2
+
+# Python-Markdown 3.2 Release Notes
+
+Python-Markdown version 3.2 supports Python versions 2.7, 3.5, 3.6, 3.7,
+PyPy and PyPy3.
+
+## Bug fixes
+
+The following bug fixes are included in the 3.2 release:
+
+* Refactor bold and italic logic in order to solve complex nesting issues (#792).

--- a/markdown/extensions/legacy_em.py
+++ b/markdown/extensions/legacy_em.py
@@ -13,7 +13,8 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
-from ..import inlinepatterns
+from .. import inlinepatterns
+import re
 
 # _emphasis_
 EMPHASIS_RE = r'(_)([^_]+)\1'
@@ -32,8 +33,8 @@ class LegacyUnderscoreProcessor(inlinepatterns.UnderscoreProcessor):
         (re.compile(inlinepatterns.EM_STRONG2_RE, re.DOTALL | re.UNICODE), 'double', 'strong,em'),
         (re.compile(inlinepatterns.STRONG_EM2_RE, re.DOTALL | re.UNICODE), 'double', 'em,strong'),
         (re.compile(STRONG_EM_RE, re.DOTALL | re.UNICODE), 'double2', 'strong,em'),
-        (re.compile(EMPHASIS_RE, re.DOTALL | re.UNICODE), 'single', 'strong'),
-        (re.compile(STRONG_RE, re.DOTALL | re.UNICODE), 'single', 'em')
+        (re.compile(STRONG_RE, re.DOTALL | re.UNICODE), 'single', 'strong'),
+        (re.compile(EMPHASIS_RE, re.DOTALL | re.UNICODE), 'single', 'em')
     ]
 
 
@@ -42,4 +43,4 @@ class LegacyEmExtension(Extension):
 
     def extendMarkdown(self, md):
         """ Modify inline patterns. """
-        md.inlinepatterns.register(LegacyUnderscoreProcessor(r'_'), 'em_strong2', 50)
+        md.inlinePatterns.register(LegacyUnderscoreProcessor(r'_'), 'em_strong2', 50)

--- a/markdown/extensions/legacy_em.py
+++ b/markdown/extensions/legacy_em.py
@@ -13,10 +13,28 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
-from ..inlinepatterns import SimpleTagInlineProcessor
+from ..import inlinepatterns
 
-EMPHASIS_RE = r'(\*|_)(.+?)\1'
-STRONG_RE = r'(\*{2}|_{2})(.+?)\1'
+# _emphasis_
+EMPHASIS_RE = r'(_)([^_]+)\1'
+
+# __strong__
+STRONG_RE = r'(_{2})(.+?)\1'
+
+# __strong_em___
+STRONG_EM_RE = r'(_)\1(?!\1)(.+?)\1(?!\1)(.+?)\1{3}'
+
+
+class LegacyUnderscoreProcessor(inlinepatterns.UnderscoreProcessor):
+    """Emphasis processor for handling strong and em matches inside underscores."""
+
+    PATTERNS = [
+        (re.compile(inlinepatterns.EM_STRONG2_RE, re.DOTALL | re.UNICODE), 'double', 'strong,em'),
+        (re.compile(inlinepatterns.STRONG_EM2_RE, re.DOTALL | re.UNICODE), 'double', 'em,strong'),
+        (re.compile(STRONG_EM_RE, re.DOTALL | re.UNICODE), 'double2', 'strong,em'),
+        (re.compile(EMPHASIS_RE, re.DOTALL | re.UNICODE), 'single', 'strong'),
+        (re.compile(STRONG_RE, re.DOTALL | re.UNICODE), 'single', 'em')
+    ]
 
 
 class LegacyEmExtension(Extension):
@@ -24,7 +42,4 @@ class LegacyEmExtension(Extension):
 
     def extendMarkdown(self, md):
         """ Modify inline patterns. """
-        md.inlinePatterns.register(SimpleTagInlineProcessor(STRONG_RE, 'strong'), 'strong', 40)
-        md.inlinePatterns.register(SimpleTagInlineProcessor(EMPHASIS_RE, 'em'), 'emphasis', 30)
-        md.inlinePatterns.deregister('strong2')
-        md.inlinePatterns.deregister('emphasis2')
+        md.inlinepatterns.register(LegacyUnderscoreProcessor(r'_'), 'em_strong2', 50)

--- a/markdown/extensions/legacy_em.py
+++ b/markdown/extensions/legacy_em.py
@@ -13,7 +13,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
-from .. import inlinepatterns
+from ..inlinepatterns import UnderscoreProcessor, EmStrongItem, EM_STRONG2_RE, STRONG_EM2_RE
 import re
 
 # _emphasis_
@@ -26,15 +26,15 @@ STRONG_RE = r'(_{2})(.+?)\1'
 STRONG_EM_RE = r'(_)\1(?!\1)(.+?)\1(?!\1)(.+?)\1{3}'
 
 
-class LegacyUnderscoreProcessor(inlinepatterns.UnderscoreProcessor):
+class LegacyUnderscoreProcessor(UnderscoreProcessor):
     """Emphasis processor for handling strong and em matches inside underscores."""
 
     PATTERNS = [
-        (re.compile(inlinepatterns.EM_STRONG2_RE, re.DOTALL | re.UNICODE), 'double', 'strong,em'),
-        (re.compile(inlinepatterns.STRONG_EM2_RE, re.DOTALL | re.UNICODE), 'double', 'em,strong'),
-        (re.compile(STRONG_EM_RE, re.DOTALL | re.UNICODE), 'double2', 'strong,em'),
-        (re.compile(STRONG_RE, re.DOTALL | re.UNICODE), 'single', 'strong'),
-        (re.compile(EMPHASIS_RE, re.DOTALL | re.UNICODE), 'single', 'em')
+        EmStrongItem(re.compile(EM_STRONG2_RE, re.DOTALL | re.UNICODE), 'double', 'strong,em'),
+        EmStrongItem(re.compile(STRONG_EM2_RE, re.DOTALL | re.UNICODE), 'double', 'em,strong'),
+        EmStrongItem(re.compile(STRONG_EM_RE, re.DOTALL | re.UNICODE), 'double2', 'strong,em'),
+        EmStrongItem(re.compile(STRONG_RE, re.DOTALL | re.UNICODE), 'single', 'strong'),
+        EmStrongItem(re.compile(EMPHASIS_RE, re.DOTALL | re.UNICODE), 'single', 'em')
     ]
 
 

--- a/markdown/extensions/legacy_em.py
+++ b/markdown/extensions/legacy_em.py
@@ -44,3 +44,8 @@ class LegacyEmExtension(Extension):
     def extendMarkdown(self, md):
         """ Modify inline patterns. """
         md.inlinePatterns.register(LegacyUnderscoreProcessor(r'_'), 'em_strong2', 50)
+
+
+def makeExtension(**kwargs):  # pragma: no cover
+    """ Return an instance of the LegacyEmExtension """
+    return LegacyEmExtension(**kwargs)

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -69,7 +69,6 @@ try:  # pragma: no cover
     from html import entities
 except ImportError:  # pragma: no cover
     import htmlentitydefs as entities
-from collections import OrderedDict
 
 
 def build_inlinepatterns(md, **kwargs):
@@ -576,7 +575,7 @@ class AsteriskProcessor(InlineProcessor):
         return el, start, end
 
 
-class UnderscoreProcessor(InlineProcessor):
+class UnderscoreProcessor(AsteriskProcessor):
     """Emphasis processor for handling strong and em matches inside underscores."""
 
     PATTERNS = [

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -352,7 +352,7 @@ class SimpleTagInlineProcessor(InlineProcessor):
         InlineProcessor.__init__(self, pattern)
         self.tag = tag
 
-    def handleMatch(self, m, data):
+    def handleMatch(self, m, data):  # pragma: no cover
         el = util.etree.Element(self.tag)
         el.text = m.group(2)
         return el, m.start(0), m.end(0)
@@ -408,7 +408,7 @@ class DoubleTagInlineProcessor(SimpleTagInlineProcessor):
     Useful for strong emphasis etc.
 
     """
-    def handleMatch(self, m, data):
+    def handleMatch(self, m, data):  # pragma: no cover
         tag1, tag2 = self.tag.split(",")
         el1 = util.etree.Element(tag1)
         el2 = util.etree.SubElement(el1, tag2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Test Tools: test_tools.md
   - Contributing to Python-Markdown: contributing.md
   - Change Log: change_log/index.md
+  - Release Notes for v.3.2: change_log/release-3.2.md
   - Release Notes for v.3.1: change_log/release-3.1.md
   - Release Notes for v.3.0: change_log/release-3.0.md
   - Release Notes for v.2.6: change_log/release-2.6.md

--- a/tests/test_syntax/extensions/test_legacy_em.py
+++ b/tests/test_syntax/extensions/test_legacy_em.py
@@ -38,3 +38,17 @@ class TestLegacyEm(TestCase):
             '<p><strong>connected</strong>words__</p>',
             extensions=['legacy_em']
         )
+
+    def test_complex_emphasis_underscore(self):
+        self.assertMarkdownRenders(
+            'This is text __bold _italic bold___ with more text',
+            '<p>This is text <strong>bold <em>italic bold</em></strong> with more text</p>',
+            extensions=['legacy_em']
+        )
+
+    def test_complex_emphasis_underscore_mid_word(self):
+        self.assertMarkdownRenders(
+            'This is text __bold_italic bold___ with more text',
+            '<p>This is text <strong>bold<em>italic bold</em></strong> with more text</p>',
+            extensions=['legacy_em']
+        )

--- a/tests/test_syntax/inline/test_emphasis.py
+++ b/tests/test_syntax/inline/test_emphasis.py
@@ -108,3 +108,10 @@ class TestNotEmphasis(TestCase):
             'This is text __bold_italic bold___ with more text',
             '<p>This is text __bold_italic bold___ with more text</p>'
         )
+
+    def test_nested_emphasis(self):
+
+        self.assertMarkdownRenders(
+            'This text is **bold *italic* *italic* bold**',
+            '<p>This text is <strong>bold <em>italic</em> <em>italic</em> bold</strong></p>'
+        )

--- a/tests/test_syntax/inline/test_emphasis.py
+++ b/tests/test_syntax/inline/test_emphasis.py
@@ -84,3 +84,27 @@ class TestNotEmphasis(TestCase):
             '_ bar _',
             '<p>_ bar _</p>'
         )
+
+    def test_complex_emphasis_asterisk(self):
+        self.assertMarkdownRenders(
+            'This is text **bold *italic bold*** with more text',
+            '<p>This is text <strong>bold <em>italic bold</em></strong> with more text</p>'
+        )
+
+    def test_complex_emphasis_asterisk_mid_word(self):
+        self.assertMarkdownRenders(
+            'This is text **bold*italic bold*** with more text',
+            '<p>This is text <strong>bold<em>italic bold</em></strong> with more text</p>'
+        )
+
+    def test_complex_emphasis_smart_underscore(self):
+        self.assertMarkdownRenders(
+            'This is text __bold _italic bold___ with more text',
+            '<p>This is text <strong>bold <em>italic bold</em></strong> with more text</p>'
+        )
+
+    def test_complex_emphasis_smart_underscore_mid_word(self):
+        self.assertMarkdownRenders(
+            'This is text __bold_italic bold___ with more text',
+            '<p>This is text __bold_italic bold___ with more text</p>'
+        )


### PR DESCRIPTION
This refactors em strong logic into two processors: one for asterisks and one for underscores.  All logic for the respective emphasis convention is consolidated, and a new pattern is added to handle `**strong*em***` and `__strong_em___` respectively.