### PR TITLE
Skip tests with pygments version mismatch.

### DIFF
--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -21,6 +21,7 @@ License: BSD (see LICENSE.md for details).
 
 from markdown.test_tools import TestCase
 from markdown.extensions.codehilite import CodeHiliteExtension, CodeHilite
+import os
 
 try:
     import pygments  # noqa
@@ -28,9 +29,18 @@ try:
 except ImportError:
     has_pygments = False
 
+# The version required by the tests is the version specified and installed in the 'pygments' tox env.
+# In any environment where the PYGMENTS_VERSION environment variabe is either not defined or doesn't
+# match the version of Pygments installed, all tests which rely in pygments will be skipped.
+required_pygments_version = os.environ.get('PYGMENTS_VERSION', '')
+
 
 class TestCodeHiliteClass(TestCase):
     """ Test the markdown.extensions.codehilite.CodeHilite class. """
+
+    def setUp(self):
+        if has_pygments and pygments.__version__ != required_pygments_version:
+            self.skipTest(f'Pygments=={required_pygments_version} is required')
 
     maxDiff = None
 
@@ -339,6 +349,10 @@ class TestCodeHiliteClass(TestCase):
 
 class TestCodeHiliteExtension(TestCase):
     """ Test codehilite extension. """
+
+    def setUp(self):
+        if has_pygments and pygments.__version__ != required_pygments_version:
+            self.skipTest(f'Pygments=={required_pygments_version} is required')
 
     maxDiff = None
 

--- a/tests/test_syntax/extensions/test_fenced_code.py
+++ b/tests/test_syntax/extensions/test_fenced_code.py
@@ -23,19 +23,19 @@ from markdown.test_tools import TestCase
 import markdown
 import os
 
+try:
+    import pygments  # noqa
+    has_pygments = True
+except ImportError:
+    has_pygments = False
+
+# The version required by the tests is the version specified and installed in the 'pygments' tox env.
+# In any environment where the PYGMENTS_VERSION environment variabe is either not defined or doesn't
+# match the version of Pygments installed, all tests which rely in pygments will be skipped.
+required_pygments_version = os.environ.get('PYGMENTS_VERSION', '')
+
 
 class TestFencedCode(TestCase):
-
-    def setUp(self):
-        # Only set self.has_pygments to True if pygments is installed and the version matches
-        # the version expected by the tests. The version expected by the tests is the version
-        # specified and installed in the 'pygments' tox env. Outside of the tox env, an environment
-        # variable named PYGMENTS_VERSION will need to be defined to force the tests to use pygments.
-        try:
-            import pygments  # noqa
-            self.has_pygments = pygments.__version__ == os.environ.get('PYGMENTS_VERSION', '')
-        except ImportError:
-            self.has_pygments = False
 
     def testBasicFence(self):
         self.assertMarkdownRenders(
@@ -132,165 +132,6 @@ class TestFencedCode(TestCase):
                 '''
             ),
             extensions=['fenced_code']
-        )
-
-    def testFencedCodeWithHighlightLines(self):
-        if self.has_pygments:
-            expected = self.dedent(
-                '''
-                <div class="codehilite"><pre><span></span><code><span class="hll">line 1
-                </span>line 2
-                <span class="hll">line 3
-                </span></code></pre></div>
-                '''
-            )
-        else:
-            expected = self.dedent(
-                    '''
-                    <pre class="codehilite"><code>line 1
-                    line 2
-                    line 3
-                    </code></pre>
-                    '''
-                )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ```hl_lines="1 3"
-                line 1
-                line 2
-                line 3
-                ```
-                '''
-            ),
-            expected,
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedLanguageAndHighlightLines(self):
-        if self.has_pygments:
-            expected = (
-                '<div class="codehilite"><pre><span></span><code>'
-                '<span class="hll"><span class="n">line</span> <span class="mi">1</span>\n'
-                '</span><span class="n">line</span> <span class="mi">2</span>\n'
-                '<span class="hll"><span class="n">line</span> <span class="mi">3</span>\n'
-                '</span></code></pre></div>'
-            )
-        else:
-            expected = self.dedent(
-                    '''
-                    <pre class="codehilite"><code class="language-python">line 1
-                    line 2
-                    line 3
-                    </code></pre>
-                    '''
-                )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` .python hl_lines="1 3"
-                line 1
-                line 2
-                line 3
-                ```
-                '''
-            ),
-            expected,
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedLanguageAndPygmentsDisabled(self):
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` .python
-                # Some python code
-                ```
-                '''
-            ),
-            self.dedent(
-                '''
-                <pre><code class="language-python"># Some python code
-                </code></pre>
-                '''
-            ),
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(use_pygments=False),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedLanguageDoubleEscape(self):
-        if self.has_pygments:
-            expected = (
-                '<div class="codehilite"><pre><span></span><code>'
-                '<span class="p">&lt;</span><span class="nt">span</span>'
-                '<span class="p">&gt;</span>This<span class="ni">&amp;amp;</span>'
-                'That<span class="p">&lt;/</span><span class="nt">span</span>'
-                '<span class="p">&gt;</span>\n'
-                '</code></pre></div>'
-            )
-        else:
-            expected = (
-                '<pre class="codehilite"><code class="language-html">'
-                '&lt;span&gt;This&amp;amp;That&lt;/span&gt;\n'
-                '</code></pre>'
-            )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ```html
-                <span>This&amp;That</span>
-                ```
-                '''
-            ),
-            expected,
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedAmps(self):
-        if self.has_pygments:
-            expected = self.dedent(
-                '''
-                <div class="codehilite"><pre><span></span><code>&amp;
-                &amp;amp;
-                &amp;amp;amp;
-                </code></pre></div>
-                '''
-            )
-        else:
-            expected = self.dedent(
-                '''
-                <pre class="codehilite"><code class="language-text">&amp;
-                &amp;amp;
-                &amp;amp;amp;
-                </code></pre>
-                '''
-            )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ```text
-                &
-                &amp;
-                &amp;amp;
-                ```
-                '''
-            ),
-            expected,
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(),
-                'fenced_code'
-            ]
         )
 
     def test_fenced_code_in_raw_html(self):
@@ -407,116 +248,6 @@ class TestFencedCode(TestCase):
             extensions=['fenced_code']
         )
 
-    def testFencedCodeWithHighlightLinesInAttr(self):
-        if self.has_pygments:
-            expected = self.dedent(
-                '''
-                <div class="codehilite"><pre><span></span><code><span class="hll">line 1
-                </span>line 2
-                <span class="hll">line 3
-                </span></code></pre></div>
-                '''
-            )
-        else:
-            expected = self.dedent(
-                    '''
-                    <pre class="codehilite"><code>line 1
-                    line 2
-                    line 3
-                    </code></pre>
-                    '''
-                )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ```{ hl_lines="1 3" }
-                line 1
-                line 2
-                line 3
-                ```
-                '''
-            ),
-            expected,
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedLanguageAndHighlightLinesInAttr(self):
-        if self.has_pygments:
-            expected = (
-                '<div class="codehilite"><pre><span></span><code>'
-                '<span class="hll"><span class="n">line</span> <span class="mi">1</span>\n'
-                '</span><span class="n">line</span> <span class="mi">2</span>\n'
-                '<span class="hll"><span class="n">line</span> <span class="mi">3</span>\n'
-                '</span></code></pre></div>'
-            )
-        else:
-            expected = self.dedent(
-                    '''
-                    <pre class="codehilite"><code class="language-python">line 1
-                    line 2
-                    line 3
-                    </code></pre>
-                    '''
-                )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { .python hl_lines="1 3" }
-                line 1
-                line 2
-                line 3
-                ```
-                '''
-            ),
-            expected,
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedLanguageIdInAttrAndPygmentsDisabled(self):
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { .python #foo }
-                # Some python code
-                ```
-                '''
-            ),
-            self.dedent(
-                '''
-                <pre id="foo"><code class="language-python"># Some python code
-                </code></pre>
-                '''
-            ),
-            extensions=[
-                markdown.extensions.codehilite.CodeHiliteExtension(use_pygments=False),
-                'fenced_code'
-            ]
-        )
-
-    def testFencedLanguageIdAndPygmentsDisabledInAttr(self):
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { .python #foo use_pygments=False }
-                # Some python code
-                ```
-                '''
-            ),
-            self.dedent(
-                '''
-                <pre id="foo"><code class="language-python"># Some python code
-                </code></pre>
-                '''
-            ),
-            extensions=['codehilite', 'fenced_code']
-        )
-
     def testFencedLanguageIdAndPygmentsDisabledInAttrNoCodehilite(self):
         self.assertMarkdownRenders(
             self.dedent(
@@ -551,108 +282,6 @@ class TestFencedCode(TestCase):
                 '''
             ),
             extensions=['fenced_code']
-        )
-
-    def testFencedLanguageAttrCssclass(self):
-        if self.has_pygments:
-            expected = self.dedent(
-                '''
-                <div class="pygments"><pre><span></span><code><span class="c1"># Some python code</span>
-                </code></pre></div>
-                '''
-            )
-        else:
-            expected = (
-                '<pre class="pygments"><code class="language-python"># Some python code\n'
-                '</code></pre>'
-            )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { .python css_class='pygments' }
-                # Some python code
-                ```
-                '''
-            ),
-            expected,
-            extensions=['codehilite', 'fenced_code']
-        )
-
-    def testFencedLanguageAttrLinenums(self):
-        if self.has_pygments:
-            expected = (
-                '<table class="codehilitetable"><tr>'
-                '<td class="linenos"><div class="linenodiv"><pre>1</pre></div></td>'
-                '<td class="code"><div class="codehilite"><pre><span></span>'
-                '<code><span class="c1"># Some python code</span>\n'
-                '</code></pre></div>\n'
-                '</td></tr></table>'
-            )
-        else:
-            expected = (
-                '<pre class="codehilite"><code class="language-python linenums"># Some python code\n'
-                '</code></pre>'
-            )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { .python linenums=True }
-                # Some python code
-                ```
-                '''
-            ),
-            expected,
-            extensions=['codehilite', 'fenced_code']
-        )
-
-    def testFencedLanguageAttrGuesslang(self):
-        if self.has_pygments:
-            expected = self.dedent(
-                '''
-                <div class="codehilite"><pre><span></span><code># Some python code
-                </code></pre></div>
-                '''
-            )
-        else:
-            expected = (
-                '<pre class="codehilite"><code># Some python code\n'
-                '</code></pre>'
-            )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { guess_lang=False }
-                # Some python code
-                ```
-                '''
-            ),
-            expected,
-            extensions=['codehilite', 'fenced_code']
-        )
-
-    def testFencedLanguageAttrNoclasses(self):
-        if self.has_pygments:
-            expected = (
-                '<div class="codehilite" style="background: #f8f8f8">'
-                '<pre style="line-height: 125%; margin: 0;"><span></span><code>'
-                '<span style="color: #408080; font-style: italic"># Some python code</span>\n'
-                '</code></pre></div>'
-            )
-        else:
-            expected = (
-                '<pre class="codehilite"><code class="language-python"># Some python code\n'
-                '</code></pre>'
-            )
-        self.assertMarkdownRenders(
-            self.dedent(
-                '''
-                ``` { .python noclasses=True }
-                # Some python code
-                ```
-                '''
-            ),
-            expected,
-            extensions=['codehilite', 'fenced_code']
         )
 
     def testFencedLanguageNoCodehiliteWithAttrList(self):
@@ -743,4 +372,382 @@ class TestFencedCode(TestCase):
                 '''
             ),
             extensions=[markdown.extensions.fenced_code.FencedCodeExtension(lang_prefix='lang-')]
+        )
+
+
+class TestFencedCodeWithCodehilite(TestCase):
+
+    def setUp(self):
+        if has_pygments and pygments.__version__ != required_pygments_version:
+            self.skipTest(f'Pygments=={required_pygments_version} is required')
+
+    def testFencedCodeWithHighlightLines(self):
+        if has_pygments:
+            expected = self.dedent(
+                '''
+                <div class="codehilite"><pre><span></span><code><span class="hll">line 1
+                </span>line 2
+                <span class="hll">line 3
+                </span></code></pre></div>
+                '''
+            )
+        else:
+            expected = self.dedent(
+                    '''
+                    <pre class="codehilite"><code>line 1
+                    line 2
+                    line 3
+                    </code></pre>
+                    '''
+                )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ```hl_lines="1 3"
+                line 1
+                line 2
+                line 3
+                ```
+                '''
+            ),
+            expected,
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedLanguageAndHighlightLines(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite"><pre><span></span><code>'
+                '<span class="hll"><span class="n">line</span> <span class="mi">1</span>\n'
+                '</span><span class="n">line</span> <span class="mi">2</span>\n'
+                '<span class="hll"><span class="n">line</span> <span class="mi">3</span>\n'
+                '</span></code></pre></div>'
+            )
+        else:
+            expected = self.dedent(
+                    '''
+                    <pre class="codehilite"><code class="language-python">line 1
+                    line 2
+                    line 3
+                    </code></pre>
+                    '''
+                )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` .python hl_lines="1 3"
+                line 1
+                line 2
+                line 3
+                ```
+                '''
+            ),
+            expected,
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedLanguageAndPygmentsDisabled(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` .python
+                # Some python code
+                ```
+                '''
+            ),
+            self.dedent(
+                '''
+                <pre><code class="language-python"># Some python code
+                </code></pre>
+                '''
+            ),
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(use_pygments=False),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedLanguageDoubleEscape(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite"><pre><span></span><code>'
+                '<span class="p">&lt;</span><span class="nt">span</span>'
+                '<span class="p">&gt;</span>This<span class="ni">&amp;amp;</span>'
+                'That<span class="p">&lt;/</span><span class="nt">span</span>'
+                '<span class="p">&gt;</span>\n'
+                '</code></pre></div>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code class="language-html">'
+                '&lt;span&gt;This&amp;amp;That&lt;/span&gt;\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ```html
+                <span>This&amp;That</span>
+                ```
+                '''
+            ),
+            expected,
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedAmps(self):
+        if has_pygments:
+            expected = self.dedent(
+                '''
+                <div class="codehilite"><pre><span></span><code>&amp;
+                &amp;amp;
+                &amp;amp;amp;
+                </code></pre></div>
+                '''
+            )
+        else:
+            expected = self.dedent(
+                '''
+                <pre class="codehilite"><code class="language-text">&amp;
+                &amp;amp;
+                &amp;amp;amp;
+                </code></pre>
+                '''
+            )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ```text
+                &
+                &amp;
+                &amp;amp;
+                ```
+                '''
+            ),
+            expected,
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedCodeWithHighlightLinesInAttr(self):
+        if has_pygments:
+            expected = self.dedent(
+                '''
+                <div class="codehilite"><pre><span></span><code><span class="hll">line 1
+                </span>line 2
+                <span class="hll">line 3
+                </span></code></pre></div>
+                '''
+            )
+        else:
+            expected = self.dedent(
+                    '''
+                    <pre class="codehilite"><code>line 1
+                    line 2
+                    line 3
+                    </code></pre>
+                    '''
+                )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ```{ hl_lines="1 3" }
+                line 1
+                line 2
+                line 3
+                ```
+                '''
+            ),
+            expected,
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedLanguageAndHighlightLinesInAttr(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite"><pre><span></span><code>'
+                '<span class="hll"><span class="n">line</span> <span class="mi">1</span>\n'
+                '</span><span class="n">line</span> <span class="mi">2</span>\n'
+                '<span class="hll"><span class="n">line</span> <span class="mi">3</span>\n'
+                '</span></code></pre></div>'
+            )
+        else:
+            expected = self.dedent(
+                    '''
+                    <pre class="codehilite"><code class="language-python">line 1
+                    line 2
+                    line 3
+                    </code></pre>
+                    '''
+                )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python hl_lines="1 3" }
+                line 1
+                line 2
+                line 3
+                ```
+                '''
+            ),
+            expected,
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(linenums=None, guess_lang=False),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedLanguageIdInAttrAndPygmentsDisabled(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python #foo }
+                # Some python code
+                ```
+                '''
+            ),
+            self.dedent(
+                '''
+                <pre id="foo"><code class="language-python"># Some python code
+                </code></pre>
+                '''
+            ),
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(use_pygments=False),
+                'fenced_code'
+            ]
+        )
+
+    def testFencedLanguageIdAndPygmentsDisabledInAttr(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python #foo use_pygments=False }
+                # Some python code
+                ```
+                '''
+            ),
+            self.dedent(
+                '''
+                <pre id="foo"><code class="language-python"># Some python code
+                </code></pre>
+                '''
+            ),
+            extensions=['codehilite', 'fenced_code']
+        )
+
+    def testFencedLanguageAttrCssclass(self):
+        if has_pygments:
+            expected = self.dedent(
+                '''
+                <div class="pygments"><pre><span></span><code><span class="c1"># Some python code</span>
+                </code></pre></div>
+                '''
+            )
+        else:
+            expected = (
+                '<pre class="pygments"><code class="language-python"># Some python code\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python css_class='pygments' }
+                # Some python code
+                ```
+                '''
+            ),
+            expected,
+            extensions=['codehilite', 'fenced_code']
+        )
+
+    def testFencedLanguageAttrLinenums(self):
+        if has_pygments:
+            expected = (
+                '<table class="codehilitetable"><tr>'
+                '<td class="linenos"><div class="linenodiv"><pre>1</pre></div></td>'
+                '<td class="code"><div class="codehilite"><pre><span></span>'
+                '<code><span class="c1"># Some python code</span>\n'
+                '</code></pre></div>\n'
+                '</td></tr></table>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code class="language-python linenums"># Some python code\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python linenums=True }
+                # Some python code
+                ```
+                '''
+            ),
+            expected,
+            extensions=['codehilite', 'fenced_code']
+        )
+
+    def testFencedLanguageAttrGuesslang(self):
+        if has_pygments:
+            expected = self.dedent(
+                '''
+                <div class="codehilite"><pre><span></span><code># Some python code
+                </code></pre></div>
+                '''
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code># Some python code\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { guess_lang=False }
+                # Some python code
+                ```
+                '''
+            ),
+            expected,
+            extensions=['codehilite', 'fenced_code']
+        )
+
+    def testFencedLanguageAttrNoclasses(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite" style="background: #f8f8f8">'
+                '<pre style="line-height: 125%; margin: 0;"><span></span><code>'
+                '<span style="color: #408080; font-style: italic"># Some python code</span>\n'
+                '</code></pre></div>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code class="language-python"># Some python code\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python noclasses=True }
+                # Some python code
+                ```
+                '''
+            ),
+            expected,
+            extensions=['codehilite', 'fenced_code']
         )


### PR DESCRIPTION
If pygments is installed and the version doesn't match the expected version.
then any relevant tests will fail. To avoid failing tests due to different
output by pygments, those tests will be skipped. The pygments tox env
sets the `PYGMENTS_VERSION environment variable, so that env will always
run those tests against the expected version.