### PR TITLE
Proposal: Add support for definition terms <dt> in TOC

### DIFF
--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -238,7 +238,7 @@ class TocTreeprocessor(Treeprocessor):
 
         toc_tokens = []
         for el in doc.iter():
-            if not isinstance(el.tag, string_type)
+            if not isinstance(el.tag, string_type):
                 continue
 
             level = None

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -247,7 +247,7 @@ class TocTreeprocessor(Treeprocessor):
                 self.set_level(el)
                 # Then get its level.
                 level = int(el.tag[-1])
-            else if self.dt_rgx.match(el.tag):
+            elif self.dt_rgx.match(el.tag):
                 # Definition terms are outside of the header hierarchy,
                 # so let's give them a 7.
                 level = 7 + self.base_level


### PR DESCRIPTION
This is a need that showed up for me recently. In a glossary document, it's nice to have definition terms show up in the table of contents and have those permalinks and anchors added. This permits deep-linking into glossaries from other resources.

By default, this functionality is turned off -- the default depth is still 6, but `<dt>` elements get an imaginary hierarchy depth of 7. Turning this functionality on is as simple as specifying `toc_depth: 7`. The assumption here is that, if people don't want `h6` elements in their hierarchy, they probably won't want `<dt>`s in there either.

If this feature seems useful enough to warrant inclusion, I request a pair of eyes to look over two concerns (will create a review to comment on the specific lines).

Apologies for the big diff; if I didn't had to de-indent a bunch of lines, the diff would be much smaller.