### PR TITLE
Run pyupgrade across the code base

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -259,7 +259,7 @@ class CodeBlockProcessor(BlockProcessor):
             code = sibling[0]
             block, theRest = self.detab(block)
             code.text = util.AtomicString(
-                '%s\n%s\n' % (code.text, util.code_escape(block.rstrip()))
+                '{}\n{}\n'.format(code.text, util.code_escape(block.rstrip()))
             )
         else:
             # This is a new codeblock. Create the elements and insert text.
@@ -421,12 +421,12 @@ class OListProcessor(BlockProcessor):
                 # This is an indented (possibly nested) item.
                 if items[-1].startswith(' '*self.tab_length):
                     # Previous item was indented. Append to that item.
-                    items[-1] = '%s\n%s' % (items[-1], line)
+                    items[-1] = '{}\n{}'.format(items[-1], line)
                 else:
                     items.append(line)
             else:
                 # This is another line of previous item. Append to that item.
-                items[-1] = '%s\n%s' % (items[-1], line)
+                items[-1] = '{}\n{}'.format(items[-1], line)
         return items
 
 
@@ -553,7 +553,7 @@ class EmptyBlockProcessor(BlockProcessor):
            len(sibling) and sibling[0].tag == 'code'):
             # Last block is a codeblock. Append to preserve whitespace.
             sibling[0].text = util.AtomicString(
-                '%s%s' % (sibling[0].text, filler)
+                '{}{}'.format(sibling[0].text, filler)
             )
 
 
@@ -580,13 +580,13 @@ class ParagraphProcessor(BlockProcessor):
                 if sibling is not None:
                     # Insetrt after sibling.
                     if sibling.tail:
-                        sibling.tail = '%s\n%s' % (sibling.tail, block)
+                        sibling.tail = '{}\n{}'.format(sibling.tail, block)
                     else:
                         sibling.tail = '\n%s' % block
                 else:
                     # Append to parent.text
                     if parent.text:
-                        parent.text = '%s\n%s' % (parent.text, block)
+                        parent.text = '{}\n{}'.format(parent.text, block)
                     else:
                         parent.text = block.lstrip()
             else:

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -132,7 +132,7 @@ class Markdown(object):
                 )
             elif ext is not None:
                 raise TypeError(
-                    'Extension "%s.%s" must be of type: "%s.%s"' % (
+                    'Extension "{}.{}" must be of type: "{}.{}"'.format(
                         ext.__class__.__module__, ext.__class__.__name__,
                         Extension.__module__, Extension.__name__
                     )

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -50,7 +50,7 @@ class Extension(object):
 
     def getConfigs(self):
         """ Return all configs settings as a dict. """
-        return dict([(key, self.getConfig(key)) for key in self.config.keys()])
+        return {key: self.getConfig(key) for key in self.config}
 
     def getConfigInfo(self):
         """ Return all config descriptions as a list of tuples. """
@@ -81,7 +81,7 @@ class Extension(object):
             # Must be a 2.x extension. Pass in a dumby md_globals.
             self.extendMarkdown(md, {})
             warnings.warn(
-                "The 'md_globals' parameter of '{0}.{1}.extendMarkdown' is "
+                "The 'md_globals' parameter of '{}.{}.extendMarkdown' is "
                 "deprecated.".format(self.__class__.__module__, self.__class__.__name__),
                 category=DeprecationWarning,
                 stacklevel=2

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -61,7 +61,7 @@ class AdmonitionProcessor(BlockProcessor):
         if m:
             klass, title = self.get_class_and_title(m)
             div = etree.SubElement(parent, 'div')
-            div.set('class', '%s %s' % (self.CLASSNAME, klass))
+            div.set('class', '{} {}'.format(self.CLASSNAME, klass))
             if title:
                 p = etree.SubElement(div, 'p')
                 p.text = title

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -145,7 +145,7 @@ class AttrListTreeprocessor(Treeprocessor):
                 # add to class
                 cls = elem.get('class')
                 if cls:
-                    elem.set('class', '%s %s' % (cls, v))
+                    elem.set('class', '{} {}'.format(cls, v))
                 else:
                     elem.set('class', v)
             else:

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -45,7 +45,7 @@ class DefListProcessor(BlockProcessor):
         else:
             d, theRest = self.detab(block)
         if d:
-            d = '%s\n%s' % (m.group(2), d)
+            d = '{}\n{}'.format(m.group(2), d)
         else:
             d = m.group(2)
         sibling = self.lastChild(parent)

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -91,9 +91,9 @@ class FencedBlockPreprocessor(Preprocessor):
                                              self._escape(m.group('code')))
 
                 placeholder = self.md.htmlStash.store(code)
-                text = '%s\n%s\n%s' % (text[:m.start()],
-                                       placeholder,
-                                       text[m.end():])
+                text = '{}\n{}\n{}'.format(text[:m.start()],
+                                           placeholder,
+                                           text[m.end():])
             else:
                 break
         return text.split("\n")

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -152,14 +152,14 @@ class FootnoteExtension(Extension):
         if self.getConfig("UNIQUE_IDS"):
             return 'fn%s%d-%s' % (self.get_separator(), self.unique_prefix, id)
         else:
-            return 'fn%s%s' % (self.get_separator(), id)
+            return 'fn{}{}'.format(self.get_separator(), id)
 
     def makeFootnoteRefId(self, id, found=False):
         """ Return footnote back-link id. """
         if self.getConfig("UNIQUE_IDS"):
             return self.unique_ref('fnref%s%d-%s' % (self.get_separator(), self.unique_prefix, id), found)
         else:
-            return self.unique_ref('fnref%s%s' % (self.get_separator(), id), found)
+            return self.unique_ref('fnref{}{}'.format(self.get_separator(), id), found)
 
     def makeFootnotesDiv(self, root):
         """ Return div of footnotes as et Element. """
@@ -355,7 +355,7 @@ class FootnotePostTreeprocessor(Treeprocessor):
     def get_num_duplicates(self, li):
         """ Get the number of duplicate refs of the footnote. """
         fn, rest = li.attrib.get('id', '').split(self.footnotes.get_separator(), 1)
-        link_id = '%sref%s%s' % (fn, self.footnotes.get_separator(), rest)
+        link_id = '{}ref{}{}'.format(fn, self.footnotes.get_separator(), rest)
         return self.footnotes.found_refs.get(link_id, 0)
 
     def handle_duplicates(self, parent):

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -26,7 +26,7 @@ import re
 def build_url(label, base, end):
     """ Build a url from the label, a base, and an end. """
     clean_label = re.sub(r'([ ]+_)|(_[ ]+)|([ ]+)', '_', label)
-    return '%s%s%s' % (base, clean_label, end)
+    return '{}{}{}'.format(base, clean_label, end)
 
 
 class WikiLinkExtension(Extension):

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -308,7 +308,7 @@ class EscapeInlineProcessor(InlineProcessor):
     def handleMatch(self, m, data):
         char = m.group(1)
         if char in self.md.ESCAPED_CHARS:
-            return '%s%s%s' % (util.STX, ord(char), util.ETX), m.start(0), m.end(0)
+            return '{}{}{}'.format(util.STX, ord(char), util.ETX), m.start(0), m.end(0)
         else:
             return None, m.start(0), m.end(0)
 
@@ -361,7 +361,7 @@ class BacktickInlineProcessor(InlineProcessor):
     """ Return a `<code>` element containing the matching text. """
     def __init__(self, pattern):
         InlineProcessor.__init__(self, pattern)
-        self.ESCAPED_BSLASH = '%s%s%s' % (util.STX, ord('\\'), util.ETX)
+        self.ESCAPED_BSLASH = '{}{}{}'.format(util.STX, ord('\\'), util.ETX)
         self.tag = 'code'
 
     def handleMatch(self, m, data):
@@ -708,7 +708,7 @@ class AutomailInlineProcessor(InlineProcessor):
             """Return entity definition by code, or the code if not defined."""
             entity = entities.codepoint2name.get(code)
             if entity:
-                return "%s%s;" % (util.AMP_SUBSTITUTE, entity)
+                return "{}{};".format(util.AMP_SUBSTITUTE, entity)
             else:
                 return "%s#%d;" % (util.AMP_SUBSTITUTE, code)
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -111,7 +111,7 @@ class AndSubstitutePostprocessor(Postprocessor):
 class UnescapePostprocessor(Postprocessor):
     """ Restore escaped chars """
 
-    RE = re.compile(r'%s(\d+)%s' % (util.STX, util.ETX))
+    RE = re.compile(r'{}(\d+){}'.format(util.STX, util.ETX))
 
     def unescape(self, m):
         return util.int2str(int(m.group(1)))

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -63,7 +63,7 @@ except NameError:  # pragma: no cover
 
 def _raise_serialization_error(text):  # pragma: no cover
     raise TypeError(
-        "cannot serialize %r (type %s)" % (text, type(text).__name__)
+        "cannot serialize {!r} (type {})".format(text, type(text).__name__)
         )
 
 
@@ -158,7 +158,7 @@ def _serialize_html(write, elem, format):
                     # handle boolean attributes
                     write(" %s" % v)
                 else:
-                    write(' %s="%s"' % (k, v))
+                    write(' {}="{}"'.format(k, v))
         if namespace_uri:
             write(' xmlns="%s"' % (_escape_attrib(namespace_uri)))
         if format == "xhtml" and tag.lower() in HTML_EMPTY:

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -310,12 +310,12 @@ class InlineProcessor(Treeprocessor):
         placeholder = self.__stashNode(node, pattern.type())
 
         if new_style:
-            return "%s%s%s" % (data[:start],
-                               placeholder, data[end:]), True, 0
+            return "{}{}{}".format(data[:start],
+                                   placeholder, data[end:]), True, 0
         else:  # pragma: no cover
-            return "%s%s%s%s" % (leftData,
-                                 match.group(1),
-                                 placeholder, match.groups()[-1]), True, 0
+            return "{}{}{}{}".format(leftData,
+                                     match.group(1),
+                                     placeholder, match.groups()[-1]), True, 0
 
     def __build_ancestors(self, parent, parents):
         """Build the ancestor list."""
@@ -351,7 +351,7 @@ class InlineProcessor(Treeprocessor):
         # to ensure we don't have the user accidentally change it on us.
         tree_parents = [] if ancestors is None else ancestors[:]
 
-        self.parent_map = dict((c, p) for p in tree.iter() for c in p)
+        self.parent_map = {c: p for p in tree.iter() for c in p}
         stack = [(tree, tree_parents)]
 
         while stack:

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -319,7 +319,7 @@ class Registry(object):
         return len(self._priority)
 
     def __repr__(self):
-        return '<{0}({1})>'.format(self.__class__.__name__, list(self))
+        return '<{}({})>'.format(self.__class__.__name__, list(self))
 
     def get_index_for_name(self, name):
         """
@@ -330,7 +330,7 @@ class Registry(object):
             return self._priority.index(
                 [x for x in self._priority if x.name == name][0]
             )
-        raise ValueError('No item named "{0}" exists.'.format(name))
+        raise ValueError('No item named "{}" exists.'.format(name))
 
     def register(self, item, name, priority):
         """

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -37,8 +37,8 @@ class TestCaseWithAssertStartsWith(unittest.TestCase):
         if not text.startswith(expectedPrefix):
             if len(expectedPrefix) + 5 < len(text):
                 text = text[:len(expectedPrefix) + 5] + '...'
-            standardMsg = '%s not found at the start of %s' % (repr(expectedPrefix),
-                                                               repr(text))
+            standardMsg = '{} not found at the start of {}'.format(repr(expectedPrefix),
+                                                                   repr(text))
             self.fail(self._formatMessage(msg, standardMsg))
 
 
@@ -982,9 +982,9 @@ class TestTOC(TestCaseWithAssertStartsWith):
     def testUniqueFunc(self):
         """ Test 'unique' function. """
         from markdown.extensions.toc import unique
-        ids = set(['foo'])
+        ids = {'foo'}
         self.assertEqual(unique('foo', ids), 'foo_1')
-        self.assertEqual(ids, set(['foo', 'foo_1']))
+        self.assertEqual(ids, {'foo', 'foo_1'})
 
     def testTocInHeaders(self):
 


### PR DESCRIPTION
The pyupgrade tool automatically upgrades syntax and patterns to newer
versions of Python.

- Use dict comprehension.
- Use set literals.
- Remove unnecessary numeric placeholders from string formatting.
- Replace modulus string formatting with .format().