### PR TITLE
Disallow square brackets in reference link ids.

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,6 +3,10 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
+(under development): version 3.3.7 (a bug-fix release).
+
+* Disallow square brackets in reference link ids (#1209).
+
 Nov 17, 2021: version 3.3.6 (a bug-fix release).
 
 * Fix a dependency issue (#1195, #1196).

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -559,7 +559,7 @@ class EmptyBlockProcessor(BlockProcessor):
 class ReferenceProcessor(BlockProcessor):
     """ Process link references. """
     RE = re.compile(
-        r'^[ ]{0,3}\[([^\]]*)\]:[ ]*\n?[ ]*([^\s]+)[ ]*(?:\n[ ]*)?((["\'])(.*)\4[ ]*|\((.*)\)[ ]*)?$', re.MULTILINE
+        r'^[ ]{0,3}\[([^\[\]]*)\]:[ ]*\n?[ ]*([^\s]+)[ ]*(?:\n[ ]*)?((["\'])(.*)\4[ ]*|\((.*)\)[ ]*)?$', re.MULTILINE
     )
 
     def test(self, parent, block):

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -350,3 +350,37 @@ class TestReferenceLinks(TestCase):
             '<p>I would like to tell you about the [code of</p>\n'
             '<p>conduct][] we are using in this project.</p>'
         )
+
+    def test_ref_link_nested_left_bracket(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [Text[]
+
+                [Text[]: http://example.com
+                """
+            ),
+            self.dedent(
+                """
+                <p>[Text[]</p>
+                <p>[Text[]: http://example.com</p>
+                """
+            )
+        )
+
+    def test_ref_link_nested_right_bracket(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [Text]]
+
+                [Text]]: http://example.com
+                """
+            ),
+            self.dedent(
+                """
+                <p>[Text]]</p>
+                <p>[Text]]: http://example.com</p>
+                """
+            )
+        )


### PR DESCRIPTION
We already disallow right square brackets. This also disallows left
square brackets, which ensures link references will be less likely
to collide with standard links in some weird edge cases. Fixes #1209.