### PR TITLE
Use skip_install=true for lint targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27, py35, py36, py37, pypy, pypy3, flake8, checkspelling, pep517check
 requires = setuptools>=36
 isolated_build = True
+min_verison = 1.9
 
 [testenv]
 extras = testing
@@ -12,6 +13,7 @@ commands = coverage run --source=markdown -m unittest discover {toxinidir}/tests
 [testenv:flake8]
 deps = flake8
 commands = flake8 {toxinidir}/markdown {toxinidir}/tests {toxinidir}/setup.py
+skip_install = true
 
 [testenv:checkspelling]
 deps =
@@ -22,6 +24,7 @@ commands = {toxinidir}/checkspelling.sh
 [testenv:pep517check]
 deps = pep517
 commands = python -m pep517.check {toxinidir}
+skip_install = true
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
Avoids installing the package (and any potential dependencies) to the
virtualenv before running lint or static commands. The package is not
required to be installed to do simple static code analysis. Results in a
slightly faster run, as fetching and installing dependencies is skipped.

For additional information on the configuration option, see:

https://tox.readthedocs.io/en/latest/config.html#confval-skip_install=BOOL

> Do not install the current package. This can be used when you need the
> virtualenv management but do not want to install the current package
> into that environment.