### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,10 +7,10 @@ on:
     branches:
       - master
     tags:
-      - "**"
+      - '**'
   pull_request:
     branches:
-      - "**"
+      - '**'
 
 jobs:
   test:
@@ -82,7 +82,7 @@ jobs:
         if: ${{ matrix.tox-env == 'checklinks' }}
         uses: actions/setup-node@v2
         with:
-          node-version: "10"
+          node-version: '10'
           cache: npm
       - name: Install dependencies
         run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -80,7 +80,7 @@ jobs:
           python-version: 3.7
       - name: Setup Node
         if: ${{ matrix.tox-env == 'checklinks' }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: "10"
           cache: npm

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,12 +5,12 @@ name: CI
 on:
   push:
     branches:
-      - master
+    - master
     tags:
-      - '**'
+    - '**'
   pull_request:
     branches:
-      - '**'
+    - '**'
 
 jobs:
   test:
@@ -38,25 +38,25 @@ jobs:
       TOXENV: ${{ matrix.tox-env }}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          sudo apt-get install libtidy-dev
-          python -m pip install --upgrade pip tox coverage codecov
-      - name: Run tox
-        run: python -m tox
-      - name: Upload Results
-        if: success()
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: ${{ matrix.tox-env }}
-          fail_ci_if_error: false
+    - uses: actions/checkout@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libtidy-dev
+        python -m pip install --upgrade pip tox coverage codecov
+    - name: Run tox
+      run: python -m tox
+    - name: Upload Results
+      if: success()
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: ${{ matrix.tox-env }}
+        fail_ci_if_error: false
 
   lint:
     runs-on: ubuntu-latest
@@ -73,21 +73,21 @@ jobs:
     continue-on-error: ${{ matrix.tox-env == 'checklinks' }}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Setup Node
-        if: ${{ matrix.tox-env == 'checklinks' }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: '10'
-          cache: npm
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip tox
-          if [[ "$TOXENV" == 'checklinks' ]]; then npm install -g markdown-link-check; fi
-          if [[ "$TOXENV" == 'checkspelling' ]]; then sudo apt-get install aspell aspell-en; fi
-      - name: Run tox
-        run: python -m tox
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Setup Node
+      if: ${{ matrix.tox-env == 'checklinks' }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: '10'
+        cache: npm
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip tox
+        if [[ "$TOXENV" == 'checklinks' ]]; then npm install -g markdown-link-check; fi
+        if [[ "$TOXENV" == 'checkspelling' ]]; then sudo apt-get install aspell aspell-en; fi
+    - name: Run tox
+      run: python -m tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,16 +5,15 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
     tags:
-    - '**'
+      - "**"
   pull_request:
     branches:
-    - '**'
+      - "**"
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -39,25 +38,25 @@ jobs:
       TOXENV: ${{ matrix.tox-env }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt-get install libtidy-dev
-        python -m pip install --upgrade pip tox coverage codecov
-    - name: Run tox
-      run: python -m tox
-    - name: Upload Results
-      if: success()
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: ${{ matrix.tox-env }}
-        fail_ci_if_error: false
+      - uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libtidy-dev
+          python -m pip install --upgrade pip tox coverage codecov
+      - name: Run tox
+        run: python -m tox
+      - name: Upload Results
+        if: success()
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: ${{ matrix.tox-env }}
+          fail_ci_if_error: false
 
   lint:
     runs-on: ubuntu-latest
@@ -74,20 +73,21 @@ jobs:
     continue-on-error: ${{ matrix.tox-env == 'checklinks' }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Setup Node
-      if: ${{ matrix.tox-env == 'checklinks' }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: '10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip tox
-        if [[ "$TOXENV" == 'checklinks' ]]; then npm install -g markdown-link-check; fi
-        if [[ "$TOXENV" == 'checkspelling' ]]; then sudo apt-get install aspell aspell-en; fi
-    - name: Run tox
-      run: python -m tox
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Setup Node
+        if: ${{ matrix.tox-env == 'checklinks' }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+          cache: npm
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip tox
+          if [[ "$TOXENV" == 'checklinks' ]]; then npm install -g markdown-link-check; fi
+          if [[ "$TOXENV" == 'checkspelling' ]]; then sudo apt-get install aspell aspell-en; fi
+      - name: Run tox
+        run: python -m tox


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Fix #1153

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
