### PR TITLE
update install requires to drop quotes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     license='BSD License',
     packages=['markdown', 'markdown.extensions'],
     python_requires='>=3.6',
-    install_requires=["importlib-metadata>='4.4';python_version<'3.10'"],
+    install_requires=["importlib-metadata>=4.4;python_version<'3.10'"],
     extras_require={
         'testing': [
             'coverage',


### PR DESCRIPTION
closes #1196 

verified that pip consider requirements are met if an older version of importlib-metadata is installed when quotes are present