### PR TITLE
Add push trigger to tox workflow.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,8 +1,16 @@
-# This workflow will install Python dependencies and run tox tests with a matrix of Python versions.
+# This workflow will install dependencies and run tests/linters with a matrix of tox environments.
 
 name: CI
 
-on: [pull_request]
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '**'
+  pull_request:
+    branches:
+    - '**'
 
 jobs:
   test:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -75,6 +75,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Setup Node
+      if: ${{ matrix.tox-env == 'checklinks' }}
       uses: actions/setup-node@v1
       with:
         node-version: '10'

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![BSD License][bsdlicense-button]][bsdlicense]
 [![Code of Conduct][codeofconduct-button]][Code of Conduct]
 
-[build-button]: https://github.com/Python-Markdown/markdown/workflows/CI/badge.svg
-[build]: https://github.com/Python-Markdown/markdown/actions?query=workflow%3ACI
+[build-button]: https://github.com/Python-Markdown/markdown/workflows/CI/badge.svg?event=push
+[build]: https://github.com/Python-Markdown/markdown/actions?query=workflow%3ACI+event%3Apush
 [codecov-button]: https://codecov.io/gh/Python-Markdown/markdown/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/Python-Markdown/markdown
 [mdversion-button]: https://img.shields.io/pypi/v/Markdown.svg


### PR DESCRIPTION
The build button/badge in the README now only points to `push` events so that an unmerged failing PR doesn't cause the build status to show as 'failing.'