### PR TITLE
Ensure bdist_wheel no longer creates a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 license_file = LICENSE.md


### PR DESCRIPTION
Now that the project doesn't support Python 2, the setup shouldn't produce a universal wheel. The wheel on PyPI is tagged `py2.py3` and although `Requires-Python` is set, users with an older pip, or users using another index which doesn't support this will have a problem.

Similar to https://github.com/pypa/setuptools/pull/1978

Related to https://github.com/piwheels/piwheels/issues/208