### PR TITLE
Fix a case where content under admonitions weren't dettabbed properly

### DIFF
--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -101,6 +101,7 @@ The following bug fixes are included in the 3.3 release:
 * Fix unescaping of HTML characters `<>` in CodeHilite (#990).
 * Fix complex scenarios involving lists and admonitions (#1004).
 * Fix complex scenarios with nested ordered and unordered lists in a definition list (#918).
+* Fix corner cases with lists under admonitions.
 
 [spec]: https://www.w3.org/TR/html5/text-level-semantics.html#the-code-element
 [fenced_code]: ../extensions/fenced_code_blocks.md

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -78,13 +78,15 @@ class BlockProcessor:
         else:
             return None
 
-    def detab(self, text):
+    def detab(self, text, length=None):
         """ Remove a tab from the front of each line of the given text. """
+        if length is None:
+            length = self.tab_length
         newtext = []
         lines = text.split('\n')
         for line in lines:
-            if line.startswith(' '*self.tab_length):
-                newtext.append(line[self.tab_length:])
+            if line.startswith(' ' * length):
+                newtext.append(line[length:])
             elif not line.strip():
                 newtext.append('')
             else:

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -48,7 +48,7 @@ class AdmonitionProcessor(BlockProcessor):
         self.current_sibling = None
         self.content_indention = 0
 
-    def get_sibling(self, parent, block):
+    def parse_content(self, parent, block):
         """Get sibling admontion.
 
         Retrieve the appropriate siblimg element. This can get trickly when
@@ -56,13 +56,16 @@ class AdmonitionProcessor(BlockProcessor):
 
         """
 
+        old_block = block
+        the_rest = ''
+
         # We already acquired the block via test
         if self.current_sibling is not None:
             sibling = self.current_sibling
-            block = block[self.content_indent:]
+            block, the_rest = self.detab(block, self.content_indent)
             self.current_sibling = None
             self.content_indent = 0
-            return sibling, block
+            return sibling, block, the_rest
 
         sibling = self.lastChild(parent)
 
@@ -96,17 +99,19 @@ class AdmonitionProcessor(BlockProcessor):
                 sibling = None
 
             if sibling is not None:
+                indent += self.tab_length
+                block, the_rest = self.detab(old_block, indent)
                 self.current_sibling = sibling
                 self.content_indent = indent
 
-        return sibling, block
+        return sibling, block, the_rest
 
     def test(self, parent, block):
 
         if self.RE.search(block):
             return True
         else:
-            return self.get_sibling(parent, block)[0] is not None
+            return self.parse_content(parent, block)[0] is not None
 
     def run(self, parent, blocks):
         block = blocks.pop(0)
@@ -116,10 +121,9 @@ class AdmonitionProcessor(BlockProcessor):
             if m.start() > 0:
                 self.parser.parseBlocks(parent, [block[:m.start()]])
             block = block[m.end():]  # removes the first line
+            block, theRest = self.detab(block)
         else:
-            sibling, block = self.get_sibling(parent, block)
-
-        block, theRest = self.detab(block)
+            sibling, block, theRest = self.parse_content(parent, block)
 
         if m:
             klass, title = self.get_class_and_title(m)

--- a/tests/test_syntax/extensions/test_admonition.py
+++ b/tests/test_syntax/extensions/test_admonition.py
@@ -213,3 +213,33 @@ class TestAdmonition(TestCase):
             ),
             extensions=['admonition']
         )
+
+    def test_admontion_detabbing(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                !!! note "Admonition"
+                    - Parent 1
+
+                        - Child 1
+                        - Child 2
+                '''
+            ),
+            self.dedent(
+                '''
+                <div class="admonition note">
+                <p class="admonition-title">Admonition</p>
+                <ul>
+                <li>
+                <p>Parent 1</p>
+                <ul>
+                <li>Child 1</li>
+                <li>Child 2</li>
+                </ul>
+                </li>
+                </ul>
+                </div>
+                '''
+            ),
+            extensions=['admonition']
+        )


### PR DESCRIPTION
Admonitions would not render the following case properly:

```
!!! note "Admonition"
    - Parent 1

        - Child 1
        - Child 2
```

But would render this properly:

```
!!! note "Admontion"
    - Parent 1
        - Child 1
        - Child 2
```

The problem stemmed from bad detabbing of the content, where in the first example, the child list was parsed like this:

```
  - Child 1
      - Child 2
```

This pull addresses the issue of ensuring that each block is processed properly so that content that is highly sensitive to indentation works correctly.
