### PR TITLE
Remove tox.ini from MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ recursive-include docs *
 recursive-include tests *.txt *.html *.py
 include setup.py
 include setup.cfg
-include tox.ini
 include makefile
 include LICENSE.md
 include README.md


### PR DESCRIPTION
Tox has already been removed from `make test` and is no longer recommended
for testing in the contributing guide. Additionally, the extra tests it runs
(checking the spelling of documentation, etc) are of no value to end users.
As things are currently set us, tox is only used on the Travis CI server.
Given the above, there is no reason to include it in the release tarball.
Closes #808.