### PR TITLE
Bump version to 3.3.6

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,6 +3,10 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
+Nov 17, 2021: version 3.3.6 (a bug-fix release).
+
+* Fix a dependency issue (#1195, #1196).
+
 Nov 16, 2021: version 3.3.5 (a bug-fix release).
 
 * Make the `slugify_unicode` function not remove diacritical marks (#1118).

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -26,7 +26,7 @@ License: BSD (see LICENSE.md for details).
 # (1, 2, 0, 'beta', 2) => "1.2b2"
 # (1, 2, 0, 'rc', 4) => "1.2rc4"
 # (1, 2, 0, 'final', 0) => "1.2"
-__version_info__ = (3, 3, 5, 'final', 0)
+__version_info__ = (3, 3, 6, 'final', 0)
 
 
 def _get_version(version_info):


### PR DESCRIPTION
As the only fix in this release addresses an installation issue, I think we should release immediately.