### PR TITLE
Properly parse processing instructions in md_in_html

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -5,6 +5,7 @@ Python-Markdown Change Log
 
 Under development: version 3.3.4 (a bug-fix release).
 
+* Properly parse processing instructions in md_in_html (#1070).
 * Properly parse code spans in md_in_html (#1069).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -204,10 +204,7 @@ class HTMLExtractorExtra(HTMLExtractor):
             if self.at_line_start() and is_block:
                 self.handle_data('\n' + self.md.htmlStash.store(data) + '\n\n')
             else:
-                if self.mdstate and self.mdstate[-1] == "off":
-                    self.handle_data(self.md.htmlStash.store(data))
-                else:
-                    self.handle_data(data)
+                self.handle_data(self.md.htmlStash.store(data))
 
 
 class HtmlBlockPreprocessor(Preprocessor):

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -634,6 +634,56 @@ class TestMdInHTML(TestCase):
             )
         )
 
+    def test_md1_PI_oneliner(self):
+        self.assertMarkdownRenders(
+            '<div markdown="1"><?php print("foo"); ?></div>',
+            self.dedent(
+                """
+                <div>
+                <?php print("foo"); ?>
+                </div>
+                """
+            )
+        )
+
+    def test_md1_PI_multiline(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div markdown="1">
+                <?php print("foo"); ?>
+                </div>
+                """
+            ),
+            self.dedent(
+                """
+                <div>
+                <?php print("foo"); ?>
+                </div>
+                """
+            )
+        )
+
+    def test_md1_PI_blank_lines(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div markdown="1">
+
+                <?php print("foo"); ?>
+
+                </div>
+                """
+            ),
+            self.dedent(
+                """
+                <div>
+                <?php print("foo"); ?>
+                </div>
+                """
+            )
+        )
+
     def test_md_span_paragraph(self):
         self.assertMarkdownRenders(
             '<p markdown="span">*foo*</p>',


### PR DESCRIPTION
Empty tags do not have a `mardkown` attribute set on them. Therefore,
there is no need to check the mdstack to determine behavior. If we
are in any md_in_html state (regardless of block, span, etc) the
behavior is the same. Fixes #1070.