### PR TITLE
Allow checklinks check to fail.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -68,6 +68,9 @@ jobs:
     env:
       TOXENV: ${{ matrix.tox-env }}
 
+    # Allow checklinks to fail
+    continue-on-error: ${{ matrix.tox-env == 'checklinks' }}
+
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python


### PR DESCRIPTION
There are too many random arbitrary failures with this check. We still
want the check to run to ensure we don't introduce any new errors.
However, the random errors on external URLs are frustrating, especcially
when a different URL fails on each run. And then when the URL is checked
manually, it is clearly good.

If the tool provided a flag to limit the check to intenral URLs only (it
doesn't), we wouldn't use that anyway because we do want to know when an
extenral URL becomes invalid. Although, I suppose we could do two runs,
one intenral and one external and only allow the external to fail. But
that will have to wait until such a feature is added to the tool or we
find a better tool.