### PR TITLE
Avoid importing packaging or pkg_resources for version validation

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -10,6 +10,8 @@ Under development: version 3.2.2 (a bug-fix release).
 * Correctly report if an extension raises a `TypeError` (#939).
 * Raise a `KeyError` when attempting to delete a nonexistent key from the
   extension registry (#939). 
+* Remove import of `packaging` (or `pkg_resources` fallback) entirely.
+* Remove `setuptools` as a run-time dependency (`install_required`).
 
 Feb 12, 2020: Released version 3.2.1 (a bug-fix release).
 

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -19,11 +19,6 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-try:
-    import packaging.version
-except ImportError:
-    from pkg_resources.extern import packaging
-
 # __version_info__ format:
 # (major, minor, patch, dev/alpha/beta/rc/final, #)
 # (1, 1, 2, 'dev', 0) => "1.1.2.dev0"
@@ -34,22 +29,21 @@ except ImportError:
 __version_info__ = (3, 2, 1, 'final', 0)
 
 
-def _get_version():  # pragma: no cover
+def _get_version(version_info):
     " Returns a PEP 440-compliant version number from version_info. "
-    assert len(__version_info__) == 5
-    assert __version_info__[3] in ('dev', 'alpha', 'beta', 'rc', 'final')
+    assert len(version_info) == 5
+    assert version_info[3] in ('dev', 'alpha', 'beta', 'rc', 'final')
 
-    parts = 2 if __version_info__[2] == 0 else 3
-    v = '.'.join(map(str, __version_info__[:parts]))
+    parts = 2 if version_info[2] == 0 else 3
+    v = '.'.join(map(str, version_info[:parts]))
 
-    if __version_info__[3] == 'dev':
-        v += '.dev' + str(__version_info__[4])
-    elif __version_info__[3] != 'final':
+    if version_info[3] == 'dev':
+        v += '.dev' + str(version_info[4])
+    elif version_info[3] != 'final':
         mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
-        v += mapping[__version_info__[3]] + str(__version_info__[4])
+        v += mapping[version_info[3]] + str(version_info[4])
 
-    # Ensure version is valid and normalized
-    return str(packaging.version.Version(v))
+    return v
 
 
-__version__ = _get_version()
+__version__ = _get_version(__version_info__)

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
     python_requires='>=3.5',
-    install_requires=['setuptools >= 36', "importlib_metadata;python_version<'3.8'"],
+    install_requires=["importlib_metadata;python_version<'3.8'"],
     extras_require={
         'testing': [
             'coverage',

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,24 @@
+import unittest
+from markdown.__meta__ import _get_version, __version__
+
+
+class TestVersion(unittest.TestCase):
+
+    def test_get_version(self):
+        """Test that _get_version formats __version_info__ as required by PEP 440."""
+
+        self.assertEqual(_get_version((1, 1, 2, 'dev', 0)), "1.1.2.dev0")
+        self.assertEqual(_get_version((1, 1, 2, 'alpha', 1)), "1.1.2a1")
+        self.assertEqual(_get_version((1, 2, 0, 'beta', 2)), "1.2b2")
+        self.assertEqual(_get_version((1, 2, 0, 'rc', 4)), "1.2rc4")
+        self.assertEqual(_get_version((1, 2, 0, 'final', 0)), "1.2")
+
+    def test__version__IsValid(self):
+        """Test that __version__ is valid and normalized."""
+
+        try:
+            import packaging.version
+        except ImportError:
+            from pkg_resources.extern import packaging
+
+        self.assertEqual(__version__, str(packaging.version.Version(__version__)))


### PR DESCRIPTION
Importing the `pkg_resources` module has high memory and startup time cost. A recent change 102e01c2462f20fdd29073bc0b1fe2252b517add already avoided it for loading extensions, but it's still used for validating `__version__` has correct format.

It is possible to avoid it by installing the `packaging` package, but that adds a dependency for something quite trivial.

Instead, remove the validation and add tests which check the output is as expected (they pass before and after).