### PR TITLE
Add PY39 support and drop PY35

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,16 +20,16 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py35, py36, py37, py38, pypy3, pygments]
+        tox-env: [py36, py37, py38, py39, pypy3, pygments]
         include:
-          - tox-env: py35
-            python-version: 3.5
           - tox-env: py36
             python-version: 3.6
           - tox-env: py37
             python-version: 3.7
           - tox-env: py38
             python-version: 3.8
+          - tox-env: py39
+            python-version: 3.9
           - tox-env: pypy3
             python-version: pypy3
           - tox-env: pygments
@@ -91,4 +91,3 @@ jobs:
         if [[ "$TOXENV" == 'checkspelling' ]]; then sudo apt-get install aspell aspell-en; fi
     - name: Run tox
       run: python -m tox
-

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Setup Node

--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -2,8 +2,7 @@ title: Release Notes for v3.3
 
 # Python-Markdown 3.3 Release Notes
 
-Python-Markdown version 3.3 supports Python versions 3.5, 3.6, 3.7, 3.8, and
-PyPy3.
+Python-Markdown version 3.3 supports Python versions 3.6, 3.7, 3.8, 3.9 and PyPy3.
 
 ## Backwards-incompatible changes
 
@@ -87,6 +86,8 @@ The following new features have been included in the 3.3 release:
   method which removes non-ASCII characters remains the default. Import and pass
   `markdown.extensions.headerid.slugify_unicode` to the `slugify` configuration option
   to use the new behavior.
+
+* Support was added for Python 3.9 and dropped for Python 3.5.
 
 ## Bug fixes
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     maintainer_email='waylan.limberg@icloud.com',
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=["importlib-metadata;python_version<'3.8'"],
     extras_require={
         'testing': [
@@ -114,10 +114,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy3, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py36, py37, py38, py39, pypy3, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]
 extras = testing
 deps = pytidylib
-commands = 
+commands =
     coverage run --source=markdown -m unittest discover {toxinidir}/tests
     coverage xml
     coverage report --show-missing


### PR DESCRIPTION
Python 3.5 reached end-of-life on 2020-09-12. Python 3.9 is scheduled for release on 2020-10-05. Might as well address both together.

Note, I haven't tested on PY39 yet. The GH Action/Check will be the first and I haven't checked if anything special is required to run a pre-release version. If it fails, I'll come back after the final release and rerun it.