### PR TITLE
Fix issues related to hr tags

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,6 +8,7 @@ Under development: version 3.3.3 (a bug-fix release).
 * Unify all block-level tags (#1047).
 * Fix issue where some empty elements would have text rendered as `None` when using `md_in_html` (#1049).
 * Avoid catastrophic backtracking in `hr` regex (#1055).
+* Fix `hr` HTML handling (#1053).
 
 Oct 19, 2020: version 3.3.2 (a bug-fix release).
 

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -36,8 +36,9 @@ class HTMLExtractorExtra(HTMLExtractor):
         # Block-level tags which never get their content parsed.
         self.raw_tags = ['canvas', 'math', 'option', 'pre', 'script', 'style', 'textarea']
         # Block-level tags in which the content gets parsed as blocks
-        self.block_tags = [tag for tag in self.block_level_tags if tag not in self.span_tags + self.raw_tags]
         super().__init__(md, *args, **kwargs)
+
+        self.block_tags = [tag for tag in self.block_level_tags if tag not in self.span_tags + self.raw_tags + self.empty_tags]
 
     def reset(self):
         """Reset this instance.  Loses all unprocessed data."""

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -30,15 +30,18 @@ class HTMLExtractorExtra(HTMLExtractor):
 
     def __init__(self, md, *args, **kwargs):
         # All block-level tags.
-        self.block_level_tags = md.block_level_elements.copy()
+        self.block_level_tags = set(md.block_level_elements.copy())
         # Block-level tags in which the content only gets span level parsing
-        self.span_tags = ['address', 'dd', 'dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'legend', 'li', 'p', 'td', 'th']
+        self.span_tags = set(
+            ['address', 'dd', 'dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'legend', 'li', 'p', 'td', 'th']
+        )
         # Block-level tags which never get their content parsed.
-        self.raw_tags = ['canvas', 'math', 'option', 'pre', 'script', 'style', 'textarea']
+        self.raw_tags = set(['canvas', 'math', 'option', 'pre', 'script', 'style', 'textarea'])
         # Block-level tags in which the content gets parsed as blocks
         super().__init__(md, *args, **kwargs)
 
-        self.block_tags = [tag for tag in self.block_level_tags if tag not in self.span_tags + self.raw_tags + self.empty_tags]
+        self.block_tags = set(self.block_level_tags) - (self.span_tags | self.raw_tags | self.empty_tags)
+        self.span_and_blocks_tags = self.block_tags | self.span_tags
 
     def reset(self):
         """Reset this instance.  Loses all unprocessed data."""
@@ -72,10 +75,10 @@ class HTMLExtractorExtra(HTMLExtractor):
             # Only use the parent state if it is more restrictive than the markdown attribute.
             md_attr = parent_state
         if ((md_attr == '1' and tag in self.block_tags) or
-                (md_attr == 'block' and tag in self.span_tags + self.block_tags)):
+                (md_attr == 'block' and tag in self.span_and_blocks_tags)):
             return 'block'
         elif ((md_attr == '1' and tag in self.span_tags) or
-              (md_attr == 'span' and tag in self.span_tags + self.block_tags)):
+              (md_attr == 'span' and tag in self.span_and_blocks_tags)):
             return 'span'
         elif tag in self.block_level_tags:
             return 'off'
@@ -91,6 +94,18 @@ class HTMLExtractorExtra(HTMLExtractor):
         return value
 
     def handle_starttag(self, tag, attrs):
+        # Handle tags that should always be empty and do not specify a closing tag
+        if tag in self.empty_tags:
+            attrs = {key: value if value is not None else key for key, value in attrs}
+            if "markdown" in attrs:
+                attrs.pop('markdown')
+                element = etree.Element(tag, attrs)
+                data = etree.tostring(element, encoding='unicode', method='html')
+            else:
+                data = self.get_starttag_text()
+            self.handle_empty_tag(data, True)
+            return
+
         if tag in self.block_level_tags:
             # Valueless attr (ex: `<tag checked>`) results in `[('checked', None)]`.
             # Convert to `{'checked': 'checked'}`.
@@ -161,6 +176,19 @@ class HTMLExtractorExtra(HTMLExtractor):
                     self.handle_data(self.md.htmlStash.store(text))
                 else:
                     self.handle_data(text)
+
+    def handle_startendtag(self, tag, attrs):
+        if tag in self.empty_tags:
+            attrs = {key: value if value is not None else key for key, value in attrs}
+            if "markdown" in attrs:
+                attrs.pop('markdown')
+                element = etree.Element(tag, attrs)
+                data = etree.tostring(element, encoding='unicode', method='html')
+            else:
+                data = self.get_starttag_text()
+        else:
+            data = self.get_starttag_text()
+        self.handle_empty_tag(data, is_block=self.md.is_block_level(tag))
 
     def handle_data(self, data):
         if self.inraw or not self.mdstack:

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -58,7 +58,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
             kwargs['convert_charrefs'] = False
 
         # Block tags that should contain no content (self closing)
-        self.empty_tags = ['hr']
+        self.empty_tags = set(['hr'])
 
         # This calls self.reset
         super().__init__(*args, **kwargs)
@@ -124,6 +124,11 @@ class HTMLExtractor(htmlparser.HTMLParser):
             return '</{}>'.format(tag)
 
     def handle_starttag(self, tag, attrs):
+        # Handle tags that should always be empty and do not specify a closing tag
+        if tag in self.empty_tags:
+            self.handle_startendtag(tag, attrs)
+            return
+
         if self.md.is_block_level(tag) and (self.intail or (self.at_line_start() and not self.inraw)):
             # Started a new raw block. Prepare stack.
             self.inraw = True
@@ -272,14 +277,6 @@ class HTMLExtractor(htmlparser.HTMLParser):
         if end.endswith('/>'):
             # XHTML-style empty tag: <span attr="value" />
             self.handle_startendtag(tag, attrs)
-        elif tag in self.empty_tags:
-            pattern = r'\s*</\s*{}\s*>'.format(tag)
-            if re.match(pattern, self.rawdata[self.line_offset + self.offset + len(self.__starttag_text):]):
-                if tag in self.CDATA_CONTENT_ELEMENTS:
-                    self.set_cdata_mode(tag)
-                self.handle_starttag(tag, attrs)
-            else:
-                self.handle_startendtag(tag, attrs)
         else:
             # *** set cdata_mode first so we can override it in handle_starttag (see #1036) ***
             if tag in self.CDATA_CONTENT_ELEMENTS:

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1405,7 +1405,13 @@ class TestHTMLBlocks(TestCase):
 
     def test_hr_only_start(self):
         self.assertMarkdownRenders(
-            "*emphasis1*\n<hr>\n*emphasis2*",
+            self.dedent(
+                """
+                *emphasis1*
+                <hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -1417,7 +1423,13 @@ class TestHTMLBlocks(TestCase):
 
     def test_hr_self_close(self):
         self.assertMarkdownRenders(
-            "*emphasis1*\n<hr/>\n*emphasis2*",
+            self.dedent(
+                """
+                *emphasis1*
+                <hr/>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -1428,8 +1440,15 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_hr_start_and_end(self):
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
-            "*emphasis1*\n<hr></hr>\n*emphasis2*",
+            self.dedent(
+                """
+                *emphasis1*
+                <hr></hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -1441,8 +1460,15 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_hr_only_end(self):
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
-            "*emphasis1*\n</hr>\n*emphasis2*",
+            self.dedent(
+                """
+                *emphasis1*
+                </hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em>
@@ -1453,9 +1479,18 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_hr_with_content(self):
-        # Content is not allowed and will be treated as normal content between two hr tags
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Content is not allowed and will be treated as normal content between two hr tags.
         self.assertMarkdownRenders(
-            "*emphasis1*\n<hr>\n**content**\n</hr>\n*emphasis2*",
+            self.dedent(
+                """
+                *emphasis1*
+                <hr>
+                **content**
+                </hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1402,3 +1402,67 @@ class TestHTMLBlocks(TestCase):
                 """
             )
         )
+
+    def test_hr_only_start(self):
+        self.assertMarkdownRenders(
+            "*emphasis1*\n<hr>\n*emphasis2*",
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p><em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_hr_self_close(self):
+        self.assertMarkdownRenders(
+            "*emphasis1*\n<hr/>\n*emphasis2*",
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr/>
+                <p><em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_hr_start_and_end(self):
+        self.assertMarkdownRenders(
+            "*emphasis1*\n<hr></hr>\n*emphasis2*",
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p></hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_hr_only_end(self):
+        self.assertMarkdownRenders(
+            "*emphasis1*\n</hr>\n*emphasis2*",
+            self.dedent(
+                """
+                <p><em>emphasis1</em>
+                </hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_hr_with_content(self):
+        # Content is not allowed and will be treated as normal content between two hr tags
+        self.assertMarkdownRenders(
+            "*emphasis1*\n<hr>\n**content**\n</hr>\n*emphasis2*",
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p><strong>content</strong>
+                </hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -893,6 +893,84 @@ class TestMdInHTML(TestCase):
             )
         )
 
+    def test_md1_hr_only_start(self):
+        self.assertMarkdownRenders(
+            '*emphasis1*\n<hr markdown="1">\n*emphasis2*',
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p><em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_md1_hr_self_close(self):
+        self.assertMarkdownRenders(
+            '*emphasis1*\n<hr markdown="1" />\n*emphasis2*',
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p><em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_md1_hr_start_and_end(self):
+        self.assertMarkdownRenders(
+            '*emphasis1*\n<hr markdown="1"></hr>\n*emphasis2*',
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p></hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_md1_hr_only_end(self):
+        self.assertMarkdownRenders(
+            "*emphasis1*\n</hr>\n*emphasis2*",
+            self.dedent(
+                """
+                <p><em>emphasis1</em>
+                </hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_md1_hr_with_content(self):
+        self.assertMarkdownRenders(
+            '*emphasis1*\n<hr markdown="1">\n**content**\n</hr>\n*emphasis2*',
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p><strong>content</strong>
+                </hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )
+
+    def test_no_md1_hr_with_content(self):
+        # Content is not allowed and will be treated as normal content between two hr tags
+        self.assertMarkdownRenders(
+            '*emphasis1*\n<hr>\n**content**\n</hr>\n*emphasis2*',
+            self.dedent(
+                """
+                <p><em>emphasis1</em></p>
+                <hr>
+                <p><strong>content</strong>
+                </hr>
+                <em>emphasis2</em></p>
+                """
+            )
+        )
+
     def test_md1_nested_abbr_ref(self):
         self.assertMarkdownRenders(
             self.dedent(

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -895,7 +895,13 @@ class TestMdInHTML(TestCase):
 
     def test_md1_hr_only_start(self):
         self.assertMarkdownRenders(
-            '*emphasis1*\n<hr markdown="1">\n*emphasis2*',
+            self.dedent(
+                """
+                *emphasis1*
+                <hr markdown="1">
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -907,7 +913,13 @@ class TestMdInHTML(TestCase):
 
     def test_md1_hr_self_close(self):
         self.assertMarkdownRenders(
-            '*emphasis1*\n<hr markdown="1" />\n*emphasis2*',
+            self.dedent(
+                """
+                *emphasis1*
+                <hr markdown="1" />
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -918,8 +930,15 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_hr_start_and_end(self):
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
-            '*emphasis1*\n<hr markdown="1"></hr>\n*emphasis2*',
+            self.dedent(
+                """
+                *emphasis1*
+                <hr markdown="1"></hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -931,8 +950,15 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_hr_only_end(self):
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
-            "*emphasis1*\n</hr>\n*emphasis2*",
+            self.dedent(
+                """
+                *emphasis1*
+                </hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em>
@@ -943,8 +969,18 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_hr_with_content(self):
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Content is not allowed and will be treated as normal content between two hr tags
         self.assertMarkdownRenders(
-            '*emphasis1*\n<hr markdown="1">\n**content**\n</hr>\n*emphasis2*',
+            self.dedent(
+                """
+                *emphasis1*
+                <hr markdown="1">
+                **content**
+                </hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>
@@ -957,9 +993,18 @@ class TestMdInHTML(TestCase):
         )
 
     def test_no_md1_hr_with_content(self):
+        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
         # Content is not allowed and will be treated as normal content between two hr tags
         self.assertMarkdownRenders(
-            '*emphasis1*\n<hr>\n**content**\n</hr>\n*emphasis2*',
+            self.dedent(
+                """
+                *emphasis1*
+                <hr>
+                **content**
+                </hr>
+                *emphasis2*
+                """
+            ),
             self.dedent(
                 """
                 <p><em>emphasis1</em></p>


### PR DESCRIPTION
Ensure that start/end tag handler does not include tags in the previous
paragraph.

Provide special handling for tags like hr that never have content.