### PR TITLE
Unescape IDs in TOC.

### DIFF
--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -16,6 +16,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 from . import Extension
 from ..treeprocessors import Treeprocessor
 from ..util import etree, parseBoolValue, AMP_SUBSTITUTE, HTML_PLACEHOLDER_RE
+from ..postprocessors import UnescapePostprocessor
 import re
 import unicodedata
 
@@ -54,6 +55,12 @@ def stashedHTML2text(text, md):
         return re.sub(r'(<[^>]+>)|(&[\#a-zA-Z0-9]+;)', '', raw)
 
     return HTML_PLACEHOLDER_RE.sub(_html_sub, text)
+
+
+def unescape(text):
+    """ Unescape escaped text. """
+    c = UnescapePostprocessor()
+    return c.run(text)
 
 
 def nest_toc_tokens(toc_list):
@@ -242,7 +249,7 @@ class TocTreeprocessor(Treeprocessor):
 
                 # Do not override pre-existing ids
                 if "id" not in el.attrib:
-                    innertext = stashedHTML2text(text, self.md)
+                    innertext = unescape(stashedHTML2text(text, self.md))
                     el.attrib["id"] = unique(self.slugify(innertext, self.sep), used_ids)
 
                 toc_tokens.append({

--- a/tests/test_syntax/extensions/test_toc.py
+++ b/tests/test_syntax/extensions/test_toc.py
@@ -1,0 +1,34 @@
+"""
+Python Markdown
+
+A Python implementation of John Gruber's Markdown.
+
+Documentation: https://python-markdown.github.io/
+GitHub: https://github.com/Python-Markdown/markdown/
+PyPI: https://pypi.org/project/Markdown/
+
+Started by Manfred Stienstra (http://www.dwerg.net/).
+Maintained for a few years by Yuri Takhteyev (http://www.freewisdom.org).
+Currently maintained by Waylan Limberg (https://github.com/waylan),
+Dmitry Shachnev (https://github.com/mitya57) and Isaac Muse (https://github.com/facelessuser).
+
+Copyright 2007-2019 The Python Markdown Project (v. 1.7 and later)
+Copyright 2004, 2005, 2006 Yuri Takhteyev (v. 0.2-1.6b)
+Copyright 2004 Manfred Stienstra (the original version)
+
+License: BSD (see LICENSE.md for details).
+"""
+
+from markdown.test_tools import TestCase
+
+
+class TestTOC(TestCase):
+
+    # TODO: Move the rest of the TOC tests here.
+
+    def test_escaped_char_in_id(self):
+        self.assertMarkdownRenders(
+            r'# escaped\_character',
+            '<h1 id="escaped_character">escaped_character</h1>',
+            extensions=['toc']
+        )


### PR DESCRIPTION
The slugify function will stript the STX and ETX characters from
placeholders for backslash excaped characters. Therefore, we need
to unescape any text before passing it to slugify. Fixes #864.