### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [codecov-button]: https://codecov.io/gh/Python-Markdown/markdown/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/Python-Markdown/markdown
 [mdversion-button]: http://img.shields.io/pypi/v/Markdown.svg
-[md-pypi]: http://pypi.python.org/pypi/Markdown
+[md-pypi]: https://pypi.org/project/Markdown/
 [pyversion-button]: http://img.shields.io/pypi/pyversions/Markdown.svg
 [bsdlicense-button]: http://img.shields.io/badge/license-BSD-yellow.svg
 [bsdlicense]: http://opensource.org/licenses/BSD-3-Clause

--- a/docs/change_log/release-2.5.md
+++ b/docs/change_log/release-2.5.md
@@ -14,7 +14,7 @@ Backwards-incompatible Changes
 * Python-Markdown no longer supports Python version 2.6. You must be using Python
   versions 2.7, 3.2, 3.3, or 3.4.
 
-[importlib]: https://pypi.python.org/pypi/importlib
+[importlib]: https://pypi.org/project/importlib/
 
 * The `force_linenos` configuration key on the [CodeHilite Extension] has been **deprecated**
   and will raise a `KeyError` if provided. In the previous release (2.4), it was


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html