### PR TITLE
Add require_changelog workflow action

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -22,3 +22,4 @@ jobs:
           change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
           Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,7 +1,8 @@
 name: bot
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
     - '**'
 

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,7 +1,7 @@
 name: bot
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
     - '**'
 

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: mskelton/changelog-reminder-action@v1
-    with:
-      # Match any file in the docs/change_log/ dir.
-      changelogRegex: "docs/change_log/.*"
-      # Only require changelog update if changes were made in markdown/
-      include: "markdown/.*"
-      message: |
-        @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
-        change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
+      with:
+        # Match any file in the docs/change_log/ dir.
+        changelogRegex: "docs/change_log/.*"
+        # Only require changelog update if changes were made in markdown/
+        include: "markdown/.*"
+        message: |
+          @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
+          change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
-        Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.
+          Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,8 +1,7 @@
 name: bot
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
     branches:
     - '**'
 

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,7 +1,7 @@
 name: bot
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - '**'
 

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,7 +1,7 @@
 name: bot
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
     - '**'
 
@@ -17,8 +17,4 @@ jobs:
         changelogRegex: "docs/change_log/.*"
         # Only require changelog update if changes were made in markdown/
         include: "markdown/.*"
-        message: |
-          @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
-          change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
-
-          Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.
+        message: ""

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,7 +1,7 @@
 name: bot
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - '**'
 
@@ -22,4 +22,3 @@ jobs:
           change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
           Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.
-        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -1,0 +1,24 @@
+name: bot
+
+on:
+  pull_request:
+    branches:
+    - '**'
+
+jobs:
+  require_changelog:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: mskelton/changelog-reminder-action@v1
+    with:
+      # Match any file in the docs/change_log/ dir.
+      changelogRegex: "docs/change_log/.*"
+      # Only require changelog update if changes were made in markdown/
+      include: "markdown/.*"
+      message: |
+        @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
+        change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
+
+        Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -17,4 +17,8 @@ jobs:
         changelogRegex: "docs/change_log/.*"
         # Only require changelog update if changes were made in markdown/
         include: "markdown/.*"
-        message: ""
+        message: |
+          @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
+          change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
+
+          Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -52,7 +52,7 @@ Constants you might want to modify
 -----------------------------------------------------------------------------
 """
 
-# We should deprecate this as it are now defined on the class in core.py
+
 BLOCK_LEVEL_ELEMENTS = [
     # Elements which are invalid to wrap in a `<p>` tag.
     # See https://w3c.github.io/html/grouping-content.html#the-p-element

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -52,7 +52,7 @@ Constants you might want to modify
 -----------------------------------------------------------------------------
 """
 
-
+# We should deprecate this as it are now defined on the class in core.py
 BLOCK_LEVEL_ELEMENTS = [
     # Elements which are invalid to wrap in a `<p>` tag.
     # See https://w3c.github.io/html/grouping-content.html#the-p-element


### PR DESCRIPTION
This action checks that an update was made to any file in docs/change_log/
but only if changes were made to files in markdown/. Presumably,
any changes outside of markdown/ do not affect the behavior and do not
require a notation in the change_log.

When a change_log entry is missing, a comment is added to the PR informing
the PR author. If a later commit to the PR includes a change_log entry,
then the comment is hidden. A comment should only be added once per PR.