### PR TITLE
Remove `install_requires=['setuptools >= 36']` from setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ addons:
     - libtidy-0.99-0
 
 install:
-  # NOTE: setuptools needs to be installed explicitly for py34 (trusty).
-  - pip install 'setuptools>=36' tox
+  - pip install tox
 
 script:
   - tox

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -20,11 +20,6 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-try:
-    import packaging.version
-except ImportError:
-    from pkg_resources.extern import packaging
-
 # __version_info__ format:
 # (major, minor, patch, dev/alpha/beta/rc/final, #)
 # (1, 1, 2, 'dev', 0) => "1.1.2.dev0"
@@ -49,8 +44,7 @@ def _get_version():  # pragma: no cover
         mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
         v += mapping[__version_info__[3]] + str(__version_info__[4])
 
-    # Ensure version is valid and normalized
-    return str(packaging.version.Version(v))
+    return v
 
 
 __version__ = _get_version()

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    install_requires=['setuptools >= 36'],
     extras_require={
         'testing': [
             'coverage',

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -1043,3 +1043,16 @@ class TestGeneralDeprecations(unittest.TestCase):
         self.assertTrue('__version__' in dir_attr)
         self.assertFalse('version_info' in dir_attr)
         self.assertTrue('__version_info__' in dir_attr)
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        self.assertIsInstance(markdown.__version_info__, tuple)
+        self.assertIsInstance(markdown.__version__, str)
+        # PEP 440 compliant.
+        # https://www.python.org/dev/peps/pep-0440/
+        regex = r'[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|b|rc|\.dev)[0-9]+)?'
+        if PY3:
+            self.assertRegex(markdown.__version__, regex)
+        else:
+            self.assertRegexpMatches(markdown.__version__, regex)


### PR DESCRIPTION
A modern seutptools is required at build time, not install time. Adding
setuptools to install_requires does not play nice with pip-tools. It
leaves a very large warning at the bottom of requirements.txt files:

    # WARNING: The following packages were not pinned, but pip requires them to be
    # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
    # setuptools==41.0.1        # via markdown

This becomes an issue when installing packages with --require-hashes as
now setuptools is not pinned. This results in the error:

    In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
        setuptools>=36 from ... (from markdown==3.1.1->-r .../requirements.txt (line 30))