### PR TITLE
Simplify xml.etree.ElementTree loading

### DIFF
--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -49,15 +49,19 @@ Internally, this change relies on the Pygments 2.4, so you must be using at leas
 that version to see this effect. Users with earlier Pygments versions will
 continue to see the old behavior.
 
-### markdown.util.etree deprecated
+### `markdown.util.etree` deprecated
 
-Previously, Python-Markdown was using either `xml.etree.cElementTree` module or
-`xml.etree.ElementTree`, based on their availability. In modern Python versions,
-the former is a deprecated alias for the latter. Thus, the compatibility layer is
-deprecated and applications are advised to use `xml.etree.ElementTree` directly.
+Previously, Python-Markdown was using either the `xml.etree.cElementTree` module
+or the `xml.etree.ElementTree` module, based on their availability. In modern
+Python versions, the former is a deprecated alias for the latter. Thus, the
+compatibility layer is deprecated and extensions are advised to use 
+`xml.etree.ElementTree` directly. Importing `markdown.util.etree` will raise
+a `DeprecationWarning` begining in version 3.2 and may be removed in a future
+release. 
 
-If the code of your extension used `from markdown.util import etree`, replace it
-with `import xml.etree.ElementTree as etree`.
+Therefore, extension developers are encouraged to replace
+`from markdown.util import etree` with
+`import xml.etree.ElementTree as etree` in their code.
 
 ## New features
 

--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -56,7 +56,7 @@ or the `xml.etree.ElementTree` module, based on their availability. In modern
 Python versions, the former is a deprecated alias for the latter. Thus, the
 compatibility layer is deprecated and extensions are advised to use 
 `xml.etree.ElementTree` directly. Importing `markdown.util.etree` will raise
-a `DeprecationWarning` begining in version 3.2 and may be removed in a future
+a `DeprecationWarning` beginning in version 3.2 and may be removed in a future
 release. 
 
 Therefore, extension developers are encouraged to replace

--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -49,6 +49,16 @@ Internally, this change relies on the Pygments 2.4, so you must be using at leas
 that version to see this effect. Users with earlier Pygments versions will
 continue to see the old behavior.
 
+### markdown.util.etree deprecated
+
+Previously, Python-Markdown was using either `xml.etree.cElementTree` module or
+`xml.etree.ElementTree`, based on their availability. In modern Python versions,
+the former is a deprecated alias for the latter. Thus, the compatibility layer is
+deprecated and applications are advised to use `xml.etree.ElementTree` directly.
+
+If the code of your extension used `from markdown.util import etree`, replace it
+with `import xml.etree.ElementTree as etree`.
+
 ## New features
 
 The following new features have been included in the release:

--- a/docs/extensions/api.md
+++ b/docs/extensions/api.md
@@ -82,7 +82,7 @@ For an example, consider this simplified emphasis pattern:
 
 ```python
 from markdown.inlinepatterns import Pattern
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 
 class EmphasisPattern(Pattern):
     def handleMatch(self, m):
@@ -141,7 +141,7 @@ you'll need.
 
 ```python
 from markdown.inlinepatterns import InlineProcessor
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 
 # an oversimplified regex
 MYPATTERN = r'\*([^*]+)\*'
@@ -184,7 +184,7 @@ in order to communicate to the parser that no match was found.
         if not handled:
             return None, None, None
 
-        el = util.etree.Element("a")
+        el = etree.Element("a")
         el.text = text
 
         el.set("href", href)
@@ -429,21 +429,11 @@ As mentioned, the Markdown parser converts a source document to an
 Markdown has provided some helpers to ease that manipulation within the context
 of the Markdown module.
 
-First, to get access to the ElementTree module import ElementTree from
-`markdown` rather than importing it directly. This will ensure you are using
-the same version of ElementTree as markdown. The module is found at
-`markdown.util.etree` within Markdown.
+First, import the ElementTree module:
 
 ```python
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 ```
-
-`markdown.util.etree` tries to import ElementTree from any known location,
-first as a standard library module (from `xml.etree` in Python 2.5), then as
-a third party package (ElementTree). In each instance, `cElementTree` is
-tried first, then ElementTree if the faster C implementation is not
-available on your system.
-
 Sometimes you may want text inserted into an element to be parsed by
 [Inline Patterns][]. In such a situation, simply insert the text as you normally
 would and the text will be automatically run through the Inline Patterns.
@@ -482,7 +472,7 @@ def set_link_class(self, element):
 
 For more information about working with ElementTree see the ElementTree
 [Documentation](https://effbot.org/zone/element-index.htm)
-([Python Docs](http://docs.python.org/lib/module-xml.etree.ElementTree.html)).
+([Python Docs](https://docs.python.org/3/library/xml.etree.elementtree.html)).
 
 ## Integrating Your Code Into Markdown {: #integrating_into_markdown }
 

--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -19,6 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
+import xml.etree.ElementTree as etree
 from . import util
 
 
@@ -85,9 +86,9 @@ class BlockParser:
 
         """
         # Create a ElementTree from the lines
-        self.root = util.etree.Element(self.md.doc_tag)
+        self.root = etree.Element(self.md.doc_tag)
         self.parseChunk(self.root, '\n'.join(lines))
-        return util.etree.ElementTree(self.root)
+        return etree.ElementTree(self.root)
 
     def parseChunk(self, parent, text):
         """ Parse a chunk of markdown text and attach to given etree node.

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -32,6 +32,7 @@ as they need to alter how markdown blocks are parsed.
 
 import logging
 import re
+import xml.etree.ElementTree as etree
 from . import util
 from .blockparser import BlockParser
 
@@ -194,7 +195,7 @@ class ListIndentProcessor(BlockProcessor):
                 # If the parent li has text, that text needs to be moved to a p
                 # The p must be 'inserted' at beginning of list in the event
                 # that other children already exist i.e.; a nested sublist.
-                p = util.etree.Element('p')
+                p = etree.Element('p')
                 p.text = sibling[-1].text
                 sibling[-1].text = ''
                 sibling[-1].insert(0, p)
@@ -205,7 +206,7 @@ class ListIndentProcessor(BlockProcessor):
 
     def create_item(self, parent, block):
         """ Create a new li and parse the block with it as the parent. """
-        li = util.etree.SubElement(parent, 'li')
+        li = etree.SubElement(parent, 'li')
         self.parser.parseBlocks(li, [block])
 
     def get_level(self, parent, block):
@@ -259,8 +260,8 @@ class CodeBlockProcessor(BlockProcessor):
             )
         else:
             # This is a new codeblock. Create the elements and insert text.
-            pre = util.etree.SubElement(parent, 'pre')
-            code = util.etree.SubElement(pre, 'code')
+            pre = etree.SubElement(parent, 'pre')
+            code = etree.SubElement(pre, 'code')
             block, theRest = self.detab(block)
             code.text = util.AtomicString('%s\n' % util.code_escape(block.rstrip()))
         if theRest:
@@ -294,7 +295,7 @@ class BlockQuoteProcessor(BlockProcessor):
             quote = sibling
         else:
             # This is a new blockquote. Create a new parent element.
-            quote = util.etree.SubElement(parent, 'blockquote')
+            quote = etree.SubElement(parent, 'blockquote')
         # Recursively parse block with blockquote as parent.
         # change parser state so blockquotes embedded in lists use p tags
         self.parser.state.set('blockquote')
@@ -354,7 +355,7 @@ class OListProcessor(BlockProcessor):
                 # since it's possible there are other children for this
                 # sibling, we can't just SubElement the p, we need to
                 # insert it as the first item.
-                p = util.etree.Element('p')
+                p = etree.Element('p')
                 p.text = lst[-1].text
                 lst[-1].text = ''
                 lst[-1].insert(0, p)
@@ -362,12 +363,12 @@ class OListProcessor(BlockProcessor):
             # likely only when a header is not followed by a blank line
             lch = self.lastChild(lst[-1])
             if lch is not None and lch.tail:
-                p = util.etree.SubElement(lst[-1], 'p')
+                p = etree.SubElement(lst[-1], 'p')
                 p.text = lch.tail.lstrip()
                 lch.tail = ''
 
             # parse first block differently as it gets wrapped in a p.
-            li = util.etree.SubElement(lst, 'li')
+            li = etree.SubElement(lst, 'li')
             self.parser.state.set('looselist')
             firstitem = items.pop(0)
             self.parser.parseBlocks(li, [firstitem])
@@ -381,7 +382,7 @@ class OListProcessor(BlockProcessor):
             lst = parent
         else:
             # This is a new list so create parent with appropriate tag.
-            lst = util.etree.SubElement(parent, self.TAG)
+            lst = etree.SubElement(parent, self.TAG)
             # Check if a custom start integer is set
             if not self.LAZY_OL and self.STARTSWITH != '1':
                 lst.attrib['start'] = self.STARTSWITH
@@ -395,7 +396,7 @@ class OListProcessor(BlockProcessor):
                 self.parser.parseBlocks(lst[-1], [item])
             else:
                 # New item. Create li and parse with it as parent
-                li = util.etree.SubElement(lst, 'li')
+                li = etree.SubElement(lst, 'li')
                 self.parser.parseBlocks(li, [item])
         self.parser.state.reset()
 
@@ -458,7 +459,7 @@ class HashHeaderProcessor(BlockProcessor):
                 # recursively parse this lines as a block.
                 self.parser.parseBlocks(parent, [before])
             # Create header using named groups from RE
-            h = util.etree.SubElement(parent, 'h%d' % len(m.group('level')))
+            h = etree.SubElement(parent, 'h%d' % len(m.group('level')))
             h.text = m.group('header').strip()
             if after:
                 # Insert remaining lines as first block for future parsing.
@@ -484,7 +485,7 @@ class SetextHeaderProcessor(BlockProcessor):
             level = 1
         else:
             level = 2
-        h = util.etree.SubElement(parent, 'h%d' % level)
+        h = etree.SubElement(parent, 'h%d' % level)
         h.text = lines[0].strip()
         if len(lines) > 2:
             # Block contains additional lines. Add to  master blocks for later.
@@ -518,7 +519,7 @@ class HRProcessor(BlockProcessor):
             # Recursively parse lines before hr so they get parsed first.
             self.parser.parseBlocks(parent, [prelines])
         # create hr
-        util.etree.SubElement(parent, 'hr')
+        etree.SubElement(parent, 'hr')
         # check for lines in block after hr.
         postlines = block[match.end():].lstrip('\n')
         if postlines:
@@ -587,5 +588,5 @@ class ParagraphProcessor(BlockProcessor):
                         parent.text = block.lstrip()
             else:
                 # Create a regular paragraph
-                p = util.etree.SubElement(parent, 'p')
+                p = etree.SubElement(parent, 'p')
                 p.text = block.lstrip()

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -19,8 +19,9 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 from . import Extension
 from ..preprocessors import Preprocessor
 from ..inlinepatterns import InlineProcessor
-from ..util import etree, AtomicString
+from ..util import AtomicString
 import re
+import xml.etree.ElementTree as etree
 
 # Global Vars
 ABBR_REF_RE = re.compile(r'[*]\[(?P<abbr>[^\]]*)\][ ]?:\s*(?P<title>.*)')

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -19,7 +19,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-from ..util import etree
+import xml.etree.ElementTree as etree
 import re
 
 

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor, ListIndentProcessor
-from ..util import etree
+import xml.etree.ElementTree as etree
 import re
 
 

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -22,6 +22,7 @@ from .. import util
 from collections import OrderedDict
 import re
 import copy
+import xml.etree.ElementTree as etree
 
 FN_BACKLINK_TEXT = util.STX + "zz1337820767766393qq" + util.ETX
 NBSP_PLACEHOLDER = util.STX + "qq3936677670287331zz" + util.ETX
@@ -165,14 +166,14 @@ class FootnoteExtension(Extension):
         if not list(self.footnotes.keys()):
             return None
 
-        div = util.etree.Element("div")
+        div = etree.Element("div")
         div.set('class', 'footnote')
-        util.etree.SubElement(div, "hr")
-        ol = util.etree.SubElement(div, "ol")
-        surrogate_parent = util.etree.Element("div")
+        etree.SubElement(div, "hr")
+        ol = etree.SubElement(div, "ol")
+        surrogate_parent = etree.Element("div")
 
         for index, id in enumerate(self.footnotes.keys(), start=1):
-            li = util.etree.SubElement(ol, "li")
+            li = etree.SubElement(ol, "li")
             li.set("id", self.makeFootnoteId(id))
             # Parse footnote with surrogate parent as li cannot be used.
             # List block handlers have special logic to deal with li.
@@ -181,7 +182,7 @@ class FootnoteExtension(Extension):
             for el in list(surrogate_parent):
                 li.append(el)
                 surrogate_parent.remove(el)
-            backlink = util.etree.Element("a")
+            backlink = etree.Element("a")
             backlink.set("href", "#" + self.makeFootnoteRefId(id))
             backlink.set("class", "footnote-backref")
             backlink.set(
@@ -196,7 +197,7 @@ class FootnoteExtension(Extension):
                     node.text = node.text + NBSP_PLACEHOLDER
                     node.append(backlink)
                 else:
-                    p = util.etree.SubElement(li, "p")
+                    p = etree.SubElement(li, "p")
                     p.append(backlink)
         return div
 
@@ -313,8 +314,8 @@ class FootnoteInlineProcessor(InlineProcessor):
     def handleMatch(self, m, data):
         id = m.group(1)
         if id in self.footnotes.footnotes.keys():
-            sup = util.etree.Element("sup")
-            a = util.etree.SubElement(sup, "a")
+            sup = etree.Element("sup")
+            a = etree.SubElement(sup, "a")
             sup.set('id', self.footnotes.makeFootnoteRefId(id, found=True))
             a.set('href', '#' + self.footnotes.makeFootnoteId(id))
             a.set('class', 'footnote-ref')

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -18,6 +18,7 @@ from . import Extension
 from ..blockprocessors import BlockProcessor
 from .. import util
 import re
+import xml.etree.ElementTree as etree
 
 
 class MarkdownInHtmlProcessor(BlockProcessor):
@@ -52,7 +53,7 @@ class MarkdownInHtmlProcessor(BlockProcessor):
 
         # Create Element
         markdown_value = tag['attrs'].pop('markdown')
-        element = util.etree.SubElement(parent, tag['tag'], tag['attrs'])
+        element = etree.SubElement(parent, tag['tag'], tag['attrs'])
 
         # Slice Off Block
         if nest:

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-from ..util import etree
+import xml.etree.ElementTree as etree
 import re
 PIPE_NONE = 0
 PIPE_LEFT = 1

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -15,10 +15,11 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..treeprocessors import Treeprocessor
-from ..util import etree, parseBoolValue, AMP_SUBSTITUTE, HTML_PLACEHOLDER_RE
+from ..util import parseBoolValue, AMP_SUBSTITUTE, HTML_PLACEHOLDER_RE
 from ..postprocessors import UnescapePostprocessor
 import re
 import unicodedata
+import xml.etree.ElementTree as etree
 
 
 def slugify(value, separator):

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..inlinepatterns import InlineProcessor
-from ..util import etree
+import xml.etree.ElementTree as etree
 import re
 
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -63,6 +63,7 @@ So, we apply the expressions in the following order:
 from . import util
 from collections import namedtuple
 import re
+import xml.etree.ElementTree as etree
 try:  # pragma: no cover
     from html import entities
 except ImportError:  # pragma: no cover
@@ -334,7 +335,7 @@ class SimpleTagPattern(Pattern):  # pragma: no cover
         self.tag = tag
 
     def handleMatch(self, m):
-        el = util.etree.Element(self.tag)
+        el = etree.Element(self.tag)
         el.text = m.group(3)
         return el
 
@@ -350,7 +351,7 @@ class SimpleTagInlineProcessor(InlineProcessor):
         self.tag = tag
 
     def handleMatch(self, m, data):  # pragma: no cover
-        el = util.etree.Element(self.tag)
+        el = etree.Element(self.tag)
         el.text = m.group(2)
         return el, m.start(0), m.end(0)
 
@@ -358,13 +359,13 @@ class SimpleTagInlineProcessor(InlineProcessor):
 class SubstituteTagPattern(SimpleTagPattern):  # pragma: no cover
     """ Return an element of type `tag` with no children. """
     def handleMatch(self, m):
-        return util.etree.Element(self.tag)
+        return etree.Element(self.tag)
 
 
 class SubstituteTagInlineProcessor(SimpleTagInlineProcessor):
     """ Return an element of type `tag` with no children. """
     def handleMatch(self, m, data):
-        return util.etree.Element(self.tag), m.start(0), m.end(0)
+        return etree.Element(self.tag), m.start(0), m.end(0)
 
 
 class BacktickInlineProcessor(InlineProcessor):
@@ -376,7 +377,7 @@ class BacktickInlineProcessor(InlineProcessor):
 
     def handleMatch(self, m, data):
         if m.group(3):
-            el = util.etree.Element(self.tag)
+            el = etree.Element(self.tag)
             el.text = util.AtomicString(util.code_escape(m.group(3).strip()))
             return el, m.start(0), m.end(0)
         else:
@@ -391,8 +392,8 @@ class DoubleTagPattern(SimpleTagPattern):  # pragma: no cover
     """
     def handleMatch(self, m):
         tag1, tag2 = self.tag.split(",")
-        el1 = util.etree.Element(tag1)
-        el2 = util.etree.SubElement(el1, tag2)
+        el1 = etree.Element(tag1)
+        el2 = etree.SubElement(el1, tag2)
         el2.text = m.group(3)
         if len(m.groups()) == 5:
             el2.tail = m.group(4)
@@ -407,8 +408,8 @@ class DoubleTagInlineProcessor(SimpleTagInlineProcessor):
     """
     def handleMatch(self, m, data):  # pragma: no cover
         tag1, tag2 = self.tag.split(",")
-        el1 = util.etree.Element(tag1)
-        el2 = util.etree.SubElement(el1, tag2)
+        el1 = etree.Element(tag1)
+        el2 = etree.SubElement(el1, tag2)
         el2.text = m.group(2)
         if len(m.groups()) == 3:
             el2.tail = m.group(3)
@@ -454,7 +455,7 @@ class AsteriskProcessor(InlineProcessor):
 
     def build_single(self, m, tag, idx):
         """Return single tag."""
-        el1 = util.etree.Element(tag)
+        el1 = etree.Element(tag)
         text = m.group(2)
         self.parse_sub_patterns(text, el1, None, idx)
         return el1
@@ -463,8 +464,8 @@ class AsteriskProcessor(InlineProcessor):
         """Return double tag."""
 
         tag1, tag2 = tags.split(",")
-        el1 = util.etree.Element(tag1)
-        el2 = util.etree.Element(tag2)
+        el1 = etree.Element(tag1)
+        el2 = etree.Element(tag2)
         text = m.group(2)
         self.parse_sub_patterns(text, el2, None, idx)
         el1.append(el2)
@@ -477,8 +478,8 @@ class AsteriskProcessor(InlineProcessor):
         """Return double tags (variant 2): `<strong>text <em>text</em></strong>`."""
 
         tag1, tag2 = tags.split(",")
-        el1 = util.etree.Element(tag1)
-        el2 = util.etree.Element(tag2)
+        el1 = etree.Element(tag1)
+        el2 = etree.Element(tag2)
         text = m.group(2)
         self.parse_sub_patterns(text, el1, None, idx)
         text = m.group(3)
@@ -604,7 +605,7 @@ class LinkInlineProcessor(InlineProcessor):
         if not handled:
             return None, None, None
 
-        el = util.etree.Element("a")
+        el = etree.Element("a")
         el.text = text
 
         el.set("href", href)
@@ -762,7 +763,7 @@ class ImageInlineProcessor(LinkInlineProcessor):
         if not handled:
             return None, None, None
 
-        el = util.etree.Element("img")
+        el = etree.Element("img")
 
         el.set("src", src)
 
@@ -814,7 +815,7 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
         return id, end, True
 
     def makeTag(self, href, title, text):
-        el = util.etree.Element('a')
+        el = etree.Element('a')
 
         el.set('href', href)
         if title:
@@ -835,7 +836,7 @@ class ShortReferenceInlineProcessor(ReferenceInlineProcessor):
 class ImageReferenceInlineProcessor(ReferenceInlineProcessor):
     """ Match to a stored reference and return img element. """
     def makeTag(self, href, title, text):
-        el = util.etree.Element("img")
+        el = etree.Element("img")
         el.set("src", href)
         if title:
             el.set("title", title)
@@ -846,7 +847,7 @@ class ImageReferenceInlineProcessor(ReferenceInlineProcessor):
 class AutolinkInlineProcessor(InlineProcessor):
     """ Return a link Element given an autolink (`<http://example/com>`). """
     def handleMatch(self, m, data):
-        el = util.etree.Element("a")
+        el = etree.Element("a")
         el.set('href', self.unescape(m.group(1)))
         el.text = util.AtomicString(m.group(1))
         return el, m.start(0), m.end(0)
@@ -857,7 +858,7 @@ class AutomailInlineProcessor(InlineProcessor):
     Return a mailto link Element given an automail link (`<foo@example.com>`).
     """
     def handleMatch(self, m, data):
-        el = util.etree.Element('a')
+        el = etree.Element('a')
         email = self.unescape(m.group(1))
         if email.startswith("mailto:"):
             email = email[len("mailto:"):]

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -38,14 +38,8 @@
 
 
 from xml.etree.ElementTree import ProcessingInstruction
-from . import util
+from xml.etree.ElementTree import Comment, ElementTree, QName
 import re
-ElementTree = util.etree.ElementTree
-QName = util.etree.QName
-if hasattr(util.etree, 'test_comment'):  # pragma: no cover
-    Comment = util.etree.test_comment
-else:  # pragma: no cover
-    Comment = util.etree.Comment
 
 __all__ = ['to_html_string', 'to_xhtml_string']
 

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -19,6 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
+import xml.etree.ElementTree as etree
 from . import util
 from . import inlinepatterns
 
@@ -375,7 +376,7 @@ class InlineProcessor(Treeprocessor):
                     self.ancestors.pop()
                 if child.tail:
                     tail = self.__handleInline(child.tail)
-                    dumby = util.etree.Element('d')
+                    dumby = etree.Element('d')
                     child.tail = None
                     tailResult = self.__processPlaceholders(tail, dumby, False)
                     if dumby.tail:

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -24,6 +24,7 @@ import sys
 from collections import namedtuple
 from functools import wraps
 import warnings
+import xml.etree.ElementTree
 from .pep562 import Pep562
 
 
@@ -32,6 +33,7 @@ PY37 = (3, 7) <= sys.version_info
 
 # TODO: Remove deprecated variables in a future release.
 __deprecated__ = {
+    'etree': ('xml.etree.ElementTree', xml.etree.ElementTree),
     'string_type': ('str', str),
     'text_type': ('str', str),
     'int2str': ('chr', chr),
@@ -81,23 +83,6 @@ RTL_BIDI_RANGES = (
     # Thaana (0780-07BF), Nko (07C0-07FF).
     ('\u2D30', '\u2D7F')  # Tifinagh
 )
-
-# Extensions should use "markdown.util.etree" instead of "etree" (or do `from
-# markdown.util import etree`).  Do not import it by yourself.
-
-try:  # pragma: no cover
-    # Is the C implementation of ElementTree available?
-    import xml.etree.cElementTree as etree
-    from xml.etree.ElementTree import Comment
-    # Serializers (including ours) test with non-c Comment
-    etree.test_comment = Comment
-    if etree.VERSION < "1.0.5":
-        raise RuntimeError("cElementTree version 1.0.5 or higher is required.")
-except (ImportError, RuntimeError):  # pragma: no cover
-    # Use the Python implementation of ElementTree?
-    import xml.etree.ElementTree as etree
-    if etree.VERSION < "1.1":
-        raise RuntimeError("ElementTree version 1.1 or higher is required")
 
 
 """

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -34,6 +34,7 @@ from logging import DEBUG, WARNING, CRITICAL
 import yaml
 import tempfile
 from io import BytesIO
+import xml.etree.ElementTree as etree
 from xml.etree.ElementTree import ProcessingInstruction
 
 
@@ -122,7 +123,7 @@ class TestBlockParser(unittest.TestCase):
 
     def testParseChunk(self):
         """ Test BlockParser.parseChunk. """
-        root = markdown.util.etree.Element("div")
+        root = etree.Element("div")
         text = 'foo'
         self.parser.parseChunk(root, text)
         self.assertEqual(
@@ -134,8 +135,8 @@ class TestBlockParser(unittest.TestCase):
         """ Test BlockParser.parseDocument. """
         lines = ['#foo', '', 'bar', '', '    baz']
         tree = self.parser.parseDocument(lines)
-        self.assertIsInstance(tree, markdown.util.etree.ElementTree)
-        self.assertIs(markdown.util.etree.iselement(tree.getroot()), True)
+        self.assertIsInstance(tree, etree.ElementTree)
+        self.assertIs(etree.iselement(tree.getroot()), True)
         self.assertEqual(
             markdown.serializers.to_xhtml_string(tree.getroot()),
             "<div><h1>foo</h1><p>bar</p><pre><code>baz\n</code></pre></div>"
@@ -482,11 +483,11 @@ class testETreeComments(unittest.TestCase):
 
     def setUp(self):
         # Create comment node
-        self.comment = markdown.util.etree.Comment('foo')
+        self.comment = etree.Comment('foo')
 
     def testCommentIsComment(self):
         """ Test that an ElementTree Comment passes the `is Comment` test. """
-        self.assertIs(self.comment.tag, markdown.util.etree.Comment)
+        self.assertIs(self.comment.tag, etree.Comment)
 
     def testCommentIsBlockLevel(self):
         """ Test that an ElementTree Comment is recognized as BlockLevel. """
@@ -517,8 +518,8 @@ class testElementTailTests(unittest.TestCase):
 
     def testBrTailNoNewline(self):
         """ Test that last <br> in tree has a new line tail """
-        root = markdown.util.etree.Element('root')
-        br = markdown.util.etree.SubElement(root, 'br')
+        root = etree.Element('root')
+        br = etree.SubElement(root, 'br')
         self.assertEqual(br.tail, None)
         self.pretty.run(root)
         self.assertEqual(br.tail, "\n")
@@ -529,15 +530,15 @@ class testSerializers(unittest.TestCase):
 
     def testHtml(self):
         """ Test HTML serialization. """
-        el = markdown.util.etree.Element('div')
+        el = etree.Element('div')
         el.set('id', 'foo<&">')
-        p = markdown.util.etree.SubElement(el, 'p')
+        p = etree.SubElement(el, 'p')
         p.text = 'foo <&escaped>'
         p.set('hidden', 'hidden')
-        markdown.util.etree.SubElement(el, 'hr')
-        non_element = markdown.util.etree.SubElement(el, None)
+        etree.SubElement(el, 'hr')
+        non_element = etree.SubElement(el, None)
         non_element.text = 'non-element text'
-        script = markdown.util.etree.SubElement(non_element, 'script')
+        script = etree.SubElement(non_element, 'script')
         script.text = '<&"test\nescaping">'
         el.tail = "tail text"
         self.assertEqual(
@@ -552,15 +553,15 @@ class testSerializers(unittest.TestCase):
 
     def testXhtml(self):
         """" Test XHTML serialization. """
-        el = markdown.util.etree.Element('div')
+        el = etree.Element('div')
         el.set('id', 'foo<&">')
-        p = markdown.util.etree.SubElement(el, 'p')
+        p = etree.SubElement(el, 'p')
         p.text = 'foo<&escaped>'
         p.set('hidden', 'hidden')
-        markdown.util.etree.SubElement(el, 'hr')
-        non_element = markdown.util.etree.SubElement(el, None)
+        etree.SubElement(el, 'hr')
+        non_element = etree.SubElement(el, None)
         non_element.text = 'non-element text'
-        script = markdown.util.etree.SubElement(non_element, 'script')
+        script = etree.SubElement(non_element, 'script')
         script.text = '<&"test\nescaping">'
         el.tail = "tail text"
         self.assertEqual(
@@ -575,11 +576,11 @@ class testSerializers(unittest.TestCase):
 
     def testMixedCaseTags(self):
         """" Test preservation of tag case. """
-        el = markdown.util.etree.Element('MixedCase')
+        el = etree.Element('MixedCase')
         el.text = 'not valid '
-        em = markdown.util.etree.SubElement(el, 'EMPHASIS')
+        em = etree.SubElement(el, 'EMPHASIS')
         em.text = 'html'
-        markdown.util.etree.SubElement(el, 'HR')
+        etree.SubElement(el, 'HR')
         self.assertEqual(
             markdown.serializers.to_xhtml_string(el),
             '<MixedCase>not valid <EMPHASIS>html</EMPHASIS><HR /></MixedCase>'
@@ -596,17 +597,17 @@ class testSerializers(unittest.TestCase):
 
     def testQNameTag(self):
         """ Test serialization of QName tag. """
-        div = markdown.util.etree.Element('div')
-        qname = markdown.util.etree.QName('http://www.w3.org/1998/Math/MathML', 'math')
-        math = markdown.util.etree.SubElement(div, qname)
+        div = etree.Element('div')
+        qname = etree.QName('http://www.w3.org/1998/Math/MathML', 'math')
+        math = etree.SubElement(div, qname)
         math.set('display', 'block')
-        sem = markdown.util.etree.SubElement(math, 'semantics')
-        msup = markdown.util.etree.SubElement(sem, 'msup')
-        mi = markdown.util.etree.SubElement(msup, 'mi')
+        sem = etree.SubElement(math, 'semantics')
+        msup = etree.SubElement(sem, 'msup')
+        mi = etree.SubElement(msup, 'mi')
         mi.text = 'x'
-        mn = markdown.util.etree.SubElement(msup, 'mn')
+        mn = etree.SubElement(msup, 'mn')
         mn.text = '2'
-        ann = markdown.util.etree.SubElement(sem, 'annotations')
+        ann = etree.SubElement(sem, 'annotations')
         ann.text = 'x^2'
         self.assertEqual(
             markdown.serializers.to_xhtml_string(div),
@@ -625,8 +626,8 @@ class testSerializers(unittest.TestCase):
 
     def testQNameAttribute(self):
         """ Test serialization of QName attribute. """
-        div = markdown.util.etree.Element('div')
-        div.set(markdown.util.etree.QName('foo'), markdown.util.etree.QName('bar'))
+        div = etree.Element('div')
+        div.set(etree.QName('foo'), etree.QName('bar'))
         self.assertEqual(
             markdown.serializers.to_xhtml_string(div),
             '<div foo="bar"></div>'
@@ -634,14 +635,14 @@ class testSerializers(unittest.TestCase):
 
     def testBadQNameTag(self):
         """ Test serialization of QName with no tag. """
-        qname = markdown.util.etree.QName('http://www.w3.org/1998/Math/MathML')
-        el = markdown.util.etree.Element(qname)
+        qname = etree.QName('http://www.w3.org/1998/Math/MathML')
+        el = etree.Element(qname)
         self.assertRaises(ValueError, markdown.serializers.to_xhtml_string, el)
 
     def testQNameEscaping(self):
         """ Test QName escaping. """
-        qname = markdown.util.etree.QName('<&"test\nescaping">', 'div')
-        el = markdown.util.etree.Element(qname)
+        qname = etree.QName('<&"test\nescaping">', 'div')
+        el = etree.Element(qname)
         self.assertEqual(
             markdown.serializers.to_xhtml_string(el),
             '<div xmlns="&lt;&amp;&quot;test&#10;escaping&quot;&gt;"></div>'
@@ -649,8 +650,8 @@ class testSerializers(unittest.TestCase):
 
     def testQNamePreEscaping(self):
         """ Test QName that is already partially escaped. """
-        qname = markdown.util.etree.QName('&lt;&amp;"test&#10;escaping"&gt;', 'div')
-        el = markdown.util.etree.Element(qname)
+        qname = etree.QName('&lt;&amp;"test&#10;escaping"&gt;', 'div')
+        el = etree.Element(qname)
         self.assertEqual(
             markdown.serializers.to_xhtml_string(el),
             '<div xmlns="&lt;&amp;&quot;test&#10;escaping&quot;&gt;"></div>'
@@ -698,8 +699,8 @@ class testAtomicString(unittest.TestCase):
 
     def testString(self):
         """ Test that a regular string is parsed. """
-        tree = markdown.util.etree.Element('div')
-        p = markdown.util.etree.SubElement(tree, 'p')
+        tree = etree.Element('div')
+        p = etree.SubElement(tree, 'p')
         p.text = 'some *text*'
         new = self.inlineprocessor.run(tree)
         self.assertEqual(
@@ -709,8 +710,8 @@ class testAtomicString(unittest.TestCase):
 
     def testSimpleAtomicString(self):
         """ Test that a simple AtomicString is not parsed. """
-        tree = markdown.util.etree.Element('div')
-        p = markdown.util.etree.SubElement(tree, 'p')
+        tree = etree.Element('div')
+        p = etree.SubElement(tree, 'p')
         p.text = markdown.util.AtomicString('some *text*')
         new = self.inlineprocessor.run(tree)
         self.assertEqual(
@@ -720,14 +721,14 @@ class testAtomicString(unittest.TestCase):
 
     def testNestedAtomicString(self):
         """ Test that a nested AtomicString is not parsed. """
-        tree = markdown.util.etree.Element('div')
-        p = markdown.util.etree.SubElement(tree, 'p')
+        tree = etree.Element('div')
+        p = etree.SubElement(tree, 'p')
         p.text = markdown.util.AtomicString('*some* ')
-        span1 = markdown.util.etree.SubElement(p, 'span')
+        span1 = etree.SubElement(p, 'span')
         span1.text = markdown.util.AtomicString('*more* ')
-        span2 = markdown.util.etree.SubElement(span1, 'span')
+        span2 = etree.SubElement(span1, 'span')
         span2.text = markdown.util.AtomicString('*text* ')
-        span3 = markdown.util.etree.SubElement(span2, 'span')
+        span3 = etree.SubElement(span2, 'span')
         span3.text = markdown.util.AtomicString('*here*')
         span3.tail = markdown.util.AtomicString(' *to*')
         span2.tail = markdown.util.AtomicString(' *test*')
@@ -944,7 +945,7 @@ class TestAncestorExclusion(unittest.TestCase):
 
         def handleMatch(self, m, data):
             """ Handle match. """
-            el = markdown.util.etree.Element(self.tag)
+            el = etree.Element(self.tag)
             el.text = m.group(2)
             return el, m.start(0), m.end(0)
 

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -483,14 +483,10 @@ class testETreeComments(unittest.TestCase):
     def setUp(self):
         # Create comment node
         self.comment = markdown.util.etree.Comment('foo')
-        if hasattr(markdown.util.etree, 'test_comment'):
-            self.test_comment = markdown.util.etree.test_comment
-        else:
-            self.test_comment = markdown.util.etree.Comment
 
     def testCommentIsComment(self):
         """ Test that an ElementTree Comment passes the `is Comment` test. """
-        self.assertIs(self.comment.tag, markdown.util.etree.test_comment)
+        self.assertIs(self.comment.tag, markdown.util.etree.Comment)
 
     def testCommentIsBlockLevel(self):
         """ Test that an ElementTree Comment is recognized as BlockLevel. """


### PR DESCRIPTION
cElementTree [is a deprecated alias for ElementTree][1] since Python 3.3. As we are now supporting only Python ≥ 3.5, we do not need to use it.

The version check is also no longer needed. The module has [version 1.3.0][2] since 2010, so even Python 2.7 and 3.2 have it (see python/cpython@f15351d938e76c4b).

[1]: https://docs.python.org/3/library/xml.etree.elementtree.html#module-xml.etree.ElementTree
[2]: https://bugs.python.org/issue6472