### PR TITLE
Bump version to 3.3.2

### DIFF
--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -1,0 +1,30 @@
+name: manual deploy
+
+on:
+  workflow_dispatch
+
+jobs:
+
+  ghpages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -r doc-requirements.txt
+      - name: Build
+        run: |
+          python -m mkdocs build --clean --verbose
+      - name: Publish
+        if: success()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}
+          external_repository: Python-Markdown/Python-Markdown.github.io
+          publish_branch: master
+          publish_dir: ./site

--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,6 +3,11 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
+Oct 19, 2020: version 3.3.2 (a bug-fix release).
+
+* Properly parse inline HTML in md_in_html (#1040 & #1045).
+* Avoid crashing when md_in_html fails (#1040).
+
 Oct 12, 2020: version 3.3.1 (a bug-fix release).
 
 * Correctly parse raw `script` and `style` tags (#1036).

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -26,7 +26,7 @@ License: BSD (see LICENSE.md for details).
 # (1, 2, 0, 'beta', 2) => "1.2b2"
 # (1, 2, 0, 'rc', 4) => "1.2rc4"
 # (1, 2, 0, 'final', 0) => "1.2"
-__version_info__ = (3, 3, 1, 'final', 0)
+__version_info__ = (3, 3, 2, 'final', 0)
 
 
 def _get_version(version_info):


### PR DESCRIPTION
I also added a manual deployment workflow to use for future testing of #1028. It will also be useful at any time we want to manually deploy the docs without doing a release.