### PR TITLE
fix: added None check in `convert` to prevent no attribute error

### DIFF
--- a/markdown/core.py
+++ b/markdown/core.py
@@ -244,6 +244,9 @@ class Markdown:
 
         """
 
+        # Prevent `AttributeError: 'NoneType' object has no attribute 'strip'`
+        if source is None:
+            return ''
         # Fixup the source text
         if not source.strip():
             return ''  # a blank unicode string


### PR DESCRIPTION
I'm getting a NoneType error when this [mkthedocstrings function](https://github.com/mkdocstrings/mkdocstrings/blob/master/src/mkdocstrings/handlers/base.py#L219) calls this function with an empty string. While I may submit a PR there to avoid this bug too, I expect this change will make this module better for everyone.