### PR TITLE
Disallow admonitions in the middle of a block

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,6 +8,8 @@ Under development: version 3.3.4 (a bug-fix release).
 * Properly parse unclosed tags in code spans (#1066).
 * Properly parse processing instructions in md_in_html (#1070).
 * Properly parse code spans in md_in_html (#1069).
+* Disallow admonitions in the middle of a block (#1093).
+  Previously, text immediately before an admonition would just be dropped.
 * Simplified regex for HTML placeholders (#928) addressing (#932).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -37,7 +37,7 @@ class AdmonitionProcessor(BlockProcessor):
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'
-    RE = re.compile(r'(?:^|\n)!!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
+    RE = re.compile(r'^!!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
     RE_SPACES = re.compile('  +')
 
     def __init__(self, parser):

--- a/tests/test_syntax/extensions/test_admonition.py
+++ b/tests/test_syntax/extensions/test_admonition.py
@@ -192,3 +192,22 @@ class TestAdmonition(TestCase):
             ),
             extensions=['admonition', 'def_list']
         )
+
+    def test_with_preceding_text(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                foo
+                **foo**
+                !!! note "Admonition"
+                '''
+            ),
+            self.dedent(
+                '''
+                <div class="admonition note">
+                <p class="admonition-title">Admonition</p>
+                </div>
+                '''
+            ),
+            extensions=['admonition']
+        )

--- a/tests/test_syntax/extensions/test_admonition.py
+++ b/tests/test_syntax/extensions/test_admonition.py
@@ -204,9 +204,9 @@ class TestAdmonition(TestCase):
             ),
             self.dedent(
                 '''
-                <div class="admonition note">
-                <p class="admonition-title">Admonition</p>
-                </div>
+                <p>foo
+                <strong>foo</strong>
+                !!! note "Admonition"</p>
                 '''
             ),
             extensions=['admonition']


### PR DESCRIPTION
```markdown
foo
**foo**
!!! note "Admonition"
```
    
In the previous state, the "foo" text would be completely obliterated, but now the admonition will be ignored and all of this will be seen as normal text (with inline processing, of course).
