### PR TITLE
Load entry_points once using importlib.metadata.

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -5,6 +5,7 @@ Python-Markdown Change Log
 
 Under development: version 3.2.2 (a bug-fix release).
 
+* Load entry_points (for extensions) only once using `importlib.metadata`.
 * Fixed issue where double escaped entities could end up in TOC.
 
 Feb 12, 2020: Released version 3.2.1 (a bug-fix release).

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -23,7 +23,6 @@ import codecs
 import sys
 import logging
 import importlib
-import pkg_resources
 from . import util
 from .preprocessors import build_preprocessors
 from .blockprocessors import build_block_parser
@@ -141,9 +140,8 @@ class Markdown:
         Build extension from a string name, then return an instance.
 
         First attempt to load an entry point. The string name must be registered as an entry point in the
-        `markdown.extensions` group which points to a subclass of the `markdown.extensions.Extension` class. If
-        multiple distributions have registered the same name, the first one found by `pkg_resources.iter_entry_points`
-        is returned.
+        `markdown.extensions` group which points to a subclass of the `markdown.extensions.Extension` class.
+        If multiple distributions have registered the same name, the first one found is returned.
 
         If no entry point is found, assume dot notation (`path.to.module:ClassName`). Load the specified class and
         return an instance. If no class is specified, import the module and call a `makeExtension` function and return
@@ -151,7 +149,7 @@ class Markdown:
         """
         configs = dict(configs)
 
-        entry_points = [ep for ep in pkg_resources.iter_entry_points('markdown.extensions', ext_name)]
+        entry_points = [ep for ep in util.INSTALLED_EXTENSIONS if ep.name == ext_name]
         if entry_points:
             ext = entry_points[0].load()
             return ext(**configs)

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -27,6 +27,11 @@ import warnings
 import xml.etree.ElementTree
 from .pep562 import Pep562
 
+try:
+    from importlib import metadata
+except ImportError:
+    # <PY38 use backport
+    import importlib_metadata as metadata
 
 PY37 = (3, 7) <= sys.version_info
 
@@ -76,6 +81,8 @@ Constants you probably do not need to change
 -----------------------------------------------------------------------------
 """
 
+# Only load extension entry_points once.
+INSTALLED_EXTENSIONS = metadata.entry_points().get('markdown.extensions', ())
 RTL_BIDI_RANGES = (
     ('\u0590', '\u07FF'),
     # Hebrew (0590-05FF), Arabic (0600-06FF),

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
     python_requires='>=3.5',
-    install_requires=['setuptools >= 36'],
+    install_requires=['setuptools >= 36', "importlib_metadata;python_version<'3.8'"],
     extras_require={
         'testing': [
             'coverage',


### PR DESCRIPTION
This should be more performant. Fixes #942.