### PR TITLE
Update CLI to support PyYAML 5.1

### DIFF
--- a/docs/change_log/release-3.1.md
+++ b/docs/change_log/release-3.1.md
@@ -37,6 +37,7 @@ The following new features have been included in the release:
 
 The following bug fixes are included in the 3.1 release:
 
+* Update CLI to support PyYAML 5.1.
 * Overlapping raw HTML matches no longer leave placeholders behind (#458).
 * Emphasis patterns now recognize newline characters as whitespace (#783).
 * Version format had been updated to be PEP 440 compliant (#736).

--- a/markdown/__main__.py
+++ b/markdown/__main__.py
@@ -26,9 +26,17 @@ import codecs
 import warnings
 import markdown
 try:
-    import yaml
+    # We use `unsafe_load` because users may need to pass in actual Python
+    # objects. As this is only available from the CLI, the user has much
+    # worse problems if an attacker can use this as an attach vector.
+    from yaml import unsafe_load as yaml_load
 except ImportError:  # pragma: no cover
-    import json as yaml
+    try:
+        # Fall back to PyYAML <5.1
+        from yaml import load as yaml_load
+    except ImportError:
+        # Fall back to JSON
+        from json import load as yaml_load
 
 import logging
 from logging import DEBUG, WARNING, CRITICAL
@@ -97,7 +105,7 @@ def parse_options(args=None, values=None):
             options.configfile, mode="r", encoding=options.encoding
         ) as fp:
             try:
-                extension_configs = yaml.load(fp)
+                extension_configs = yaml_load(fp)
             except Exception as e:
                 message = "Failed parsing extension config file: %s" % \
                           options.configfile


### PR DESCRIPTION
This should avoid any warnings. We use `unsafe_load` because users may
need to pass in actual Python objects. As this is only available from
the CLI, the user has much worse problems if an attacker can use this
as an attach vector.

See yaml/pyyaml#265 for an explanation of the changes in 5.1.