### PR TITLE
Show readable error on Python2

### DIFF
--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -19,6 +19,12 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
+import sys
+
+# TODO: Remove this check at some point in the future.
+if sys.version_info[0] < 3:  # pragma: no cover
+    raise ImportError('A recent version of Python 3 is required.')
+
 from .core import Markdown, markdown, markdownFromFile
 from .util import PY37
 from .pep562 import Pep562

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -22,14 +22,15 @@ License: BSD (see LICENSE.md for details).
 import sys
 
 # TODO: Remove this check at some point in the future.
+# (also remove flake8's 'ignore E402' comments below)
 if sys.version_info[0] < 3:  # pragma: no cover
     raise ImportError('A recent version of Python 3 is required.')
 
-from .core import Markdown, markdown, markdownFromFile
-from .util import PY37
-from .pep562 import Pep562
-from .__meta__ import __version__, __version_info__
-import warnings
+from .core import Markdown, markdown, markdownFromFile  # noqa: E402
+from .util import PY37                                  # noqa: E402
+from .pep562 import Pep562                              # noqa: E402
+from .__meta__ import __version__, __version_info__     # noqa: E402
+import warnings                                         # noqa: E402
 
 # For backward compatibility as some extensions expect it...
 from .extensions import Extension  # noqa


### PR DESCRIPTION
Ensures anyone still using Python 2 gets a readable error message.
This does not specify a specific version number to remove the maintenance
burden of updating it with each future release. It will likely get removed
in the next few releases as it will have served its purpose by then.
Fixes #871