### PR TITLE
Support unicode ids in toc

### DIFF
--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -81,9 +81,9 @@ The following new features have been included in the 3.3 release:
   maintain the current behavior in the rebuilt Markdown in HTML extension. A few random
   edge-case bugs (see the included tests) were resolved in the process (#803).
 
-* An alternate method `markdown.extensions.headerid.slugify_unicode` has been included
+* An alternate function `markdown.extensions.headerid.slugify_unicode` has been included
   with the [Table of Contents](../extensions/toc.md) extension which supports Unicode
-  characters in table fo contents slugs. The old `markdown.extensions.headerid.slugify`
+  characters in table of contents slugs. The old `markdown.extensions.headerid.slugify`
   method which removes non-ASCII characters remains the default. Import and pass
   `markdown.extensions.headerid.slugify_unicode` to the `slugify` configuration option
   to use the new behavior.

--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -81,6 +81,13 @@ The following new features have been included in the 3.3 release:
   maintain the current behavior in the rebuilt Markdown in HTML extension. A few random
   edge-case bugs (see the included tests) were resolved in the process (#803).
 
+* An alternate method `markdown.extensions.headerid.slugify_unicode` has been included
+  with the [Table of Contents](../extensions/toc.md) extension which supports Unicode
+  characters in table fo contents slugs. The old `markdown.extensions.headerid.slugify`
+  method which removes non-ASCII characters remains the default. Import and pass
+  `markdown.extensions.headerid.slugify_unicode` to the `slugify` configuration option
+  to use the new behavior.
+
 ## Bug fixes
 
 The following bug fixes are included in the 3.3 release:

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -202,6 +202,8 @@ The following options are provided to configure the output:
 
     The callable must return a string appropriate for use in HTML `id` attributes.
 
+    An alternate version of the default callable supporting Unicode strings is also provided as `markdown.extensions.headerid.slugify_unicode`.
+
 * **`separator`**:
     Word separator. Character which replaces white space in id. Defaults to "`-`".
 

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -202,7 +202,8 @@ The following options are provided to configure the output:
 
     The callable must return a string appropriate for use in HTML `id` attributes.
 
-    An alternate version of the default callable supporting Unicode strings is also provided as `markdown.extensions.headerid.slugify_unicode`.
+    An alternate version of the default callable supporting Unicode strings is also
+    provided as `markdown.extensions.headerid.slugify_unicode`.
 
 * **`separator`**:
     Word separator. Character which replaces white space in id. Defaults to "`-`".

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -23,11 +23,20 @@ import unicodedata
 import xml.etree.ElementTree as etree
 
 
+def _slugify(value, separator, encoding='ascii'):
+    value = unicodedata.normalize('NFKD', value).encode(encoding, 'ignore')
+    value = re.sub(r'[^\w\s-]', '', value.decode(encoding)).strip().lower()
+    return re.sub(r'[%s\s]+' % separator, separator, value)
+
+
 def slugify(value, separator):
     """ Slugify a string, to make it URL friendly. """
-    value = unicodedata.normalize('NFKD', value).encode('utf-8', 'ignore')
-    value = re.sub(r'[^\w\s-]', '', value.decode('utf-8')).strip().lower()
-    return re.sub(r'[%s\s]+' % separator, separator, value)
+    return _slugify(value, separator)
+
+
+def slugify_unicode(value, separator):
+    """ Slugify a string, to make it URL friendly. """
+    return _slugify(value, separator, 'utf-8')
 
 
 IDCOUNT_RE = re.compile(r'^(.*)_([0-9]+)$')

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -23,20 +23,16 @@ import unicodedata
 import xml.etree.ElementTree as etree
 
 
-def _slugify(value, separator, encoding='ascii'):
+def slugify(value, separator, encoding='ascii'):
+    """ Slugify a string, to make it URL friendly. """
     value = unicodedata.normalize('NFKD', value).encode(encoding, 'ignore')
     value = re.sub(r'[^\w\s-]', '', value.decode(encoding)).strip().lower()
-    return re.sub(r'[%s\s]+' % separator, separator, value)
-
-
-def slugify(value, separator):
-    """ Slugify a string, to make it URL friendly. """
-    return _slugify(value, separator)
+    return re.sub(r'[{}\s]+'.format(separator), separator, value)
 
 
 def slugify_unicode(value, separator):
-    """ Slugify a string, to make it URL friendly. """
-    return _slugify(value, separator, 'utf-8')
+    """ Slugify a string, to make it URL friendly while preserving Unicode characters. """
+    return slugify(value, separator, 'utf-8')
 
 
 IDCOUNT_RE = re.compile(r'^(.*)_([0-9]+)$')

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -25,8 +25,8 @@ import xml.etree.ElementTree as etree
 
 def slugify(value, separator):
     """ Slugify a string, to make it URL friendly. """
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
-    value = re.sub(r'[^\w\s-]', '', value.decode('ascii')).strip().lower()
+    value = unicodedata.normalize('NFKD', value).encode('utf-8', 'ignore')
+    value = re.sub(r'[^\w\s-]', '', value.decode('utf-8')).strip().lower()
     return re.sub(r'[%s\s]+' % separator, separator, value)
 
 

--- a/tests/test_syntax/extensions/test_toc.py
+++ b/tests/test_syntax/extensions/test_toc.py
@@ -143,21 +143,23 @@ class TestTOC(TestCase):
         )
 
     def testPermalinkWithUnicodeInID(self):
+        from markdown.extensions.toc import slugify_unicode
         self.assertMarkdownRenders(
             '# Unicode ヘッダー',
             '<h1 id="unicode-ヘッター">'                                                            # noqa
                 'Unicode ヘッダー'                                                                  # noqa
                 '<a class="headerlink" href="#unicode-ヘッター" title="Permanent link">&para;</a>'  # noqa
             '</h1>',                                                                                # noqa
-            extensions=[TocExtension(permalink=True)]
+            extensions=[TocExtension(permalink=True, slugify=slugify_unicode)]
         )
 
     def testPermalinkWithUnicodeTitle(self):
+        from markdown.extensions.toc import slugify_unicode
         self.assertMarkdownRenders(
             '# Unicode ヘッダー',
             '<h1 id="unicode-ヘッター">'                                                            # noqa
                 'Unicode ヘッダー'                                                                  # noqa
-                '<a class="headerlink" href="#unicode-ヘッター" title="パーマリンク">&para;</a>'  # noqa
+                '<a class="headerlink" href="#unicode-ヘッター" title="パーマリンク">&para;</a>'    # noqa
             '</h1>',                                                                                # noqa
-            extensions=[TocExtension(permalink=True, permalink_title="パーマリンク")]
+            extensions=[TocExtension(permalink=True, permalink_title="パーマリンク", slugify=slugify_unicode)]
         )

--- a/tests/test_syntax/extensions/test_toc.py
+++ b/tests/test_syntax/extensions/test_toc.py
@@ -141,3 +141,23 @@ class TestTOC(TestCase):
             '</h1>',                                                              # noqa
             extensions=[TocExtension(permalink=True, permalink_title="")]
         )
+
+    def testPermalinkWithUnicodeInID(self):
+        self.assertMarkdownRenders(
+            '# Unicode ヘッダー',
+            '<h1 id="unicode-ヘッター">'                                                            # noqa
+                'Unicode ヘッダー'                                                                  # noqa
+                '<a class="headerlink" href="#unicode-ヘッター" title="Permanent link">&para;</a>'  # noqa
+            '</h1>',                                                                                # noqa
+            extensions=[TocExtension(permalink=True)]
+        )
+
+    def testPermalinkWithUnicodeTitle(self):
+        self.assertMarkdownRenders(
+            '# Unicode ヘッダー',
+            '<h1 id="unicode-ヘッター">'                                                            # noqa
+                'Unicode ヘッダー'                                                                  # noqa
+                '<a class="headerlink" href="#unicode-ヘッター" title="Permanent link">&para;</a>'  # noqa
+            '</h1>',                                                                                # noqa
+            extensions=[TocExtension(permalink=True, permalink_title="パーマリンク")]
+        )

--- a/tests/test_syntax/extensions/test_toc.py
+++ b/tests/test_syntax/extensions/test_toc.py
@@ -157,7 +157,7 @@ class TestTOC(TestCase):
             '# Unicode ヘッダー',
             '<h1 id="unicode-ヘッター">'                                                            # noqa
                 'Unicode ヘッダー'                                                                  # noqa
-                '<a class="headerlink" href="#unicode-ヘッター" title="Permanent link">&para;</a>'  # noqa
+                '<a class="headerlink" href="#unicode-ヘッター" title="パーマリンク">&para;</a>'  # noqa
             '</h1>',                                                                                # noqa
             extensions=[TocExtension(permalink=True, permalink_title="パーマリンク")]
         )


### PR DESCRIPTION
I'd like to propose a change to the way `slugify` works in `toc.py`.

Currently, `slugify` uses ascii to encode/decode strings and as a result if a header only contains unicode characters the resulting `id` and `href` becomes the default `#_1`, `#_2`, etc.

Instead, as the HTML standard does not impose any particular restriction on the character set used for the `id` attribute (https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute), I think it would be sensible to instead use utf-8 for encoding/decoding strings in `slugify` in order to better support international input.