### PR TITLE
Use simplified regex for html placeholders

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,6 +8,7 @@ Under development: version 3.3.4 (a bug-fix release).
 * Properly parse unclosed tags in code spans (#1066).
 * Properly parse processing instructions in md_in_html (#1070).
 * Properly parse code spans in md_in_html (#1069).
+* Simplified regex for HTML placeholders (#928) addressing (#932).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -85,7 +85,7 @@ class RawHtmlPostprocessor(Postprocessor):
 
         if replacements:
             base_placeholder = util.HTML_PLACEHOLDER % r'([0-9]+)'
-            pattern = re.compile( "<p>{}</p>".format(base_placeholder) + '|' + base_placeholder )
+            pattern = re.compile("<p>{}</p>".format(base_placeholder) + '|' + base_placeholder)
             processed_text = pattern.sub(substitute_match, text)
         else:
             return text

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -79,13 +79,13 @@ class RawHtmlPostprocessor(Postprocessor):
             key = m.group(0)
 
             if key not in replacements:
-                return '<p>' + replacements[key[3:-4]] + '</p>'
+                return f'<p>{ replacements[key[3:-4]] }</p>'
 
             return replacements[key]
 
         if replacements:
             base_placeholder = util.HTML_PLACEHOLDER % r'([0-9]+)'
-            pattern = re.compile("<p>{}</p>".format(base_placeholder) + '|' + base_placeholder)
+            pattern = re.compile(f'<p>{ base_placeholder }</p>|{ base_placeholder }')
             processed_text = pattern.sub(substitute_match, text)
         else:
             return text

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -75,9 +75,18 @@ class RawHtmlPostprocessor(Postprocessor):
                     self.md.htmlStash.get_placeholder(i))] = html
             replacements[self.md.htmlStash.get_placeholder(i)] = html
 
+        def substitute_match(m):
+            key = m.group(0)
+
+            if key not in replacements:
+                return '<p>' + replacements[key[3:-4]] + '</p>'
+
+            return replacements[key]
+
         if replacements:
-            pattern = re.compile("|".join(re.escape(k) for k in replacements))
-            processed_text = pattern.sub(lambda m: replacements[m.group(0)], text)
+            base_placeholder = util.HTML_PLACEHOLDER % r'([0-9]+)'
+            pattern = re.compile( "<p>{}</p>".format(base_placeholder) + '|' + base_placeholder )
+            processed_text = pattern.sub(substitute_match, text)
         else:
             return text
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -79,7 +79,10 @@ class RawHtmlPostprocessor(Postprocessor):
             key = m.group(0)
 
             if key not in replacements:
-                return f'<p>{ replacements[key[3:-4]] }</p>'
+                if key[3:-4] in replacements:
+                    return f'<p>{ replacements[key[3:-4]] }</p>'
+                else:
+                    return key
 
             return replacements[key]
 

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -21,6 +21,7 @@ License: BSD (see LICENSE.md for details).
 """
 
 from markdown.test_tools import TestCase
+import markdown
 
 
 class TestHTMLBlocks(TestCase):
@@ -1606,3 +1607,13 @@ class TestHTMLBlocks(TestCase):
                 """
             )
         )
+
+    def test_placeholder_in_source(self):
+        # This should never occur, but third party extensions could create weird edge cases.
+        md = markdown.Markdown()
+        # Ensure there is an htmlstash so relevant code (nested in `if replacements`) is run.
+        md.htmlStash.store('foo')
+        # Run with a placeholder which is not in the stash
+        placeholder = md.htmlStash.get_placeholder(md.htmlStash.html_counter + 1)
+        result = md.postprocessors['raw_html'].run(placeholder)
+        self.assertEqual(placeholder, result)


### PR DESCRIPTION
This is a copy of #1083 with additions to avoid a `KeyError`. As #1083 was on the `master` branch, it was easier to create a new PR than to push my changes to the existing PR (see the [Contributing Guide][1]).

[1]: https://python-markdown.github.io/contributing/#pull-requests