### PR TITLE
Drop unneeded dependency python_version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
     python_requires='>=3.6',
-    install_requires=["importlib-metadata;python_version<'3.8'"],
+    install_requires=["importlib-metadata"],
     extras_require={
         'testing': [
             'coverage',


### PR DESCRIPTION
Line 78 implies that the dependency [python_version](https://pypi.org/project/python_version/) is required for a [minimal installation](https://packaging.python.org/discussions/install-requires-vs-requirements/) of markdown. 

However, searching through the code and looking at https://github.com/Python-Markdown/markdown/commit/102e01c2462f20fdd29073bc0b1fe2252b517add#diff-2eeaed663bd0d25b7e608891384b7298 I don't see python_version imported in this package. 

Apologies in advance if I'm mistaken. 