### PR TITLE
Fix importlib-metadata requirement name for Python < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
     python_requires='>=3.5',
-    install_requires=["importlib_metadata;python_version<'3.8'"],
+    install_requires=["importlib-metadata;python_version<'3.8'"],
     extras_require={
         'testing': [
             'coverage',


### PR DESCRIPTION
The [`importlib-metadata`](https://pypi.org/project/importlib-metadata/) package on PyPI has a hyphen in its name, not underscore.

This might fix #961.