### PR TITLE
Revert: Use simplified regex for html placeholders

### DIFF
--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -93,5 +93,4 @@ The following bug fixes are included in the 3.2 release:
 * HTML tag placeholders are no longer included in  `.toc_tokens` (#899).
 * Unescape backslash-escaped characters in TOC ids (#864).
 * Refactor bold and italic logic in order to solve complex nesting issues (#792).
-* Always wrap CodeHilite code in <code> tags (#862) </code>
-* Regex for HTML placeholders simplified for speed improvement (#928).
+* Always wrap CodeHilite code in `code` tags (#862)

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -77,7 +77,7 @@ class RawHtmlPostprocessor(Postprocessor):
             replacements[self.md.htmlStash.get_placeholder(i)] = html
 
         if replacements:
-            pattern = util.HTML_PLACEHOLDER_RE
+            pattern = re.compile("|".join(re.escape(k) for k in replacements))
             processed_text = pattern.sub(lambda m: replacements[m.group(0)], text)
         else:
             return text


### PR DESCRIPTION
Not sure how tests didn't get run on this, but it was completely
breaking ~~all~~ a lot of tests. This reverts the change.

Fixes #932 