### PR TITLE
Optimize away a `len` call in InlineProcessor

### DIFF
--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -126,7 +126,8 @@ class InlineProcessor(Treeprocessor):
         """
         if not isinstance(data, util.AtomicString):
             startIndex = 0
-            while patternIndex < len(self.inlinePatterns):
+            count = len(self.inlinePatterns)
+            while patternIndex < count:
                 data, matched, startIndex = self.__applyPattern(
                     self.inlinePatterns[patternIndex], data, patternIndex, startIndex
                 )


### PR DESCRIPTION
The gains are tiny but when the total number of calls to these is in the hundreds of thousands, it makes a sizeable difference.

* ~Eliminate most calls to the _sort function.
  When sorting isn't needed, don't check the condition inside the function only to almost always drop out of it, instead replace the whole function with a no-op.~
* Eliminate most calls to util.py:\_\_len__, just get the length once at the beginning.

~For my tests this was \~25% faster for the function itself and saved a second of build time out of total 20s when running under the profiler.~

Before:

![before](https://user-images.githubusercontent.com/371383/102730299-8b569600-4334-11eb-8d82-db2817b70bf7.gif)

After:

![after](https://user-images.githubusercontent.com/371383/102730302-8eea1d00-4334-11eb-9033-31ae7a063a77.gif)
