### PR TITLE
lxml support

### DIFF
--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -19,7 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import xml.etree.ElementTree as etree
+from . import etree
 from . import util
 
 

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -32,7 +32,7 @@ as they need to alter how markdown blocks are parsed.
 
 import logging
 import re
-import xml.etree.ElementTree as etree
+from . import etree
 from . import util
 from .blockparser import BlockParser
 

--- a/markdown/etree.py
+++ b/markdown/etree.py
@@ -1,0 +1,9 @@
+try:
+  import lxml.etree as etree
+except:
+  import xml.etree.ElementTree as etree
+  
+def __getattr__(name):
+    """Get attribute."""
+    
+    return getattr(etree, name)

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -21,7 +21,7 @@ from ..blockprocessors import BlockProcessor
 from ..inlinepatterns import InlineProcessor
 from ..util import AtomicString
 import re
-import xml.etree.ElementTree as etree
+from .. import etree
 
 
 class AbbrExtension(Extension):

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -19,7 +19,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 
 

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor, ListIndentProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 
 

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -22,7 +22,7 @@ from .. import util
 from collections import OrderedDict
 import re
 import copy
-import xml.etree.ElementTree as etree
+from .. import etree
 
 FN_BACKLINK_TEXT = util.STX + "zz1337820767766393qq" + util.ETX
 NBSP_PLACEHOLDER = util.STX + "qq3936677670287331zz" + util.ETX

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -20,7 +20,7 @@ from ..preprocessors import Preprocessor
 from ..postprocessors import RawHtmlPostprocessor
 from .. import util
 from ..htmlparser import HTMLExtractor, blank_line_re
-import xml.etree.ElementTree as etree
+from .. import etree
 
 
 class HTMLExtractorExtra(HTMLExtractor):

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 PIPE_NONE = 0
 PIPE_LEFT = 1

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -20,7 +20,7 @@ from ..postprocessors import UnescapePostprocessor
 import re
 import html
 import unicodedata
-import xml.etree.ElementTree as etree
+from .. import etree
 
 
 def slugify(value, separator, unicode=False):

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..inlinepatterns import InlineProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -63,7 +63,7 @@ So, we apply the expressions in the following order:
 from . import util
 from collections import namedtuple
 import re
-import xml.etree.ElementTree as etree
+from . import etree
 try:  # pragma: no cover
     from html import entities
 except ImportError:  # pragma: no cover

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -19,7 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import xml.etree.ElementTree as etree
+from . import etree
 from . import util
 from . import inlinepatterns
 

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -22,7 +22,7 @@ License: BSD (see LICENSE.md for details).
 import re
 import sys
 import warnings
-import xml.etree.ElementTree
+from . import etree
 from collections import namedtuple
 from functools import wraps
 from itertools import count
@@ -40,7 +40,7 @@ PY37 = (3, 7) <= sys.version_info
 
 # TODO: Remove deprecated variables in a future release.
 __deprecated__ = {
-    'etree': ('xml.etree.ElementTree', xml.etree.ElementTree),
+    'etree': ('xml.etree.ElementTree', etree),
     'string_type': ('str', str),
     'text_type': ('str', str),
     'int2str': ('chr', chr),


### PR DESCRIPTION
Some projects already rely on lxml features internally, but still want to make use of the python-markdown package. So it can be important to use the third-party implementation with python-markdown if one wants to deeper integrate with markdown library.

I did outsource the etree import mechanism into markdown/etree module as a try-except block.