### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: deploy
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+      - name: Build
+        run: |
+          python setup.py bdist_wheel sdist --formats gztar
+      - name: Publish
+        if: success()
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+
+  ghpages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -r doc-requirements.txt
+      - name: Build
+        run: |
+          python -m mkdocs build --clean --verbose
+      - name: Publish
+        if: success()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}
+          external_repository: Python-Markdown/Python-Markdown.github.io
+          publish_branch: master
+          publish_dir: ./site

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -94,7 +94,7 @@ along with a request for feedback.
 
 Pull requests will generally not be accepted if any tests are failing.
 Therefore, it is recommended that you run the tests before submitting your pull
-request. After making a pull request, check the Travis build status in the
+request. After making a pull request, check the build status in the
 GitHub interface to ensure that all tests are running as expected. If any checks
 fail, you may push additional commits to your branch. GitHub will add those
 commits to the pull request and rerun the checks.
@@ -407,20 +407,25 @@ following steps:
 
         Bump version to X.X.X
 
-6. After all checks (Travis, etc.) have passed, merge the pull request.
+6. After all checks have passed, merge the pull request.
 
 7. Create a git tag with the new version as the tag name and push to the
-   [Python-Markdown/markdown] repository.
+   [Python-Markdown/markdown] repository. The new tag should trigger a GitHub
+   workflow which will automatically deploy the release to PyPI and update the
+   documentation.
 
-8. Deploy the release to [PyPI] with the command `make deploy`.
+    In the event that the deployment fails, the following steps can be taken to
+    deploy manually:
 
-9. Deploy an update to the documentation using [MkDocs]. The following example
-   assumes that local clones of the [Python-Markdown/markdown] and
-   [Python-Markdown/Python-Markdown.github.io] repositories are in sibling
-   directories named `markdown` and `Python-Markdown.github.io` respectively.
+    - Deploy the release to [PyPI] with the command `make deploy`.
 
-        cd Python-Markdown.github.io
-        mkdocs gh-deploy --config-file ../markdown/mkdocs.yml --remote-branch master
+    - Deploy an update to the documentation using [MkDocs]. The following example
+      assumes that local clones of the [Python-Markdown/markdown] and
+      [Python-Markdown/Python-Markdown.github.io] repositories are in sibling
+      directories named `markdown` and `Python-Markdown.github.io` respectively.
+
+            cd Python-Markdown.github.io
+            mkdocs gh-deploy --config-file ../markdown/mkdocs.yml --remote-branch master
 
 ## Issue and Pull Request Labels
 


### PR DESCRIPTION
## TODO:

1. [x] <del>Create auth tokens for [PyPI][1] and [GH Pages][2].</del>
2. [ ] Test this. Maybe do a test with TestPyPI and/or an alpha release???
3. [x] <del>Update [Release Process][3] in the Contributing Guide (this replaces steps 8 & 9).</del>

[1]: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github
[2]: https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-create-ssh-deploy-key
[3]: https://github.com/Python-Markdown/markdown/blob/dc8583916a4c78feebdca4e93509dbfc439751c0/docs/contributing.md#release-process

## Notes:

I'm using [pypa/gh-action-pypi-publish] because that action is officially part of PyPA and documented in the [PyPA Guide] (I didn't even look at other options).

Of the many GitHub Pages deployment actions to choose from I chose [peaceiris/actions-gh-pages] for a few reasons:

1. As we are using org pages, we don't deploy to the same repo. It was not clear to me how to do that directly with `mkdocs gh-deploy`. We would need to checkout two repos, and deploy to the one while referencing the working files from the other (see step 9 of the [Release Process][3]).
2. This action officially supports and documents using [external repos] with public/private deploy keys (note: public key gets saved to  `Python-Markdown/Python-Markdown.github.io` and private key to `Python-Markdown/markdown`). The documentation for any other actions I looked at didn't mention how to do this, even if they appeared to have a config option for it.
3. This action also specifically provides a [MkDocs Example] in the documentation (among many other static site generators), which suggests continued support.
4. The action was one of the few highly rated ones (893 stars at time of publishing).

[pypa/gh-action-pypi-publish]: https://github.com/marketplace/actions/pypi-publish
[PyPA Guide]: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
[peaceiris/actions-gh-pages]: https://github.com/marketplace/actions/github-pages-action
[external repos]: https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-deploy-to-external-repository
[MkDocs Example]: https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-static-site-generators-with-python