### PR TITLE
Update cli.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,7 +160,7 @@ myext:
     option2: True
 ```
 
-Similarly, a [JSON] config file might look like this:
+Similarly, a [JSON] configuration file might look like this:
 
 ```json
 {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -174,7 +174,9 @@ Similarly, a [JSON] configuration file might look like this:
 
 Note that while the `--extension_configs` option does specify the
 `myext` extension, you still need to load the extension with the `-x` option,
-or the configuration for that extension will be ignored.
+or the configuration for that extension will be ignored. Further, if an
+extension requires a value that cannot be parsed in [JSON] (for example a
+reference to a function), one has to use a YML configuration file.
 
 The `--extension_configs` option will only support YAML configuration files if
 [PyYAML] is installed on your system. JSON should work with no additional

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,7 +160,7 @@ myext:
     option2: True
 ```
 
-Similarly, a [JSON] configuration file might look like this:
+Similarly, a JSON configuration file might look like this:
 
 ```json
 {
@@ -175,8 +175,8 @@ Similarly, a [JSON] configuration file might look like this:
 Note that while the `--extension_configs` option does specify the
 `myext` extension, you still need to load the extension with the `-x` option,
 or the configuration for that extension will be ignored. Further, if an
-extension requires a value that cannot be parsed in [JSON] (for example a
-reference to a function), one has to use a YML configuration file.
+extension requires a value that cannot be parsed in JSON (for example a
+reference to a function), one has to use a YAML configuration file.
 
 The `--extension_configs` option will only support YAML configuration files if
 [PyYAML] is installed on your system. JSON should work with no additional

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,6 +160,18 @@ myext:
     option2: True
 ```
 
+Similarly, a [JSON] config file might look like this:
+
+```json
+{
+  "myext":
+  {
+    "option1": "value1",
+    "option2": "value2"
+  }
+}
+```
+
 Note that while the `--extension_configs` option does specify the
 `myext` extension, you still need to load the extension with the `-x` option,
 or the configuration for that extension will be ignored.


### PR DESCRIPTION
closes #844
Add a JSON config file example for the CLI

Outstanding questions
- do I need to write and/or run tests for the contribution to documentation?
- how would I add non-json type values in a json config file? For example, [PyMdown Extensions][pymdownx] [emoji][pymdownx-emoji] extension has an option `emoji_index` which seems to take a reference to a function or a module as its input. This can be seen in the [Github-ish Configurations][pymdownx-faq] FAQ in PyMdown's docs. I tried passing `"emoji_index": "pymdownx.emoji.gemoji"` through a json config file, but that failed. So perhaps thats a limitation of the json configs file...

[pymdownx]: https://facelessuser.github.io/pymdown-extensions/
[pymdownx-emoji]: https://facelessuser.github.io/pymdown-extensions/extensions/emoji/
[pymdownx-faq]: https://facelessuser.github.io/pymdown-extensions/faq/