### PR TITLE
Don't wrongly discard text immediately before an admonition

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,6 +8,7 @@ Under development: version 3.3.4 (a bug-fix release).
 * Properly parse unclosed tags in code spans (#1066).
 * Properly parse processing instructions in md_in_html (#1070).
 * Properly parse code spans in md_in_html (#1069).
+* Don't wrongly discard text immediately before an admonition (#1092).
 * Simplified regex for HTML placeholders (#928) addressing (#932).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).

--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,7 +8,7 @@ Under development: version 3.3.4 (a bug-fix release).
 * Properly parse unclosed tags in code spans (#1066).
 * Properly parse processing instructions in md_in_html (#1070).
 * Properly parse code spans in md_in_html (#1069).
-* Don't wrongly discard text immediately before an admonition (#1092).
+* Preserve text immediately before an admonition (#1092).
 * Simplified regex for HTML placeholders (#928) addressing (#932).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -113,6 +113,8 @@ class AdmonitionProcessor(BlockProcessor):
         m = self.RE.search(block)
 
         if m:
+            if m.start() > 0:
+                self.parser.parseBlocks(parent, [block[:m.start()]])
             block = block[m.end():]  # removes the first line
         else:
             sibling, block = self.get_sibling(parent, block)

--- a/tests/test_syntax/extensions/test_admonition.py
+++ b/tests/test_syntax/extensions/test_admonition.py
@@ -192,3 +192,22 @@ class TestAdmonition(TestCase):
             ),
             extensions=['admonition', 'def_list']
         )
+
+    def test_with_preceding_text(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                foo
+                **foo**
+                !!! note "Admonition"
+                '''
+            ),
+            self.dedent(
+                '''
+                <div class="admonition note">
+                <p class="admonition-title">Admonition</p>
+                </div>
+                '''
+            ),
+            extensions=['admonition']
+        )

--- a/tests/test_syntax/extensions/test_admonition.py
+++ b/tests/test_syntax/extensions/test_admonition.py
@@ -204,6 +204,8 @@ class TestAdmonition(TestCase):
             ),
             self.dedent(
                 '''
+                <p>foo
+                <strong>foo</strong></p>
                 <div class="admonition note">
                 <p class="admonition-title">Admonition</p>
                 </div>


### PR DESCRIPTION
```markdown
foo
**foo**
!!! note "Admonition"
```
    
In the previous state, the "foo" text would be completely obliterated, but now it will be kept, and the admonition will be rendered as well.
