### PR TITLE
Ensure `<summary>` tags are parsed correctly.

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -10,6 +10,7 @@ Under development: version 3.3.5 (a bug-fix release).
 * Re-use compiled regex for block level checks (#1169).
 * Don't process shebangs in fenced code blocks when using CodeHilite (#1156).
 * Improve email address validation for Automatic Links (#1165).
+* Ensure `<summary>` tags are parsed correctly (#1079).
 
 Feb 24, 2021: version 3.3.4 (a bug-fix release).
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -82,7 +82,7 @@ class Markdown:
             # Other elements which Markdown should not be mucking up the contents of.
             'canvas', 'colgroup', 'dd', 'body', 'dt', 'group', 'iframe', 'li', 'legend',
             'math', 'map', 'noscript', 'output', 'object', 'option', 'progress', 'script',
-            'style', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
+            'style', 'summary', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
         ]
 
         self.registeredExtensions = []

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -33,13 +33,14 @@ class HTMLExtractorExtra(HTMLExtractor):
         self.block_level_tags = set(md.block_level_elements.copy())
         # Block-level tags in which the content only gets span level parsing
         self.span_tags = set(
-            ['address', 'dd', 'dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'legend', 'li', 'p', 'td', 'th']
+            ['address', 'dd', 'dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'legend', 'li', 'p', 'summary', 'td', 'th']
         )
         # Block-level tags which never get their content parsed.
         self.raw_tags = set(['canvas', 'math', 'option', 'pre', 'script', 'style', 'textarea'])
-        # Block-level tags in which the content gets parsed as blocks
+
         super().__init__(md, *args, **kwargs)
 
+        # Block-level tags in which the content gets parsed as blocks
         self.block_tags = set(self.block_level_tags) - (self.span_tags | self.raw_tags | self.empty_tags)
         self.span_and_blocks_tags = self.block_tags | self.span_tags
 

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -283,6 +283,26 @@ class TestMdInHTML(TestCase):
             )
         )
 
+    def text_md1_details(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <details markdown="1">
+                <summary>Click to expand</summary>
+                *foo*
+                </details>
+                """
+            ),
+            self.dedent(
+                """
+                <details>
+                <summary>Click to expand</summary>
+                <p><em>foo</em></p>
+                </details>
+                """
+            )
+        )
+
     def test_md1_mix(self):
         self.assertMarkdownRenders(
             self.dedent(


### PR DESCRIPTION
Fixes #1079.