### PR TITLE
Remove unnecessary calls to dict.keys()

### DIFF
--- a/markdown/core.py
+++ b/markdown/core.py
@@ -210,7 +210,7 @@ class Markdown(object):
         try:
             self.serializer = self.output_formats[self.output_format]
         except KeyError as e:
-            valid_formats = list(self.output_formats.keys())
+            valid_formats = list(self.output_formats)
             valid_formats.sort()
             message = 'Invalid Output Format: "%s". Use one of %s.' \
                 % (self.output_format,

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -50,11 +50,11 @@ class Extension(object):
 
     def getConfigs(self):
         """ Return all configs settings as a dict. """
-        return dict([(key, self.getConfig(key)) for key in self.config.keys()])
+        return dict([(key, self.getConfig(key)) for key in self.config])
 
     def getConfigInfo(self):
         """ Return all config descriptions as a list of tuples. """
-        return [(key, self.config[key][1]) for key in self.config.keys()]
+        return [(key, self.config[key][1]) for key in self.config]
 
     def setConfig(self, key, value):
         """ Set a config setting for `key` with the given `value`. """

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -164,7 +164,7 @@ class FootnoteExtension(Extension):
     def makeFootnotesDiv(self, root):
         """ Return div of footnotes as et Element. """
 
-        if not list(self.footnotes.keys()):
+        if not self.footnotes:
             return None
 
         div = util.etree.Element("div")
@@ -173,7 +173,7 @@ class FootnoteExtension(Extension):
         ol = util.etree.SubElement(div, "ol")
         surrogate_parent = util.etree.Element("div")
 
-        for index, id in enumerate(self.footnotes.keys(), start=1):
+        for index, id in enumerate(self.footnotes, start=1):
             li = util.etree.SubElement(ol, "li")
             li.set("id", self.makeFootnoteId(id))
             # Parse footnote with surrogate parent as li cannot be used.
@@ -314,13 +314,13 @@ class FootnoteInlineProcessor(InlineProcessor):
 
     def handleMatch(self, m, data):
         id = m.group(1)
-        if id in self.footnotes.footnotes.keys():
+        if id in self.footnotes.footnotes:
             sup = util.etree.Element("sup")
             a = util.etree.SubElement(sup, "a")
             sup.set('id', self.footnotes.makeFootnoteRefId(id, found=True))
             a.set('href', '#' + self.footnotes.makeFootnoteId(id))
             a.set('class', 'footnote-ref')
-            a.text = util.text_type(list(self.footnotes.footnotes.keys()).index(id) + 1)
+            a.text = util.text_type(list(self.footnotes.footnotes).index(id) + 1)
             return sup, m.start(0), m.end(0)
         else:
             return None, None, None

--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -184,7 +184,7 @@ class HtmlBlockPreprocessor(Preprocessor):
                     left_tag, left_index, ''.join(items[i:]))
                 right_listindex = \
                     self._stringindex_to_listindex(data_index, items[i:]) + i
-                if 'markdown' in attrs.keys():
+                if 'markdown' in attrs:
                     items[i] = items[i][left_index:]  # remove opening tag
                     placeholder = self.md.htmlStash.store_tag(
                         left_tag, attrs, i + 1, right_listindex + 1)
@@ -249,7 +249,7 @@ class HtmlBlockPreprocessor(Preprocessor):
 
                     if block.rstrip().endswith(">") \
                             and self._equal_tags(left_tag, right_tag):
-                        if self.markdown_in_raw and 'markdown' in attrs.keys():
+                        if self.markdown_in_raw and 'markdown' in attrs:
                             block = block[left_index:-len(right_tag) - 2]
                             new_blocks.append(self.md.htmlStash.
                                               store_tag(left_tag, attrs, 0, 2))
@@ -293,7 +293,7 @@ class HtmlBlockPreprocessor(Preprocessor):
                         text.insert(0, block[data_index:])
 
                     in_tag = False
-                    if self.markdown_in_raw and 'markdown' in attrs.keys():
+                    if self.markdown_in_raw and 'markdown' in attrs:
                         items[0] = items[0][left_index:]
                         items[-1] = items[-1][:-len(right_tag) - 2]
                         if items[len(items) - 1]:  # not a newline/empty string
@@ -315,7 +315,7 @@ class HtmlBlockPreprocessor(Preprocessor):
                     items = []
 
         if items:
-            if self.markdown_in_raw and 'markdown' in attrs.keys():
+            if self.markdown_in_raw and 'markdown' in attrs:
                 items[0] = items[0][left_index:]
                 items[-1] = items[-1][:-len(right_tag) - 2]
                 if items[len(items) - 1]:  # not a newline/empty string

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -296,7 +296,7 @@ class Registry(object):
     def __contains__(self, item):
         if isinstance(item, string_type):
             # Check if an item exists by this name.
-            return item in self._data.keys()
+            return item in self._data
         # Check if this instance exists.
         return item in self._data.values()
 


### PR DESCRIPTION
In modern Python, iter(dict) is equivalent to iter(dict.keys()). There
is normally no reason to add the extra method call.

Inspired by Lennart Regebro's talk "Prehistoric Patterns in Python" at
PyCon 2017.

https://www.youtube.com/watch?v=V5-JH23Vk0I