### PR TITLE
extend_markdown() TypeErrors swallowed because of deprecation test.

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -6,7 +6,10 @@ Python-Markdown Change Log
 Under development: version 3.2.2 (a bug-fix release).
 
 * Load entry_points (for extensions) only once using `importlib.metadata`.
-* Fixed issue where double escaped entities could end up in TOC.
+* Do not double escape entities in TOC.
+* Correctly report if an extension raises a `TypeError` (#939).
+* Raise a `KeyError` when attempting to delete a nonexistent key from the
+  extension registry (#939). 
 
 Feb 12, 2020: Released version 3.2.1 (a bug-fix release).
 

--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -94,3 +94,5 @@ The following bug fixes are included in the 3.2 release:
 * Unescape backslash-escaped characters in TOC ids (#864).
 * Refactor bold and italic logic in order to solve complex nesting issues (#792).
 * Always wrap CodeHilite code in `code` tags (#862)
+* `_extend_markdown()` now correctly reports if an extension's `extend_markdown()` raises a TypeError (#939).
+* Attempting to delete a nonexistent key from the patterns registry now raises KeyError instead of TypeError (#939). 

--- a/docs/change_log/release-3.2.md
+++ b/docs/change_log/release-3.2.md
@@ -94,5 +94,3 @@ The following bug fixes are included in the 3.2 release:
 * Unescape backslash-escaped characters in TOC ids (#864).
 * Refactor bold and italic logic in order to solve complex nesting issues (#792).
 * Always wrap CodeHilite code in `code` tags (#862)
-* `_extend_markdown()` now correctly reports if an extension's `extend_markdown()` raises a TypeError (#939).
-* Attempting to delete a nonexistent key from the patterns registry now raises KeyError instead of TypeError (#939). 

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -75,15 +75,18 @@ class Extension:
         md = args[0]
         try:
             self.extendMarkdown(md)
-        except TypeError:
-            # Must be a 2.x extension. Pass in a dumby md_globals.
-            self.extendMarkdown(md, {})
-            warnings.warn(
-                "The 'md_globals' parameter of '{}.{}.extendMarkdown' is "
-                "deprecated.".format(self.__class__.__module__, self.__class__.__name__),
-                category=DeprecationWarning,
-                stacklevel=2
-            )
+        except TypeError as e:
+            if "missing 1 required positional argument" in str(e):
+                # Must be a 2.x extension. Pass in a dumby md_globals.
+                self.extendMarkdown(md, {})
+                warnings.warn(
+                    "The 'md_globals' parameter of '{}.{}.extendMarkdown' is "
+                    "deprecated.".format(self.__class__.__module__, self.__class__.__name__),
+                    category=DeprecationWarning,
+                    stacklevel=2
+                )
+            else:
+                raise
 
     def extendMarkdown(self, md):
         """

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -399,7 +399,7 @@ class Registry:
                 stacklevel=2,
             )
         else:
-            raise TypeError
+            raise KeyError(f'Cannot delete key {key}, not registered.')
 
     def add(self, key, value, location):
         """ Register a key by location. """

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -399,7 +399,7 @@ class Registry:
                 stacklevel=2,
             )
         else:
-            raise KeyError(f'Cannot delete key {key}, not registered.')
+            raise KeyError('Cannot delete key {}, not registered.'.format(key))
 
     def add(self, key, value, location):
         """ Register a key by location. """

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -352,7 +352,7 @@ class RegistryTests(unittest.TestCase):
             self.assertEqual(list(r), ['a', 'c'])
             del r['a']
             self.assertEqual(list(r), ['c'])
-            with self.assertRaises(TypeError):
+            with self.assertRaises(KeyError):
                 del r['badname']
             del r['c']
             self.assertEqual(list(r), [])

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -337,7 +337,7 @@ class RegistryTests(unittest.TestCase):
     def testRegistryDelItem(self):
         r = markdown.util.Registry()
         r.register(Item('a'), 'a', 20)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(KeyError):
             del r[0]
         # TODO: restore this when deprecated __del__ is removed.
         # with self.assertRaises(TypeError):


### PR DESCRIPTION
Currently, an extension's `extendMarkdown()` raising a TypeError will be swallowed, or not reported.  This occurs because the calling `_extendMarkdown()` assumes the TypeError occurs because an `md_globals` argument was also passed.  This pull request modifies `_extendMarkdown()` to check this assumption.

Also, trying to delete an invalid key is a KeyError as opposed to a TypeError.

Have a wonderful day!
