### PR TITLE
document footnote's need for reset() between multiple runs

### DIFF
--- a/docs/extensions/footnotes.md
+++ b/docs/extensions/footnotes.md
@@ -103,13 +103,21 @@ markdown.markdown(some_text, extensions=['footnotes'])
 Resetting Instance State
 -----
 
-Footnote definitions are stored within the  `markdown.Markdown` class instance between multiple runs of the class.  This allows footnotes from all runs to be included in output, with  links and references that are unique, even though the class has been called multiple times.
+Footnote definitions are stored within the  `markdown.Markdown` class instance between
+multiple runs of the class.  This allows footnotes from all runs to be included in
+output, with  links and references that are unique, even though the class has been
+called multiple times.
 
 However, if needed, the definitions can be cleared between runs by calling `reset`.
 
-For instance, the home page of a blog might include the content from multiple documents. By not calling `reset`, all of the footnotes will be rendered, and they will all have unique links and references.
+For instance, the home page of a blog might include the content from multiple documents.
+By not calling `reset`, all of the footnotes will be rendered, and they will all have
+unique links and references.
 
-On the other hand, individual blog post pages might need the content from only one document, and should have footnotes pertaining only to that page. By calling `reset` between runs, the footnote definitions from the first document will be cleared before the second document is rendered.
+On the other hand, individual blog post pages might need the content from only one
+document, and should have footnotes pertaining only to that page. By calling `reset`
+between runs, the footnote definitions from the first document will be cleared before
+the second document is rendered.
 
 An example of calling `reset`:
 

--- a/docs/extensions/footnotes.md
+++ b/docs/extensions/footnotes.md
@@ -100,7 +100,18 @@ A trivial example:
 markdown.markdown(some_text, extensions=['footnotes'])
 ```
 
-Note that the footnote extension needs to have its state reset between multiple runs of the `markdown.Markdown` class. Call `reset` like this:
+Resetting Instance State
+-----
+
+Footnote definitions are stored within the  `markdown.Markdown` class instance between multiple runs of the class.  This allows footnotes from all runs to be included in output, with  links and references that are unique, even though the class has been called multiple times.
+
+However, if needed, the definitions can be cleared between runs by calling `reset`.
+
+For instance, the home page of a blog might include the content from multiple documents. By not calling `reset`, all of the footnotes will be rendered, and they will all have unique links and references.
+
+On the other hand, individual blog post pages might need the content from only one document, and should have footnotes pertaining only to that page. By calling `reset` between runs, the footnote definitions from the first document will be cleared before the second document is rendered.
+
+An example of calling `reset`:
 
 ```python
 md = markdown.Markdown(extensions=['footnotes'])
@@ -108,6 +119,3 @@ html1 = md.convert(text_with_footnote)
 md.reset()
 html2 = md.convert(text_without_footnote)
 ```
-
-Without calling `reset`, the footnote definitions from the first document will be inserted into the second document, as
-they are still stored within the class instance.

--- a/docs/extensions/footnotes.md
+++ b/docs/extensions/footnotes.md
@@ -111,4 +111,3 @@ html2 = md.convert(text_without_footnote)
 
 Without calling `reset`, the footnote definitions from the first document will be inserted into the second document, as
 they are still stored within the class instance.
-

--- a/docs/extensions/footnotes.md
+++ b/docs/extensions/footnotes.md
@@ -99,3 +99,16 @@ A trivial example:
 ```python
 markdown.markdown(some_text, extensions=['footnotes'])
 ```
+
+Note that the footnote extension needs to have its state reset between multiple runs of the `markdown.Markdown` class. Call `reset` like this:
+
+```python
+md = markdown.Markdown(extensions=['footnotes'])
+html1 = md.convert(text_with_footnote)
+md.reset()
+html2 = md.convert(text_without_footnote)
+```
+
+Without calling `reset`, the footnote definitions from the first document will be inserted into the second document, as
+they are still stored within the class instance.
+


### PR DESCRIPTION
The footnote docs page doesn't mention the need to run `reset()` between multiple runs of the `markdown.Markdown` class.

This PR adapts and adds language taken from the `extensions/api.md` page to explain what to do and why.