### PR TITLE
Fix one more misplaced changelog entry

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -18,7 +18,8 @@ Feb 24, 2021: version 3.3.4 (a bug-fix release).
 * Properly parse code spans in md_in_html (#1069).
 * Preserve text immediately before an admonition (#1092).
 * Simplified regex for HTML placeholders (#928) addressing (#932).
-* Ensure `permalinks` and `ankorlinks` are not restricted by `toc_depth` (#1107).
+* Ensure `permalinks` and `anchorlinks` are not restricted by `toc_depth` (#1107).
+* Fix corner cases with lists under admonitions (#1102).
 
 Oct 25, 2020: version 3.3.3 (a bug-fix release).
 

--- a/docs/change_log/release-3.3.md
+++ b/docs/change_log/release-3.3.md
@@ -101,7 +101,6 @@ The following bug fixes are included in the 3.3 release:
 * Fix unescaping of HTML characters `<>` in CodeHilite (#990).
 * Fix complex scenarios involving lists and admonitions (#1004).
 * Fix complex scenarios with nested ordered and unordered lists in a definition list (#918).
-* Fix corner cases with lists under admonitions.
 
 [spec]: https://www.w3.org/TR/html5/text-level-semantics.html#the-code-element
 [fenced_code]: ../extensions/fenced_code_blocks.md


### PR DESCRIPTION
PR #1102 was included in 3.3.4, not 3.3.0.

Also fix a typo in another changelog entry.