### PR TITLE
Some test tweaks.

### DIFF
--- a/markdown/test_tools.py
+++ b/markdown/test_tools.py
@@ -140,8 +140,11 @@ class LegacyTestMeta(type):
                     expected = f.read().replace("\r\n", "\n")
                 output = markdown(input, **kwargs)
                 if tidylib and normalize:
-                    expected = _normalize_whitespace(expected)
-                    output = _normalize_whitespace(output)
+                    try:
+                        expected = _normalize_whitespace(expected)
+                        output = _normalize_whitespace(output)
+                    except OSError:
+                        self.skipTest("Tidylib's c library not available.")
                 elif normalize:
                     self.skipTest('Tidylib not available.')
                 self.assertMultiLineEqual(output, expected)

--- a/tests/test_syntax/extensions/test_fenced_code.py
+++ b/tests/test_syntax/extensions/test_fenced_code.py
@@ -21,14 +21,19 @@ License: BSD (see LICENSE.md for details).
 
 from markdown.test_tools import TestCase
 import markdown
+import os
 
 
 class TestFencedCode(TestCase):
 
     def setUp(self):
-        self.has_pygments = True
+        # Only set self.has_pygments to True if pygments is installed and the version matches
+        # the version expected by the tests. The version expected by the tests is the version
+        # specified and installed in the 'pygments' tox env. Outside of the tox env, an environment
+        # variable named PYGMENTS_VERSION will need to be defined to force the tests to use pygments.
         try:
             import pygments  # noqa
+            self.has_pygments = pygments.__version__ == os.environ.get('PYGMENTS_VERSION', '')
         except ImportError:
             self.has_pygments = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,11 @@ commands =
 
 [testenv:pygments]
 # Run tests with pygments installed (override deps only).
+setenv =
+    PYGMENTS_VERSION = 2.7.1
 deps =
     pytidylib
-    pygments==2.7.1
+    pygments=={env:PYGMENTS_VERSION}
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
* Pygments specific tests now only run when the pygments version installed
  matches the expected version. That version is defined in an environment
  variable (PYGMENTS_VERSION) in the 'pygments' tox env (see #1030).
* When the Python lib tidylib is installed but the underlying c lib is not,
  the relevant tests are now skipped rather than fail. This matches the
  behavior when the Python lib is not installed. The tox envs are now useful
  on systems which don't have the c lib installed.