### PR TITLE
Fix exception cause in core.py

### DIFF
--- a/markdown/core.py
+++ b/markdown/core.py
@@ -276,14 +276,14 @@ class Markdown:
                     '<%s>' % self.doc_tag) + len(self.doc_tag) + 2
                 end = output.rindex('</%s>' % self.doc_tag)
                 output = output[start:end].strip()
-            except ValueError:  # pragma: no cover
+            except ValueError as e:  # pragma: no cover
                 if output.strip().endswith('<%s />' % self.doc_tag):
                     # We have an empty document
                     output = ''
                 else:
                     # We have a serious problem
                     raise ValueError('Markdown failed to strip top-level '
-                                     'tags. Document=%r' % output.strip())
+                                     'tags. Document=%r' % output.strip()) from e
 
         # Run the text post-processors
         for pp in self.postprocessors:


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. In this project, I found only one instance of this mistake, and fixed it in this PR.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 