### PR TITLE
Use simplified regex for html placeholders, correctly

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,6 +8,7 @@ Under development: version 3.3.4 (a bug-fix release).
 * Properly parse unclosed tags in code spans (#1066).
 * Properly parse processing instructions in md_in_html (#1070).
 * Properly parse code spans in md_in_html (#1069).
+* Simplified regex for HTML placeholders (#928) addressing (#932).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -85,7 +85,7 @@ class RawHtmlPostprocessor(Postprocessor):
 
         if replacements:
             base_placeholder = util.HTML_PLACEHOLDER % r'([0-9]+)'
-            pattern = re.compile( "<p>{}</p>".format(base_placeholder) + '|' + base_placeholder )
+            pattern = re.compile("<p>{}</p>".format(base_placeholder) + '|' + base_placeholder)
             processed_text = pattern.sub(substitute_match, text)
         else:
             return text

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -79,13 +79,13 @@ class RawHtmlPostprocessor(Postprocessor):
             key = m.group(0)
 
             if key not in replacements:
-                return '<p>' + replacements[key[3:-4]] + '</p>'
+                return f'<p>{ replacements[key[3:-4]] }</p>'
 
             return replacements[key]
 
         if replacements:
             base_placeholder = util.HTML_PLACEHOLDER % r'([0-9]+)'
-            pattern = re.compile("<p>{}</p>".format(base_placeholder) + '|' + base_placeholder)
+            pattern = re.compile(f'<p>{ base_placeholder }</p>|{ base_placeholder }')
             processed_text = pattern.sub(substitute_match, text)
         else:
             return text

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -75,9 +75,18 @@ class RawHtmlPostprocessor(Postprocessor):
                     self.md.htmlStash.get_placeholder(i))] = html
             replacements[self.md.htmlStash.get_placeholder(i)] = html
 
+        def substitute_match(m):
+            key = m.group(0)
+
+            if key not in replacements:
+                return '<p>' + replacements[key[3:-4]] + '</p>'
+
+            return replacements[key]
+
         if replacements:
-            pattern = re.compile("|".join(re.escape(k) for k in replacements))
-            processed_text = pattern.sub(lambda m: replacements[m.group(0)], text)
+            base_placeholder = util.HTML_PLACEHOLDER % r'([0-9]+)'
+            pattern = re.compile( "<p>{}</p>".format(base_placeholder) + '|' + base_placeholder )
+            processed_text = pattern.sub(substitute_match, text)
         else:
             return text
 


### PR DESCRIPTION
A reimplementation of c5f1395a944e76e95250740452706f6b16830cae

after issue #932 noted that it broke a bunch of tests

and the change was reverted by 7c595e28491d3cca28bc9901bb099bca8bcf4626

Mea culpa.

This one passes the test suite of 927 tests with 119 skipped (this is desired result, correct?), and restores the performance improvement.
