### PR TITLE
Fix minor grammatical error

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -829,7 +829,7 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
 
 
 class ShortReferenceInlineProcessor(ReferenceInlineProcessor):
-    """Shorte form of reference: [google]. """
+    """Short form of reference: [google]. """
     def evalId(self, data, index, text):
         """Evaluate the id from of [ref]  """
 


### PR DESCRIPTION
Corrected "Shorte" to "Short" in the documentation string of `ShortReferenceInlineProcessor` in the inlinepatterns.py file.