### PR TITLE
Custom parser interface

### DIFF
--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -19,7 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import xml.etree.ElementTree as etree
+from . import etree
 from . import util
 
 

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -32,7 +32,7 @@ as they need to alter how markdown blocks are parsed.
 
 import logging
 import re
-import xml.etree.ElementTree as etree
+from . import etree
 from . import util
 from .blockparser import BlockParser
 

--- a/markdown/etree.py
+++ b/markdown/etree.py
@@ -1,0 +1,9 @@
+try:
+  import lxml.etree as etree
+except:
+  import xml.etree.ElementTree as etree
+  
+def __getattr__(name):
+    """Get attribute."""
+    
+    return getattr(etree, name)

--- a/markdown/etree.py
+++ b/markdown/etree.py
@@ -1,9 +1,45 @@
-try:
-  import lxml.etree as etree
-except:
-  import xml.etree.ElementTree as etree
+"""
+Python Markdown
+
+A Python implementation of John Gruber's Markdown.
+
+Documentation: https://python-markdown.github.io/
+GitHub: https://github.com/Python-Markdown/markdown/
+PyPI: https://pypi.org/project/Markdown/
+
+Started by Manfred Stienstra (http://www.dwerg.net/).
+Maintained for a few years by Yuri Takhteyev (http://www.freewisdom.org).
+Currently maintained by Waylan Limberg (https://github.com/waylan),
+Dmitry Shachnev (https://github.com/mitya57) and Isaac Muse (https://github.com/facelessuser).
+
+Copyright 2007-2021 The Python Markdown Project (v. 1.7 and later)
+Copyright 2004, 2005, 2006 Yuri Takhteyev (v. 0.2-1.6b)
+Copyright 2004 Manfred Stienstra (the original version)
+
+License: BSD (see LICENSE.md for details).
+"""
+
+import sys
+
+def set_parser(parser):
+  """ Set parser to alternative like e.g. lxml.etree
+  usage:
+
+  import markdown
+  import lxml.etree
+  markdown.etree.set_parser(lxml.etree)
+  """
+  setattr(sys.modules[__name__], 'etree', parser)
   
+
+def reset_parser(parser):
+  """ Reset the ElementTree parser back to default """
+
+  import xml.etree.ElementTree as etree
+
 def __getattr__(name):
     """Get attribute."""
-    
     return getattr(etree, name)
+  
+if not hasattr(sys.modules[__name__], 'etree'):
+  import xml.etree.ElementTree as etree

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -21,7 +21,7 @@ from ..blockprocessors import BlockProcessor
 from ..inlinepatterns import InlineProcessor
 from ..util import AtomicString
 import re
-import xml.etree.ElementTree as etree
+from .. import etree
 
 
 class AbbrExtension(Extension):

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -19,7 +19,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 
 

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor, ListIndentProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 
 

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -22,7 +22,7 @@ from .. import util
 from collections import OrderedDict
 import re
 import copy
-import xml.etree.ElementTree as etree
+from .. import etree
 
 FN_BACKLINK_TEXT = util.STX + "zz1337820767766393qq" + util.ETX
 NBSP_PLACEHOLDER = util.STX + "qq3936677670287331zz" + util.ETX

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -20,7 +20,7 @@ from ..preprocessors import Preprocessor
 from ..postprocessors import RawHtmlPostprocessor
 from .. import util
 from ..htmlparser import HTMLExtractor, blank_line_re
-import xml.etree.ElementTree as etree
+from .. import etree
 
 
 class HTMLExtractorExtra(HTMLExtractor):

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..blockprocessors import BlockProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 PIPE_NONE = 0
 PIPE_LEFT = 1

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -20,7 +20,7 @@ from ..postprocessors import UnescapePostprocessor
 import re
 import html
 import unicodedata
-import xml.etree.ElementTree as etree
+from .. import etree
 
 
 def slugify(value, separator, unicode=False):

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 from . import Extension
 from ..inlinepatterns import InlineProcessor
-import xml.etree.ElementTree as etree
+from .. import etree
 import re
 
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -63,7 +63,7 @@ So, we apply the expressions in the following order:
 from . import util
 from collections import namedtuple
 import re
-import xml.etree.ElementTree as etree
+from . import etree
 try:  # pragma: no cover
     from html import entities
 except ImportError:  # pragma: no cover

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -19,7 +19,7 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import xml.etree.ElementTree as etree
+from . import etree
 from . import util
 from . import inlinepatterns
 

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -22,7 +22,7 @@ License: BSD (see LICENSE.md for details).
 import re
 import sys
 import warnings
-import xml.etree.ElementTree
+from . import etree
 from collections import namedtuple
 from functools import wraps
 from itertools import count
@@ -40,7 +40,7 @@ PY37 = (3, 7) <= sys.version_info
 
 # TODO: Remove deprecated variables in a future release.
 __deprecated__ = {
-    'etree': ('xml.etree.ElementTree', xml.etree.ElementTree),
+    'etree': ('xml.etree.ElementTree', etree),
     'string_type': ('str', str),
     'text_type': ('str', str),
     'int2str': ('chr', chr),


### PR DESCRIPTION
Regarding the [earlier pull request](https://github.com/Python-Markdown/markdown/pull/1177) I propose a _custom parser interface_ for better integration with third party projects using e.g. _lxml_.

### Purpose:
Help developers of third party projects to easily change the internal parser (etree) if their custom extensions do have need for extended functionality of e.g. _lxml_.

### Usage:
```python
import markdown
import lxml.etree
markdown.etree.set_parser(lxml.etree)
html = markdown.markdown("# Hello extended XPath World")
```

### Criticism:
Compatibility issues of third party parsers do not have to be targeted by Python-Markdown development team, as projects like _lxml.etree_ claim to be compatible with _xml.etree.ElementTree_

### Licensing:
There should be no legal conflicts (BSD/MIT) in case of lxml. :-D

**I hope you'll accept my idea to make my life a bit easier beyond python-markdown update cycles.**

Cheers
Dom