### PR TITLE
Bump version to 3.1

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,7 +3,7 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
-_______, 2018: Released version 3.1 ([Notes](release-3.1.md)).
+Mar 25, 2019: Released version 3.1 ([Notes](release-3.1.md)).
 
 Sept 28, 2018: Released version 3.0.1 (a bug-fix release).
 

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -198,14 +198,14 @@ The following options are provided to configure the output:
 
 * **`toc_depth`**
     Define the range of section levels to include in the Table of Contents.
-    A single integer (b) defines the bottom section level (<h1>..<hb>) only.
-    A string consisting of two digits separated by a hyphen in between ("2-5"),
-    define the top (t) and the bottom (b) (<ht>..<hb>). Defaults to `6` (bottom).
+    A single integer (`b`) defines the bottom section level (`<h1>..<hb>`) only.
+    A string consisting of two digits separated by a hyphen in between (`"2-5"`),
+    define the top (`t`) and the bottom (`b`) (`<ht>..<hb>`). Defaults to `6` (bottom).
 
     When used with conjunction with `baselevel`, this parameter will not
     take the fitted hierarchy from `baselevel` into account. That is, if
-    both `toc_depth` and `baselevel` are 3, then only the highest level
-    will be present in the table. If you set `baselevel` to 3 and
-    `toc_depth` to '2-6', the *first* headline will be `<h3>` and so still
+    both `toc_depth` and `baselevel` are `3`, then only the highest level
+    will be present in the table. If you set `baselevel` to `3` and
+    `toc_depth` to `"2-6"`, the *first* headline will be `<h3>` and so still
     included in the Table of Contents. To exclude this first level, you
-    have to set `toc_depth` to '4-6'.
+    have to set `toc_depth` to `"4-6"`.

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -43,7 +43,7 @@ __all__ = ['Markdown', 'markdown', 'markdownFromFile']
 # (1, 2, 0, 'beta', 2) => "1.2b2"
 # (1, 2, 0, 'rc', 4) => "1.2rc4"
 # (1, 2, 0, 'final', 0) => "1.2"
-__version_info__ = (3, 1, 0, 'dev', 0)
+__version_info__ = (3, 1, 0, 'final', 0)
 
 
 def _get_version():  # pragma: no cover


### PR DESCRIPTION
Version 3.1 has been in limbo for some time now. What we have is ready to go and the outstanding PRs are not ready yet, As they are big changes, I think we should just release 3.1 now and save #803 and #805 for 3.2. After all, there are some bug fixes in 3.1 I don't want to hold up any longer.