### PR TITLE
Update information about richleland/pygments-css. 

### DIFF
--- a/docs/extensions/code_hilite.md
+++ b/docs/extensions/code_hilite.md
@@ -55,7 +55,7 @@ block will not be highlighted.
     GitHub user [richeland] has provided a number of different [CSS style
     sheets][rich] which work with Pygments along with a [preview] of each theme.
     The `css_class` used is `.highlight`. Therefore, one would need to override the
-    [css_class](#css_class) option when using richeland's CSS styles. However, the
+    [`css_class`](#css_class) option when using richeland's CSS styles. However, the
     Python-Markdown project makes no guarantee that richeland's CSS styles will
     work with the version of Pygments you are using. To ensure complete
     compatibility, you should generate the CSS rules from your own installation

--- a/docs/extensions/code_hilite.md
+++ b/docs/extensions/code_hilite.md
@@ -50,15 +50,16 @@ See Pygments' excellent [documentation] for more details. If no language is
 defined, Pygments will attempt to guess the language. When that fails, the code
 block will not be highlighted.
 
-!!! note "See Also"
+!!! seealso "See Also"
 
     GitHub user [richeland] has provided a number of different [CSS style
     sheets][rich] which work with Pygments along with a [preview] of each theme.
-    The `css_class` used is the same as the default value for that option
-    (`.codehilite`). However, the Python-Markdown project makes no guarantee that
-    richeland's CSS styles will work with the version of Pygments you are using.
-    To ensure complete compatibility, you should generate the CSS rules from
-    your own installation of Pygments.
+    The `css_class` used is `.highlight`. Therefore, one would need to override the
+    [css_class](#css_class) option when using richeland's CSS styles. However, the
+    Python-Markdown project makes no guarantee that richeland's CSS styles will
+    work with the version of Pygments you are using. To ensure complete
+    compatibility, you should generate the CSS rules from your own installation
+    of Pygments.
 
 [richeland]: https://github.com/richleland
 [rich]: https://github.com/richleland/pygments-css


### PR DESCRIPTION
As of richleland/pygments-css@146834e1 the css class was set to `.highlight`.
Closes #1020.