### PR TITLE
Made package do specific imports from xml.etree.ElementTree to prevent collision with defusedxml

### DIFF
--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -19,7 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element, ElementTree
 from . import util
 
 
@@ -86,9 +86,9 @@ class BlockParser:
 
         """
         # Create a ElementTree from the lines
-        self.root = etree.Element(self.md.doc_tag)
+        self.root = Element(self.md.doc_tag)
         self.parseChunk(self.root, '\n'.join(lines))
-        return etree.ElementTree(self.root)
+        return ElementTree(self.root)
 
     def parseChunk(self, parent, text):
         """ Parse a chunk of markdown text and attach to given etree node.

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -32,7 +32,7 @@ as they need to alter how markdown blocks are parsed.
 
 import logging
 import re
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element, SubElement
 from . import util
 from .blockparser import BlockParser
 
@@ -195,7 +195,7 @@ class ListIndentProcessor(BlockProcessor):
                 # If the parent li has text, that text needs to be moved to a p
                 # The p must be 'inserted' at beginning of list in the event
                 # that other children already exist i.e.; a nested sublist.
-                p = etree.Element('p')
+                p = Element('p')
                 p.text = sibling[-1].text
                 sibling[-1].text = ''
                 sibling[-1].insert(0, p)
@@ -206,7 +206,7 @@ class ListIndentProcessor(BlockProcessor):
 
     def create_item(self, parent, block):
         """ Create a new li and parse the block with it as the parent. """
-        li = etree.SubElement(parent, 'li')
+        li = SubElement(parent, 'li')
         self.parser.parseBlocks(li, [block])
 
     def get_level(self, parent, block):
@@ -260,8 +260,8 @@ class CodeBlockProcessor(BlockProcessor):
             )
         else:
             # This is a new codeblock. Create the elements and insert text.
-            pre = etree.SubElement(parent, 'pre')
-            code = etree.SubElement(pre, 'code')
+            pre = SubElement(parent, 'pre')
+            code = SubElement(pre, 'code')
             block, theRest = self.detab(block)
             code.text = util.AtomicString('%s\n' % util.code_escape(block.rstrip()))
         if theRest:
@@ -295,7 +295,7 @@ class BlockQuoteProcessor(BlockProcessor):
             quote = sibling
         else:
             # This is a new blockquote. Create a new parent element.
-            quote = etree.SubElement(parent, 'blockquote')
+            quote = SubElement(parent, 'blockquote')
         # Recursively parse block with blockquote as parent.
         # change parser state so blockquotes embedded in lists use p tags
         self.parser.state.set('blockquote')
@@ -355,7 +355,7 @@ class OListProcessor(BlockProcessor):
                 # since it's possible there are other children for this
                 # sibling, we can't just SubElement the p, we need to
                 # insert it as the first item.
-                p = etree.Element('p')
+                p = Element('p')
                 p.text = lst[-1].text
                 lst[-1].text = ''
                 lst[-1].insert(0, p)
@@ -363,12 +363,12 @@ class OListProcessor(BlockProcessor):
             # likely only when a header is not followed by a blank line
             lch = self.lastChild(lst[-1])
             if lch is not None and lch.tail:
-                p = etree.SubElement(lst[-1], 'p')
+                p = SubElement(lst[-1], 'p')
                 p.text = lch.tail.lstrip()
                 lch.tail = ''
 
             # parse first block differently as it gets wrapped in a p.
-            li = etree.SubElement(lst, 'li')
+            li = SubElement(lst, 'li')
             self.parser.state.set('looselist')
             firstitem = items.pop(0)
             self.parser.parseBlocks(li, [firstitem])
@@ -382,7 +382,7 @@ class OListProcessor(BlockProcessor):
             lst = parent
         else:
             # This is a new list so create parent with appropriate tag.
-            lst = etree.SubElement(parent, self.TAG)
+            lst = SubElement(parent, self.TAG)
             # Check if a custom start integer is set
             if not self.LAZY_OL and self.STARTSWITH != '1':
                 lst.attrib['start'] = self.STARTSWITH
@@ -396,7 +396,7 @@ class OListProcessor(BlockProcessor):
                 self.parser.parseBlocks(lst[-1], [item])
             else:
                 # New item. Create li and parse with it as parent
-                li = etree.SubElement(lst, 'li')
+                li = SubElement(lst, 'li')
                 self.parser.parseBlocks(li, [item])
         self.parser.state.reset()
 
@@ -459,7 +459,7 @@ class HashHeaderProcessor(BlockProcessor):
                 # recursively parse this lines as a block.
                 self.parser.parseBlocks(parent, [before])
             # Create header using named groups from RE
-            h = etree.SubElement(parent, 'h%d' % len(m.group('level')))
+            h = SubElement(parent, 'h%d' % len(m.group('level')))
             h.text = m.group('header').strip()
             if after:
                 # Insert remaining lines as first block for future parsing.
@@ -485,7 +485,7 @@ class SetextHeaderProcessor(BlockProcessor):
             level = 1
         else:
             level = 2
-        h = etree.SubElement(parent, 'h%d' % level)
+        h = SubElement(parent, 'h%d' % level)
         h.text = lines[0].strip()
         if len(lines) > 2:
             # Block contains additional lines. Add to  master blocks for later.
@@ -519,7 +519,7 @@ class HRProcessor(BlockProcessor):
             # Recursively parse lines before hr so they get parsed first.
             self.parser.parseBlocks(parent, [prelines])
         # create hr
-        etree.SubElement(parent, 'hr')
+        SubElement(parent, 'hr')
         # check for lines in block after hr.
         postlines = block[match.end():].lstrip('\n')
         if postlines:
@@ -588,5 +588,5 @@ class ParagraphProcessor(BlockProcessor):
                         parent.text = block.lstrip()
             else:
                 # Create a regular paragraph
-                p = etree.SubElement(parent, 'p')
+                p = SubElement(parent, 'p')
                 p.text = block.lstrip()

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -21,7 +21,7 @@ from ..preprocessors import Preprocessor
 from ..inlinepatterns import InlineProcessor
 from ..util import AtomicString
 import re
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element
 
 # Global Vars
 ABBR_REF_RE = re.compile(r'[*]\[(?P<abbr>[^\]]*)\][ ]?:\s*(?P<title>.*)')
@@ -84,7 +84,7 @@ class AbbrInlineProcessor(InlineProcessor):
         self.title = title
 
     def handleMatch(self, m, data):
-        abbr = etree.Element('abbr')
+        abbr = Element('abbr')
         abbr.text = AtomicString(m.group('abbr'))
         abbr.set('title', self.title)
         return abbr, m.start(0), m.end(0)

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -19,7 +19,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import SubElement
 import re
 
 
@@ -121,10 +121,10 @@ class AdmonitionProcessor(BlockProcessor):
 
         if m:
             klass, title = self.get_class_and_title(m)
-            div = etree.SubElement(parent, 'div')
+            div = SubElement(parent, 'div')
             div.set('class', '{} {}'.format(self.CLASSNAME, klass))
             if title:
-                p = etree.SubElement(div, 'p')
+                p = SubElement(div, 'p')
                 p.text = title
                 p.set('class', self.CLASSNAME_TITLE)
         else:
@@ -132,7 +132,7 @@ class AdmonitionProcessor(BlockProcessor):
             if sibling.tag in ('li', 'dd') and sibling.text:
                 text = sibling.text
                 sibling.text = ''
-                p = etree.SubElement(sibling, 'p')
+                p = SubElement(sibling, 'p')
                 p.text = text
 
             div = sibling

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor, ListIndentProcessor
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import SubElement
 import re
 
 
@@ -69,14 +69,14 @@ class DefListProcessor(BlockProcessor):
                 state = 'looselist'
         else:
             # This is a new list
-            dl = etree.SubElement(parent, 'dl')
+            dl = SubElement(parent, 'dl')
         # Add terms
         for term in terms:
-            dt = etree.SubElement(dl, 'dt')
+            dt = SubElement(dl, 'dt')
             dt.text = term
         # Add definition
         self.parser.state.set(state)
-        dd = etree.SubElement(dl, 'dd')
+        dd = SubElement(dl, 'dd')
         self.parser.parseBlocks(dd, [d])
         self.parser.state.reset()
 
@@ -94,7 +94,7 @@ class DefListIndentProcessor(ListIndentProcessor):
     def create_item(self, parent, block):
         """ Create a new dd or li (depending on parent) and parse the block with it as the parent. """
 
-        dd = etree.SubElement(parent, 'dd')
+        dd = SubElement(parent, 'dd')
         self.parser.parseBlocks(dd, [block])
 
 

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -22,7 +22,7 @@ from .. import util
 from collections import OrderedDict
 import re
 import copy
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element, SubElement
 
 FN_BACKLINK_TEXT = util.STX + "zz1337820767766393qq" + util.ETX
 NBSP_PLACEHOLDER = util.STX + "qq3936677670287331zz" + util.ETX
@@ -166,14 +166,14 @@ class FootnoteExtension(Extension):
         if not list(self.footnotes.keys()):
             return None
 
-        div = etree.Element("div")
+        div = Element("div")
         div.set('class', 'footnote')
-        etree.SubElement(div, "hr")
-        ol = etree.SubElement(div, "ol")
-        surrogate_parent = etree.Element("div")
+        SubElement(div, "hr")
+        ol = SubElement(div, "ol")
+        surrogate_parent = Element("div")
 
         for index, id in enumerate(self.footnotes.keys(), start=1):
-            li = etree.SubElement(ol, "li")
+            li = SubElement(ol, "li")
             li.set("id", self.makeFootnoteId(id))
             # Parse footnote with surrogate parent as li cannot be used.
             # List block handlers have special logic to deal with li.
@@ -182,7 +182,7 @@ class FootnoteExtension(Extension):
             for el in list(surrogate_parent):
                 li.append(el)
                 surrogate_parent.remove(el)
-            backlink = etree.Element("a")
+            backlink = Element("a")
             backlink.set("href", "#" + self.makeFootnoteRefId(id))
             backlink.set("class", "footnote-backref")
             backlink.set(
@@ -197,7 +197,7 @@ class FootnoteExtension(Extension):
                     node.text = node.text + NBSP_PLACEHOLDER
                     node.append(backlink)
                 else:
-                    p = etree.SubElement(li, "p")
+                    p = SubElement(li, "p")
                     p.append(backlink)
         return div
 
@@ -314,8 +314,8 @@ class FootnoteInlineProcessor(InlineProcessor):
     def handleMatch(self, m, data):
         id = m.group(1)
         if id in self.footnotes.footnotes.keys():
-            sup = etree.Element("sup")
-            a = etree.SubElement(sup, "a")
+            sup = Element("sup")
+            a = SubElement(sup, "a")
             sup.set('id', self.footnotes.makeFootnoteRefId(id, found=True))
             a.set('href', '#' + self.footnotes.makeFootnoteId(id))
             a.set('class', 'footnote-ref')

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -18,7 +18,7 @@ from . import Extension
 from ..blockprocessors import BlockProcessor
 from .. import util
 import re
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import SubElement
 
 
 class MarkdownInHtmlProcessor(BlockProcessor):
@@ -53,7 +53,7 @@ class MarkdownInHtmlProcessor(BlockProcessor):
 
         # Create Element
         markdown_value = tag['attrs'].pop('markdown')
-        element = etree.SubElement(parent, tag['tag'], tag['attrs'])
+        element = SubElement(parent, tag['tag'], tag['attrs'])
 
         # Slice Off Block
         if nest:

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import SubElement
 import re
 PIPE_NONE = 0
 PIPE_LEFT = 1
@@ -91,10 +91,10 @@ class TableProcessor(BlockProcessor):
                 align.append(None)
 
         # Build table
-        table = etree.SubElement(parent, 'table')
-        thead = etree.SubElement(table, 'thead')
+        table = SubElement(parent, 'table')
+        thead = SubElement(table, 'thead')
         self._build_row(header, thead, align)
-        tbody = etree.SubElement(table, 'tbody')
+        tbody = SubElement(table, 'tbody')
         if len(rows) == 0:
             # Handle empty table
             self._build_empty_row(tbody, align)
@@ -104,15 +104,15 @@ class TableProcessor(BlockProcessor):
 
     def _build_empty_row(self, parent, align):
         """Build an empty row."""
-        tr = etree.SubElement(parent, 'tr')
+        tr = SubElement(parent, 'tr')
         count = len(align)
         while count:
-            etree.SubElement(tr, 'td')
+            SubElement(tr, 'td')
             count -= 1
 
     def _build_row(self, row, parent, align):
         """ Given a row of text, build table cells. """
-        tr = etree.SubElement(parent, 'tr')
+        tr = SubElement(parent, 'tr')
         tag = 'td'
         if parent.tag == 'thead':
             tag = 'th'
@@ -120,7 +120,7 @@ class TableProcessor(BlockProcessor):
         # We use align here rather than cells to ensure every row
         # contains the same number of columns.
         for i, a in enumerate(align):
-            c = etree.SubElement(tr, tag)
+            c = SubElement(tr, tag)
             try:
                 c.text = cells[i].strip(' ')
             except IndexError:  # pragma: no cover

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -20,7 +20,7 @@ from ..postprocessors import UnescapePostprocessor
 import re
 import html
 import unicodedata
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element, SubElement
 
 
 def slugify(value, separator):
@@ -201,7 +201,7 @@ class TocTreeprocessor(Treeprocessor):
         elem.tag = 'h%d' % level
 
     def add_anchor(self, c, elem_id):  # @ReservedAssignment
-        anchor = etree.Element("a")
+        anchor = Element("a")
         anchor.text = c.text
         anchor.attrib["href"] = "#" + elem_id
         anchor.attrib["class"] = self.anchorlink_class
@@ -213,7 +213,7 @@ class TocTreeprocessor(Treeprocessor):
         c.append(anchor)
 
     def add_permalink(self, c, elem_id):
-        permalink = etree.Element("a")
+        permalink = Element("a")
         permalink.text = ("%spara;" % AMP_SUBSTITUTE
                           if self.use_permalinks is True
                           else self.use_permalinks)
@@ -225,21 +225,21 @@ class TocTreeprocessor(Treeprocessor):
 
     def build_toc_div(self, toc_list):
         """ Return a string div given a toc list. """
-        div = etree.Element("div")
+        div = Element("div")
         div.attrib["class"] = "toc"
 
         # Add title to the div
         if self.title:
-            header = etree.SubElement(div, "span")
+            header = SubElement(div, "span")
             header.attrib["class"] = "toctitle"
             header.text = self.title
 
         def build_etree_ul(toc_list, parent):
-            ul = etree.SubElement(parent, "ul")
+            ul = SubElement(parent, "ul")
             for item in toc_list:
                 # List item link, to be inserted into the toc div
-                li = etree.SubElement(ul, "li")
-                link = etree.SubElement(li, "a")
+                li = SubElement(ul, "li")
+                link = SubElement(li, "a")
                 link.text = item.get('name', '')
                 link.attrib["href"] = '#' + item.get('id', '')
                 if item['children']:

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..inlinepatterns import InlineProcessor
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element
 import re
 
 
@@ -59,7 +59,7 @@ class WikiLinksInlineProcessor(InlineProcessor):
             base_url, end_url, html_class = self._getMeta()
             label = m.group(1).strip()
             url = self.config['build_url'](label, base_url, end_url)
-            a = etree.Element('a')
+            a = Element('a')
             a.text = label
             a.set('href', url)
             if html_class:

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -63,7 +63,7 @@ So, we apply the expressions in the following order:
 from . import util
 from collections import namedtuple
 import re
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element, SubElement
 try:  # pragma: no cover
     from html import entities
 except ImportError:  # pragma: no cover
@@ -338,7 +338,7 @@ class SimpleTagPattern(Pattern):  # pragma: no cover
         self.tag = tag
 
     def handleMatch(self, m):
-        el = etree.Element(self.tag)
+        el = Element(self.tag)
         el.text = m.group(3)
         return el
 
@@ -354,7 +354,7 @@ class SimpleTagInlineProcessor(InlineProcessor):
         self.tag = tag
 
     def handleMatch(self, m, data):  # pragma: no cover
-        el = etree.Element(self.tag)
+        el = Element(self.tag)
         el.text = m.group(2)
         return el, m.start(0), m.end(0)
 
@@ -362,13 +362,13 @@ class SimpleTagInlineProcessor(InlineProcessor):
 class SubstituteTagPattern(SimpleTagPattern):  # pragma: no cover
     """ Return an element of type `tag` with no children. """
     def handleMatch(self, m):
-        return etree.Element(self.tag)
+        return Element(self.tag)
 
 
 class SubstituteTagInlineProcessor(SimpleTagInlineProcessor):
     """ Return an element of type `tag` with no children. """
     def handleMatch(self, m, data):
-        return etree.Element(self.tag), m.start(0), m.end(0)
+        return Element(self.tag), m.start(0), m.end(0)
 
 
 class BacktickInlineProcessor(InlineProcessor):
@@ -380,7 +380,7 @@ class BacktickInlineProcessor(InlineProcessor):
 
     def handleMatch(self, m, data):
         if m.group(3):
-            el = etree.Element(self.tag)
+            el = Element(self.tag)
             el.text = util.AtomicString(util.code_escape(m.group(3).strip()))
             return el, m.start(0), m.end(0)
         else:
@@ -395,8 +395,8 @@ class DoubleTagPattern(SimpleTagPattern):  # pragma: no cover
     """
     def handleMatch(self, m):
         tag1, tag2 = self.tag.split(",")
-        el1 = etree.Element(tag1)
-        el2 = etree.SubElement(el1, tag2)
+        el1 = Element(tag1)
+        el2 = SubElement(el1, tag2)
         el2.text = m.group(3)
         if len(m.groups()) == 5:
             el2.tail = m.group(4)
@@ -411,8 +411,8 @@ class DoubleTagInlineProcessor(SimpleTagInlineProcessor):
     """
     def handleMatch(self, m, data):  # pragma: no cover
         tag1, tag2 = self.tag.split(",")
-        el1 = etree.Element(tag1)
-        el2 = etree.SubElement(el1, tag2)
+        el1 = Element(tag1)
+        el2 = SubElement(el1, tag2)
         el2.text = m.group(2)
         if len(m.groups()) == 3:
             el2.tail = m.group(3)
@@ -458,7 +458,7 @@ class AsteriskProcessor(InlineProcessor):
 
     def build_single(self, m, tag, idx):
         """Return single tag."""
-        el1 = etree.Element(tag)
+        el1 = Element(tag)
         text = m.group(2)
         self.parse_sub_patterns(text, el1, None, idx)
         return el1
@@ -467,8 +467,8 @@ class AsteriskProcessor(InlineProcessor):
         """Return double tag."""
 
         tag1, tag2 = tags.split(",")
-        el1 = etree.Element(tag1)
-        el2 = etree.Element(tag2)
+        el1 = Element(tag1)
+        el2 = Element(tag2)
         text = m.group(2)
         self.parse_sub_patterns(text, el2, None, idx)
         el1.append(el2)
@@ -481,8 +481,8 @@ class AsteriskProcessor(InlineProcessor):
         """Return double tags (variant 2): `<strong>text <em>text</em></strong>`."""
 
         tag1, tag2 = tags.split(",")
-        el1 = etree.Element(tag1)
-        el2 = etree.Element(tag2)
+        el1 = Element(tag1)
+        el2 = Element(tag2)
         text = m.group(2)
         self.parse_sub_patterns(text, el1, None, idx)
         text = m.group(3)
@@ -497,10 +497,10 @@ class AsteriskProcessor(InlineProcessor):
         `data` (`str`):
             text to evaluate.
 
-        `parent` (`etree.Element`):
+        `parent` (`Element`):
             Parent to attach text and sub elements to.
 
-        `last` (`etree.Element`):
+        `last` (`Element`):
             Last appended child to parent. Can also be None if parent has no children.
 
         `idx` (`int`):
@@ -608,7 +608,7 @@ class LinkInlineProcessor(InlineProcessor):
         if not handled:
             return None, None, None
 
-        el = etree.Element("a")
+        el = Element("a")
         el.text = text
 
         el.set("href", href)
@@ -766,7 +766,7 @@ class ImageInlineProcessor(LinkInlineProcessor):
         if not handled:
             return None, None, None
 
-        el = etree.Element("img")
+        el = Element("img")
 
         el.set("src", src)
 
@@ -818,7 +818,7 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
         return id, end, True
 
     def makeTag(self, href, title, text):
-        el = etree.Element('a')
+        el = Element('a')
 
         el.set('href', href)
         if title:
@@ -839,7 +839,7 @@ class ShortReferenceInlineProcessor(ReferenceInlineProcessor):
 class ImageReferenceInlineProcessor(ReferenceInlineProcessor):
     """ Match to a stored reference and return img element. """
     def makeTag(self, href, title, text):
-        el = etree.Element("img")
+        el = Element("img")
         el.set("src", href)
         if title:
             el.set("title", title)
@@ -858,7 +858,7 @@ class ShortImageReferenceInlineProcessor(ImageReferenceInlineProcessor):
 class AutolinkInlineProcessor(InlineProcessor):
     """ Return a link Element given an autolink (`<http://example/com>`). """
     def handleMatch(self, m, data):
-        el = etree.Element("a")
+        el = Element("a")
         el.set('href', self.unescape(m.group(1)))
         el.text = util.AtomicString(m.group(1))
         return el, m.start(0), m.end(0)
@@ -869,7 +869,7 @@ class AutomailInlineProcessor(InlineProcessor):
     Return a mailto link Element given an automail link (`<foo@example.com>`).
     """
     def handleMatch(self, m, data):
-        el = etree.Element('a')
+        el = Element('a')
         email = self.unescape(m.group(1))
         if email.startswith("mailto:"):
             email = email[len("mailto:"):]

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -19,7 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element
 from . import util
 from . import inlinepatterns
 
@@ -376,7 +376,7 @@ class InlineProcessor(Treeprocessor):
                     self.ancestors.pop()
                 if child.tail:
                     tail = self.__handleInline(child.tail)
-                    dumby = etree.Element('d')
+                    dumby = Element('d')
                     child.tail = None
                     tailResult = self.__processPlaceholders(tail, dumby, False)
                     if dumby.tail:

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -24,7 +24,7 @@ import sys
 from collections import namedtuple
 from functools import wraps
 import warnings
-import xml.etree.ElementTree
+from xml.etree import ElementTree
 from .pep562 import Pep562
 from itertools import count
 
@@ -39,7 +39,7 @@ PY37 = (3, 7) <= sys.version_info
 
 # TODO: Remove deprecated variables in a future release.
 __deprecated__ = {
-    'etree': ('xml.etree.ElementTree', xml.etree.ElementTree),
+    'etree': ('xml.etree.ElementTree', ElementTree),
     'string_type': ('str', str),
     'text_type': ('str', str),
     'int2str': ('chr', chr),


### PR DESCRIPTION
This comes in order to fix an error I experience when using both `markdown` and `defusedxml`:
```
TypeError: insert() argument 2 must be xml.etree.ElementTree.Element, not Element
```
My solution is based on [this comment](https://github.com/tiran/defusedxml/issues/43#issuecomment-562995041) on the issue in `defusedxml`.