### PR TITLE
Fix unescaping of HTML characters <> in CodeHilite.

### DIFF
--- a/.spell-dict
+++ b/.spell-dict
@@ -132,6 +132,7 @@ Treeprocessors
 tuple
 tuples
 unescape
+unescaping
 unittest
 unordered
 untrusted

--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -55,7 +55,7 @@ The following bug fixes are included in the 3.3 release:
 
 * Fix issues with complex emphasis (#979).
 * Limitations of `attr_list` extension are Documented (#965).
-* Fix unescaping of HTML characters <> in CodeHilite (#990).
+* Fix unescaping of HTML characters `<>` in CodeHilite (#990).
 
 [spec]: https://www.w3.org/TR/html5/text-level-semantics.html#the-code-element
 [fenced_code]: ../extensions/fenced_code_blocks.md

--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -55,6 +55,7 @@ The following bug fixes are included in the 3.3 release:
 
 * Fix issues with complex emphasis (#979).
 * Limitations of `attr_list` extension are Documented (#965).
+* Fix unescaping of HTML characters <> in CodeHilite (#990).
 
 [spec]: https://www.w3.org/TR/html5/text-level-semantics.html#the-code-element
 [fenced_code]: ../extensions/fenced_code_blocks.md

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -225,9 +225,11 @@ class HiliteTreeprocessor(Treeprocessor):
 
     def code_unescape(self, text):
         """Unescape code."""
-        text = text.replace("&amp;", "&")
         text = text.replace("&lt;", "<")
         text = text.replace("&gt;", ">")
+        # Escaped '&' should be replaced at the end to avoid
+        # conflicting with < and >.
+        text = text.replace("&amp;", "&")
         return text
 
     def run(self, root):

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -564,6 +564,29 @@ class TestCodeHiliteExtension(TestCase):
             extensions=['codehilite']
         )
 
+    def testEntitiesIntact(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite"><pre>'
+                '<span></span>'
+                '<code>&lt; &amp;lt; and &gt; &amp;gt;'
+                '\n</code></pre></div>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code class="language-text">'
+                '&lt; &amp;lt; and &gt; &amp;gt;\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            (
+                '\t:::text\n'
+                '\t< &lt; and > &gt;'
+            ),
+            expected,
+            extensions=['codehilite']
+        )
+
     def testHighlightAmps(self):
         if has_pygments:
             expected = (


### PR DESCRIPTION
Previously, we'd unescape both `&amp;gt;` and `&gt;` to the same
string because we were running the &amp; => & replacement first.
By changing the order of this replacement, we now convert:

`&amp;gt; &gt;` => `&gt; >`

as expected.

Fixes #988.