### PR TITLE
Re-use compiled regex for block level checks

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -7,6 +7,7 @@ Under development: version 3.3.5 (a bug-fix release).
 
 * Make the `slugify_unicode` function not remove diacritical marks (#1118).
 * Fix `[toc]` detection when used with `nl2br` extension (#1160)
+* Re-use compiled regex for block level checks (#1169)
 
 Feb 24, 2021: version 3.3.4 (a bug-fix release).
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -65,6 +65,8 @@ class Postprocessor(util.Processor):
 class RawHtmlPostprocessor(Postprocessor):
     """ Restore raw html to the document. """
 
+    BLOCK_LEVEL_REGEX = re.compile(r'^\<\/?([^ >]+)')
+
     def run(self, text):
         """ Iterate over html stash and restore html. """
         replacements = OrderedDict()
@@ -99,7 +101,7 @@ class RawHtmlPostprocessor(Postprocessor):
             return self.run(processed_text)
 
     def isblocklevel(self, html):
-        m = re.match(r'^\<\/?([^ >]+)', html)
+        m = self.BLOCK_LEVEL_REGEX.match(html)
         if m:
             if m.group(1)[0] in ('!', '?', '@', '%'):
                 # Comment, php etc...


### PR DESCRIPTION
## Problem

This page takes several seconds to load:

- https://spacedock.info/mod/795

## Cause

We've hit a somewhat exceptional case in that there are 76+ different markdown documents to render to HTML for that page (the author of the mod has been very prolific with creating releases, see [the "changelog" list at the bottom](https://spacedock.info/mod/795#changelog)).

With profiling enabled, it turns out that about one second is spent (re-)compiling a regex inside of `isblocklevel`, once per markdown document:

![image](https://user-images.githubusercontent.com/1559108/128635975-5e3ca35b-89fa-4e1a-aebb-b2cebb9ef40e.png)

## Other ideas

We (site developers) will probably take a number of other actions to address this slowness, such as paginating the releases and pre-rendering the markdown to HTML when saving to SQL rather than at render. But that regex still represents some low-hanging fruit for other users with many documents to render.

## Changes

Now that regex is compiled once at startup and re-used in compiled form as needed. Should speed up rendering multiple documents modestly.

FYI to @DasSkelett, going to see how this goes.