### PR TITLE
Bump version to 3.2.dev0.

### DIFF
--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -31,7 +31,7 @@ except ImportError:
 # (1, 2, 0, 'beta', 2) => "1.2b2"
 # (1, 2, 0, 'rc', 4) => "1.2rc4"
 # (1, 2, 0, 'final', 0) => "1.2"
-__version_info__ = (3, 1, 1, 'final', 0)
+__version_info__ = (3, 2, 0, 'dev', 0)
 
 
 def _get_version():  # pragma: no cover


### PR DESCRIPTION
As per the Contributing Guide, this should have happened before we commited
various 3.2 related changes. In any event, version 3.2 is now officially in
development status.