### PR TITLE
Fix changelog entry in wrong place

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -8,6 +8,7 @@ Under development: version 3.3.5 (a bug-fix release).
 * Make the `slugify_unicode` function not remove diacritical marks (#1118).
 * Fix `[toc]` detection when used with `nl2br` extension (#1160)
 * Re-use compiled regex for block level checks (#1169)
+* Don't process shebangs in fenced code blocks when using CodeHilite (#1156).
 
 Feb 24, 2021: version 3.3.4 (a bug-fix release).
 

--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -102,7 +102,6 @@ The following bug fixes are included in the 3.3 release:
 * Fix complex scenarios involving lists and admonitions (#1004).
 * Fix complex scenarios with nested ordered and unordered lists in a definition list (#918).
 * Fix corner cases with lists under admonitions.
-* Don't process shebangs in fenced code blocks when using CodeHilite (#1156).
 
 [spec]: https://www.w3.org/TR/html5/text-level-semantics.html#the-code-element
 [fenced_code]: ../extensions/fenced_code_blocks.md


### PR DESCRIPTION
Changelog entry from hash e11cd255cae5fd3c5ef5fdd6352cd28e212fd328
was placed in the wrong place.