### PR TITLE
Typo

### DIFF
--- a/tests/basic/markdown-documentation-basics.html
+++ b/tests/basic/markdown-documentation-basics.html
@@ -23,7 +23,7 @@ can <a href="/projects/markdown/basics.text">see the source for it by adding '.t
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 <p>Markdown offers two styles of headers: <em>Setext</em> and <em>atx</em>.
 Setext-style headers for <code>&lt;h1&gt;</code> and <code>&lt;h2&gt;</code> are created by
 "underlining" with equal signs (<code>=</code>) and hyphens (<code>-</code>), respectively.

--- a/tests/basic/markdown-documentation-basics.txt
+++ b/tests/basic/markdown-documentation-basics.txt
@@ -37,7 +37,7 @@ can [see the source for it by adding '.text' to the URL] [src].
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 Markdown offers two styles of headers: *Setext* and *atx*.
 Setext-style headers for `<h1>` and `<h2>` are created by

--- a/tests/basic/markdown-syntax.html
+++ b/tests/basic/markdown-syntax.html
@@ -151,7 +151,7 @@ and <code>&amp;</code> in your example code needs to be escaped.)</p>
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 <p>The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
 significantly from most other text-to-HTML formatters (including Movable
@@ -328,7 +328,7 @@ items in <code>&lt;p&gt;</code> tags in the HTML output. For example, this input
 &lt;/ul&gt;
 </code></pre>
 <p>List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:</p>
 <pre><code>1.  This is a list item with two paragraphs. Lorem ipsum dolor
     sit amet, consectetuer adipiscing elit. Aliquam hendrerit

--- a/tests/basic/markdown-syntax.txt
+++ b/tests/basic/markdown-syntax.txt
@@ -186,7 +186,7 @@ and `&` in your example code needs to be escaped.)
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -401,7 +401,7 @@ will turn into:
     </ul>
 
 List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:
 
     1.  This is a list item with two paragraphs. Lorem ipsum dolor

--- a/tests/extensions/extra/markdown-syntax.html
+++ b/tests/extensions/extra/markdown-syntax.html
@@ -151,7 +151,7 @@ and <code>&amp;</code> in your example code needs to be escaped.)</p>
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 <p>The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
 significantly from most other text-to-HTML formatters (including Movable
@@ -328,7 +328,7 @@ items in <code>&lt;p&gt;</code> tags in the HTML output. For example, this input
 &lt;/ul&gt;
 </code></pre>
 <p>List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:</p>
 <pre><code>1.  This is a list item with two paragraphs. Lorem ipsum dolor
     sit amet, consectetuer adipiscing elit. Aliquam hendrerit

--- a/tests/extensions/extra/markdown-syntax.txt
+++ b/tests/extensions/extra/markdown-syntax.txt
@@ -186,7 +186,7 @@ and `&` in your example code needs to be escaped.)
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -401,7 +401,7 @@ will turn into:
     </ul>
 
 List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:
 
     1.  This is a list item with two paragraphs. Lorem ipsum dolor

--- a/tests/extensions/toc.html
+++ b/tests/extensions/toc.html
@@ -135,7 +135,7 @@ and <code>&amp;</code> in your example code needs to be escaped.)</p>
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 <p>The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
 significantly from most other text-to-HTML formatters (including Movable
@@ -309,7 +309,7 @@ items in <code>&lt;p&gt;</code> tags in the HTML output. For example, this input
 &lt;/ul&gt;
 </code></pre>
 <p>List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:</p>
 <pre><code>1.  This is a list item with two paragraphs. Lorem ipsum dolor
     sit amet, consectetuer adipiscing elit. Aliquam hendrerit

--- a/tests/extensions/toc.txt
+++ b/tests/extensions/toc.txt
@@ -149,7 +149,7 @@ and `&` in your example code needs to be escaped.)
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -364,7 +364,7 @@ will turn into:
     </ul>
 
 List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:
 
     1.  This is a list item with two paragraphs. Lorem ipsum dolor

--- a/tests/pl/Tests_2004/Markdown Documentation - Basics.html
+++ b/tests/pl/Tests_2004/Markdown Documentation - Basics.html
@@ -29,7 +29,7 @@ can <a href="/projects/markdown/basics.text">see the source for it by adding '.t
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 
 <p>Markdown offers two styles of headers: <em>Setext</em> and <em>atx</em>.
 Setext-style headers for <code>&lt;h1&gt;</code> and <code>&lt;h2&gt;</code> are created by

--- a/tests/pl/Tests_2004/Markdown Documentation - Basics.text
+++ b/tests/pl/Tests_2004/Markdown Documentation - Basics.text
@@ -37,7 +37,7 @@ can [see the source for it by adding '.text' to the URL] [src].
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 Markdown offers two styles of headers: *Setext* and *atx*.
 Setext-style headers for `<h1>` and `<h2>` are created by

--- a/tests/pl/Tests_2004/Markdown Documentation - Syntax.html
+++ b/tests/pl/Tests_2004/Markdown Documentation - Syntax.html
@@ -186,7 +186,7 @@ and <code>&amp;</code> in your example code needs to be escaped.)</p>
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 
 <p>The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -414,7 +414,7 @@ items in <code>&lt;p&gt;</code> tags in the HTML output. For example, this input
 </code></pre>
 
 <p>List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:</p>
 
 <pre><code>1.  This is a list item with two paragraphs. Lorem ipsum dolor

--- a/tests/pl/Tests_2004/Markdown Documentation - Syntax.text
+++ b/tests/pl/Tests_2004/Markdown Documentation - Syntax.text
@@ -186,7 +186,7 @@ and `&` in your example code needs to be escaped.)
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -401,7 +401,7 @@ will turn into:
     </ul>
 
 List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:
 
     1.  This is a list item with two paragraphs. Lorem ipsum dolor

--- a/tests/pl/Tests_2007/Markdown Documentation - Basics.html
+++ b/tests/pl/Tests_2007/Markdown Documentation - Basics.html
@@ -29,7 +29,7 @@ can <a href="/projects/markdown/basics.text">see the source for it by adding '.t
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 
 <p>Markdown offers two styles of headers: <em>Setext</em> and <em>atx</em>.
 Setext-style headers for <code>&lt;h1&gt;</code> and <code>&lt;h2&gt;</code> are created by

--- a/tests/pl/Tests_2007/Markdown Documentation - Basics.text
+++ b/tests/pl/Tests_2007/Markdown Documentation - Basics.text
@@ -37,7 +37,7 @@ can [see the source for it by adding '.text' to the URL] [src].
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 Markdown offers two styles of headers: *Setext* and *atx*.
 Setext-style headers for `<h1>` and `<h2>` are created by

--- a/tests/pl/Tests_2007/Markdown Documentation - Syntax.html
+++ b/tests/pl/Tests_2007/Markdown Documentation - Syntax.html
@@ -186,7 +186,7 @@ and <code>&amp;</code> in your example code needs to be escaped.)</p>
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.</p>
+blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 
 <p>The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -414,7 +414,7 @@ items in <code>&lt;p&gt;</code> tags in the HTML output. For example, this input
 </code></pre>
 
 <p>List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:</p>
 
 <pre><code>1.  This is a list item with two paragraphs. Lorem ipsum dolor

--- a/tests/pl/Tests_2007/Markdown Documentation - Syntax.text
+++ b/tests/pl/Tests_2007/Markdown Documentation - Syntax.text
@@ -186,7 +186,7 @@ and `&` in your example code needs to be escaped.)
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
 blank line -- a line containing nothing but spaces or tabs is considered
-blank.) Normal paragraphs should not be intended with spaces or tabs.
+blank.) Normal paragraphs should not be indented with spaces or tabs.
 
 The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
@@ -401,7 +401,7 @@ will turn into:
     </ul>
 
 List items may consist of multiple paragraphs. Each subsequent
-paragraph in a list item must be intended by either 4 spaces
+paragraph in a list item must be indented by either 4 spaces
 or one tab:
 
     1.  This is a list item with two paragraphs. Lorem ipsum dolor


### PR DESCRIPTION
Fixed the the typo in a mistyping of markdown documentation: "intended by" -> "indented by"