### PR TITLE
Add custom Pygments lexer support for Codehilite

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -6,6 +6,7 @@ Python-Markdown Change Log
 Under development: version 3.3.5 (a bug-fix release).
 
 * Make the `slugify_unicode` function not remove diacritical marks (#1118).
+* Add support for custom Pygments lexers with Codehilite.
 
 Feb 24, 2021: version 3.3.4 (a bug-fix release).
 


### PR DESCRIPTION
Custom Pygments lexers can now be passed as a keyword argument -- `custom_lexers=` -- to the `CodeHilite` and `CodeHiliteExtension` classes. The lexer must be a class that inherits from `RegexLexer` or other valid Pygments lexers [as described here](https://pygments.org/docs/lexerdevelopment/). Simply pass the class inside a list -- `CodeHiliteExtension(custom_lexers=[CustomLexer])` -- and it will be instantiated with whatever extra keyword arguments you passed in like a standard lexer. Naturally, multiple lexers can be put in the list.

This is obviously a very niche use-case, so I wouldn't be gutted if it isn't worth the trouble. I'm also not sure I updated the right file for the change log.