### PR TITLE
Support fenced_code optional lang trailer: '::' up to } or newline

### DIFF
--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -34,13 +34,14 @@ class FencedBlockPreprocessor(Preprocessor):
     FENCED_BLOCK_RE = re.compile(r'''
 (?P<fence>^(?:~{3,}|`{3,}))[ ]*         # Opening ``` or ~~~
 (\{?\.?(?P<lang>[\w#.+-]*))?[ ]*        # Optional {, and lang
+(?P<lang2>::[^}\n]*)?                   # Optional lang trailer (up to } or NL)
 # Optional highlight lines, single- or double-quote-delimited
 (hl_lines=(?P<quot>"|')(?P<hl_lines>.*?)(?P=quot))?[ ]*
 }?[ ]*\n                                # Optional closing }
 (?P<code>.*?)(?<=\n)
 (?P=fence)[ ]*$''', re.MULTILINE | re.DOTALL | re.VERBOSE)
     CODE_WRAP = '<pre><code%s>%s</code></pre>'
-    LANG_TAG = ' class="%s"'
+    LANG_TAG = ' class="%s%s"'
 
     def __init__(self, md):
         super().__init__(md)
@@ -66,7 +67,8 @@ class FencedBlockPreprocessor(Preprocessor):
             if m:
                 lang = ''
                 if m.group('lang'):
-                    lang = self.LANG_TAG % m.group('lang')
+                    lang = self.LANG_TAG % (m.group('lang'), m.group(
+                            'lang2') or '')
 
                 # If config is not empty, then the codehighlite extension
                 # is enabled, so we call it to highlight the code


### PR DESCRIPTION
This is to allow [sphinx_markdown_parser](https://github.com/BroadbandForum/sphinx-markdown-parser)'s [AutoStructify](https://recommonmark.readthedocs.io/en/latest/auto_structify.html) [Embed reStructuredText](https://recommonmark.readthedocs.io/en/latest/auto_structify.html#embed-restructuredtext) option to work. Its second style expects `lang` tags like this to work as ReST directives:

~~~~~~
``` automodule:: module-name
```
~~~~~~

sphinx-markdown-parser assumes that the entire `automodule:: module-name` is parsed as the `lang` tag (and I can only assume that this used to work). However it no longer works because the lang tag needs to match this RE fragment (which doesn't allow spaces or colons):

```
(?P<lang>[\w#.+-]*)
```

The fix in this PR retains the above fragment but adds this optional fragment:

```
(?P<lang2>::[^}\n]*)?
```

I realise that the fix in this PR is probably not acceptable, because it doesn't sufficiently consider the impact on other valid syntaxes such as the `hl_lines` option, and indeed it may go against the spirit of the `lang` tag (although where is the acceptable lang syntax defined?). However I wanted to test the temperature to see whether people think that a fix at the markdown parser level might be acceptable.