### PR TITLE
Split version info into a separate file, load it using imp/importlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
           packages:
           - aspell
           - aspell-en
+    - env: TOXENV=pep517check
 
 addons:
   apt:

--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,6 +3,11 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
+_______, 2019: Released version 3.1.1 (a bug-fix release).
+
+* Fixed import failure in `setup.py` when the source directory is not
+  on `sys.path` (#823).
+
 Mar 25, 2019: Released version 3.1 ([Notes](release-3.1.md)).
 
 Sept 28, 2018: Released version 3.0.1 (a bug-fix release).

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -25,46 +25,13 @@ from __future__ import unicode_literals
 from .core import Markdown, markdown, markdownFromFile
 from .util import PY37
 from .pep562 import Pep562
-from pkg_resources.extern import packaging
+from .__meta__ import __version__, __version_info__
 import warnings
 
 # For backward compatibility as some extensions expect it...
 from .extensions import Extension  # noqa
 
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
-
-# version must conform to PEP 440
-# https://www.python.org/dev/peps/pep-0440/
-
-# __version_info__ format:
-# (major, minor, patch, dev/alpha/beta/rc/final, #)
-# (1, 1, 2, 'dev', 0) => "1.1.2.dev0"
-# (1, 1, 2, 'alpha', 1) => "1.1.2a1"
-# (1, 2, 0, 'beta', 2) => "1.2b2"
-# (1, 2, 0, 'rc', 4) => "1.2rc4"
-# (1, 2, 0, 'final', 0) => "1.2"
-__version_info__ = (3, 1, 0, 'final', 0)
-
-
-def _get_version():  # pragma: no cover
-    " Returns a PEP 440-compliant version number from version_info. "
-    assert len(__version_info__) == 5
-    assert __version_info__[3] in ('dev', 'alpha', 'beta', 'rc', 'final')
-
-    parts = 2 if __version_info__[2] == 0 else 3
-    v = '.'.join(map(str, __version_info__[:parts]))
-
-    if __version_info__[3] == 'dev':
-        v += '.dev' + str(__version_info__[4])
-    elif __version_info__[3] != 'final':
-        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
-        v += mapping[__version_info__[3]] + str(__version_info__[4])
-
-    # Ensure version is valid and normalized
-    return str(packaging.version.Version(v))
-
-
-__version__ = _get_version()
 
 __deprecated__ = {
     "version": ("__version__", __version__),

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+Python Markdown
+
+A Python implementation of John Gruber's Markdown.
+
+Documentation: https://python-markdown.github.io/
+GitHub: https://github.com/Python-Markdown/markdown/
+PyPI: https://pypi.org/project/Markdown/
+
+Started by Manfred Stienstra (http://www.dwerg.net/).
+Maintained for a few years by Yuri Takhteyev (http://www.freewisdom.org).
+Currently maintained by Waylan Limberg (https://github.com/waylan),
+Dmitry Shachnev (https://github.com/mitya57) and Isaac Muse (https://github.com/facelessuser).
+
+Copyright 2007-2018 The Python Markdown Project (v. 1.7 and later)
+Copyright 2004, 2005, 2006 Yuri Takhteyev (v. 0.2-1.6b)
+Copyright 2004 Manfred Stienstra (the original version)
+
+License: BSD (see LICENSE.md for details).
+"""
+
+from pkg_resources.extern import packaging
+
+# __version_info__ format:
+# (major, minor, patch, dev/alpha/beta/rc/final, #)
+# (1, 1, 2, 'dev', 0) => "1.1.2.dev0"
+# (1, 1, 2, 'alpha', 1) => "1.1.2a1"
+# (1, 2, 0, 'beta', 2) => "1.2b2"
+# (1, 2, 0, 'rc', 4) => "1.2rc4"
+# (1, 2, 0, 'final', 0) => "1.2"
+__version_info__ = (3, 1, 0, 'final', 0)
+
+
+def _get_version():  # pragma: no cover
+    " Returns a PEP 440-compliant version number from version_info. "
+    assert len(__version_info__) == 5
+    assert __version_info__[3] in ('dev', 'alpha', 'beta', 'rc', 'final')
+
+    parts = 2 if __version_info__[2] == 0 else 3
+    v = '.'.join(map(str, __version_info__[:parts]))
+
+    if __version_info__[3] == 'dev':
+        v += '.dev' + str(__version_info__[4])
+    elif __version_info__[3] != 'final':
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
+        v += mapping[__version_info__[3]] + str(__version_info__[4])
+
+    # Ensure version is valid and normalized
+    return str(packaging.version.Version(v))
+
+
+__version__ = _get_version()

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,28 @@ License: BSD (see LICENSE.md for details).
 """
 
 
+import os
+import sys
 from setuptools import setup
-from markdown import __version__, __version_info__
 
+
+def get_version():
+    """Get version and version_info from markdown/__meta__.py file."""
+    module_path = os.path.join(os.path.dirname('__file__'), 'markdown', '__meta__.py')
+
+    if sys.version_info[0] == 2:
+        import imp
+        meta = imp.load_source('__meta__', module_path)
+        return meta.__version__, meta.__version_info__
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location('__meta__', module_path)
+    meta = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(meta)
+    return meta.__version__, meta.__version_info__
+
+
+__version__, __version_info__ = get_version()
 
 # Get development Status for classifiers
 dev_status_map = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, pypy, pypy3, flake8, checkspelling
+envlist = py27, py35, py36, py37, pypy, pypy3, flake8, checkspelling, pep517check
 requires = setuptools>=36
 isolated_build = True
 
@@ -18,6 +18,10 @@ deps =
     mkdocs
     mkdocs_nature
 commands = {toxinidir}/checkspelling.sh
+
+[testenv:pep517check]
+deps = pep517
+commands = python -m pep517.check {toxinidir}
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
To make sure `markdown` module is importable during installation.

It fixes Travis tests and also fixes `python3 -m pep517.check`, so I hope it closes #823.