### PR TITLE
[style]: fix various typos in docstrings and comments

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -321,7 +321,7 @@ class OListProcessor(BlockProcessor):
 
     TAG = 'ol'
     # The integer (python string) with which the lists starts (default=1)
-    # Eg: If list is intialized as)
+    # Eg: If list is initialized as)
     #   3. Item
     # The ol tag will get starts="3" attribute
     STARTSWITH = '1'

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -26,7 +26,7 @@ from ..util import parseBoolValue
 class Extension:
     """ Base class for extensions to subclass. """
 
-    # Default config -- to be overriden by a subclass
+    # Default config -- to be overridden by a subclass
     # Must be of the following format:
     #     {
     #       'key': ['value', 'description']
@@ -90,9 +90,9 @@ class Extension:
 
     def extendMarkdown(self, md):
         """
-        Add the various proccesors and patterns to the Markdown Instance.
+        Add the various proccessors and patterns to the Markdown Instance.
 
-        This method must be overriden by every extension.
+        This method must be overridden by every extension.
 
         Keyword arguments:
 

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -221,7 +221,7 @@ class CodeHilite:
 
 
 class HiliteTreeprocessor(Treeprocessor):
-    """ Hilight source code in code blocks. """
+    """ Highlight source code in code blocks. """
 
     def code_unescape(self, text):
         """Unescape code."""
@@ -253,7 +253,7 @@ class HiliteTreeprocessor(Treeprocessor):
 
 
 class CodeHiliteExtension(Extension):
-    """ Add source code hilighting to markdown codeblocks. """
+    """ Add source code highlighting to markdown codeblocks. """
 
     def __init__(self, **kwargs):
         # define default configs

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -87,7 +87,7 @@ class DefListProcessor(BlockProcessor):
 class DefListIndentProcessor(ListIndentProcessor):
     """ Process indented children of definition list items. """
 
-    # Defintion lists need to be aware of all list types
+    # Definition lists need to be aware of all list types
     ITEM_TYPES = ['dd', 'li']
     LIST_TYPES = ['dl', 'ol', 'ul']
 

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -228,7 +228,7 @@ class FootnoteBlockProcessor(BlockProcessor):
                 # Any content before match is continuation of this footnote, which may be lazily indented.
                 before = therest[:m2.start()].rstrip('\n')
                 fn_blocks[0] = '\n'.join([fn_blocks[0], self.detab(before)]).lstrip('\n')
-                # Add back to blocks everything from begining of match forward for next iteration.
+                # Add back to blocks everything from beginning of match forward for next iteration.
                 blocks.insert(0, therest[m2.start():])
             else:
                 # All remaining lines of block are continuation of this footnote, which may be lazily indented.
@@ -264,7 +264,7 @@ class FootnoteBlockProcessor(BlockProcessor):
                     # Any content before match is continuation of this footnote, which may be lazily indented.
                     before = block[:m.start()].rstrip('\n')
                     fn_blocks.append(self.detab(before))
-                    # Add back to blocks everything from begining of match forward for next iteration.
+                    # Add back to blocks everything from beginning of match forward for next iteration.
                     blocks.insert(0, block[m.start():])
                     # End of this footnote.
                     break
@@ -355,7 +355,7 @@ class FootnotePostTreeprocessor(Treeprocessor):
         self.offset = 0
         for div in root.iter('div'):
             if div.attrib.get('class', '') == 'footnote':
-                # Footnotes shoul be under the first orderd list under
+                # Footnotes should be under the first ordered list under
                 # the footnote div.  So once we find it, quit.
                 for ol in div.iter('ol'):
                     self.handle_duplicates(ol)

--- a/markdown/extensions/legacy_attrs.py
+++ b/markdown/extensions/legacy_attrs.py
@@ -26,7 +26,7 @@ An extension to Python Markdown which implements legacy attributes.
 Prior to Python-Markdown version 3.0, the Markdown class had an `enable_attributes`
 keyword which was on by default and provided for attributes to be defined for elements
 using the format `{@key=value}`. This extension is provided as a replacement for
-backward compatability. New documents should be authored using attr_lists. However,
+backward compatibility. New documents should be authored using attr_lists. However,
 numerious documents exist which have been using the old attribute format for many
 years. This extension can be used to continue to render those documents correctly.
 """

--- a/markdown/extensions/legacy_em.py
+++ b/markdown/extensions/legacy_em.py
@@ -2,7 +2,7 @@
 Legacy Em Extension for Python-Markdown
 =======================================
 
-This extention provides legacy behavior for _connected_words_.
+This extension provides legacy behavior for _connected_words_.
 
 Copyright 2015-2018 The Python Markdown Project
 

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -248,7 +248,7 @@ class MarkdownInHtmlProcessor(BlockProcessor):
 
     def parse_element_content(self, element):
         """
-        Resursively parse the text content of an etree Element as Markdown.
+        Recursively parse the text content of an etree Element as Markdown.
 
         Any block level elements generated from the Markdown will be inserted as children of the element in place
         of the text content. All `markdown` attributes are removed. For any elements in which Markdown parsing has
@@ -268,7 +268,7 @@ class MarkdownInHtmlProcessor(BlockProcessor):
             for child in list(element):
                 self.parse_element_content(child)
 
-            # Parse Markdown text in tail of children. Do this seperate to avoid raw HTML parsing.
+            # Parse Markdown text in tail of children. Do this separate to avoid raw HTML parsing.
             # Save the position of each item to be inserted later in reverse.
             tails = []
             for pos, child in enumerate(element):

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -200,7 +200,7 @@ class TableProcessor(BlockProcessor):
             if not throw_out:
                 good_pipes.append(pipe)
 
-        # Split row according to table delimeters.
+        # Split row according to table delimiters.
         pos = 0
         for pipe in good_pipes:
             elements.append(row[pos:pipe])

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -365,7 +365,7 @@ class TocExtension(Extension):
         self.reset()
         tocext = self.TreeProcessorClass(md, self.getConfigs())
         # Headerid ext is set to '>prettify'. With this set to '_end',
-        # it should always come after headerid ext (and honor ids assinged
+        # it should always come after headerid ext (and honor ids assigned
         # by the header id extension) if both are used. Same goes for
         # attr_list extension. This must come last because we don't want
         # to redefine ids after toc is created. But we do want toc prettified.

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -113,7 +113,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
                 return m.end()
             else:  # pragma: no cover
                 # Value of self.lineno must exceed total number of lines.
-                # Find index of begining of last line.
+                # Find index of beginning of last line.
                 return self.rawdata.rfind('\n')
         return 0
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -673,7 +673,7 @@ class LinkInlineProcessor(InlineProcessor):
                         bracket_count -= 1
                     elif backtrack_count > 0:
                         backtrack_count -= 1
-                        # We've found our backup end location if the title doesn't reslove.
+                        # We've found our backup end location if the title doesn't resolve.
                         if backtrack_count == 0:
                             last_bracket = index + 1
 

--- a/markdown/test_tools.py
+++ b/markdown/test_tools.py
@@ -42,7 +42,7 @@ class TestCase(unittest.TestCase):
 
     The `assertMarkdownRenders` method accepts the source text, the expected
     output, and any keywords to pass to Markdown. The `default_kwargs` are used
-    except where overridden by `kwargs`. The ouput and expected ouput are passed
+    except where overridden by `kwargs`. The output and expected output are passed
     to `TestCase.assertMultiLineEqual`. An AssertionError is raised with a diff
     if the actual output does not equal the expected output.
 

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -174,7 +174,7 @@ def _get_stack_depth(size=2):
 
 
 def nearing_recursion_limit():
-    """Return true if current stack depth is withing 100 of maximum limit."""
+    """Return true if current stack depth is within 100 of maximum limit."""
     return sys.getrecursionlimit() - _get_stack_depth() < 100
 
 
@@ -349,7 +349,7 @@ class Registry:
         * `priority`: An integer or float used to sort against all items.
 
         If an item is registered with a "name" which already exists, the
-        existing item is replaced with the new item. Tread carefully as the
+        existing item is replaced with the new item. Treat carefully as the
         old item is lost with no way to recover it. The new item will be
         sorted according to its priority and will **not** retain the position
         of the old item.
@@ -388,7 +388,7 @@ class Registry:
     # Deprecated Methods which provide a smooth transition from OrderedDict
 
     def __setitem__(self, key, value):
-        """ Register item with priorty 5 less than lowest existing priority. """
+        """ Register item with priority 5 less than lowest existing priority. """
         if isinstance(key, str):
             warnings.warn(
                 'Using setitem to register a processor or pattern is deprecated. '

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -106,11 +106,11 @@ class TestAbbr(unittest.TestCase):
     def testNestedAbbr(self):
         """ Test Nested Abbreviations. """
         text = '[ABBR](/foo) and _ABBR_\n\n' + \
-               '*[ABBR]: Abreviation'
+               '*[ABBR]: Abbreviation'
         self.assertEqual(
             self.md.convert(text),
-            '<p><a href="/foo"><abbr title="Abreviation">ABBR</abbr></a> '
-            'and <em><abbr title="Abreviation">ABBR</abbr></em></p>'
+            '<p><a href="/foo"><abbr title="Abbreviation">ABBR</abbr></a> '
+            'and <em><abbr title="Abbreviation">ABBR</abbr></em></p>'
         )
 
 
@@ -175,7 +175,7 @@ The body. This is paragraph one.'''
         self.assertEqual(self.md.Meta, {})
 
     def testMetaDataWithoutNewline(self):
-        """ Test doocument with only metadata and no newline at end."""
+        """ Test document with only metadata and no newline at end."""
         text = 'title: No newline'
         self.assertEqual(self.md.convert(text), '')
         self.assertEqual(self.md.Meta, {'title': ['No newline']})

--- a/tests/test_syntax/blocks/test_blockquotes.py
+++ b/tests/test_syntax/blocks/test_blockquotes.py
@@ -28,7 +28,7 @@ class TestBlockquoteBlocks(TestCase):
 
     def test_nesting_limit(self):
         # Test that the nesting limit is within 100 levels of recursion limit. Future code changes could cause the
-        # recursion limit to need adjusted here. We need to acocunt for all of Markdown's internal calls. Finally, we
+        # recursion limit to need adjusted here. We need to account for all of Markdown's internal calls. Finally, we
         # need to account for the 100 level cushion which we are testing.
         with recursionlimit(120):
             self.assertMarkdownRenders(

--- a/tests/test_syntax/blocks/test_headers.py
+++ b/tests/test_syntax/blocks/test_headers.py
@@ -583,7 +583,7 @@ class TestHashHeaders(TestCase):
         )
 
     # TODO: Possibly change the following behavior. While this follows the behavior
-    # of markdown.pl, it is rather uncommon and not nessecarily intuitive.
+    # of markdown.pl, it is rather uncommon and not necessarily intuitive.
     # See: https://johnmacfarlane.net/babelmark2/?normalize=1&text=%23+This+is+an+H1+%23+
     def test_hash_h1_closed_trailing_space(self):
         self.assertMarkdownRenders(

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1546,7 +1546,7 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_hr_start_and_end(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1566,7 +1566,7 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_hr_only_end(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1585,7 +1585,7 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_hr_with_content(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         # Content is not allowed and will be treated as normal content between two hr tags.
         self.assertMarkdownRenders(
             self.dedent(

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -30,7 +30,7 @@ except ImportError:
     has_pygments = False
 
 # The version required by the tests is the version specified and installed in the 'pygments' tox env.
-# In any environment where the PYGMENTS_VERSION environment variabe is either not defined or doesn't
+# In any environment where the PYGMENTS_VERSION environment variable is either not defined or doesn't
 # match the version of Pygments installed, all tests which rely in pygments will be skipped.
 required_pygments_version = os.environ.get('PYGMENTS_VERSION', '')
 

--- a/tests/test_syntax/extensions/test_def_list.py
+++ b/tests/test_syntax/extensions/test_def_list.py
@@ -287,7 +287,7 @@ class TestDefList(TestCase):
 
                         term
 
-                        :   defintion
+                        :   definition
 
                             1.  list
 
@@ -305,7 +305,7 @@ class TestDefList(TestCase):
                 <dl>
                 <dt>term</dt>
                 <dd>
-                <p>defintion</p>
+                <p>definition</p>
                 <ol>
                 <li>
                 <p>list</p>

--- a/tests/test_syntax/extensions/test_fenced_code.py
+++ b/tests/test_syntax/extensions/test_fenced_code.py
@@ -30,7 +30,7 @@ except ImportError:
     has_pygments = False
 
 # The version required by the tests is the version specified and installed in the 'pygments' tox env.
-# In any environment where the PYGMENTS_VERSION environment variabe is either not defined or doesn't
+# In any environment where the PYGMENTS_VERSION environment variable is either not defined or doesn't
 # match the version of Pygments installed, all tests which rely in pygments will be skipped.
 required_pygments_version = os.environ.get('PYGMENTS_VERSION', '')
 

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1066,7 +1066,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_hr_start_and_end(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1086,7 +1086,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_hr_only_end(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1105,7 +1105,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_hr_with_content(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         # Content is not allowed and will be treated as normal content between two hr tags
         self.assertMarkdownRenders(
             self.dedent(
@@ -1129,7 +1129,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_no_md1_hr_with_content(self):
-        # Browers ignore ending hr tags, so we don't try to do anything to handle them special.
+        # Browsers ignore ending hr tags, so we don't try to do anything to handle them special.
         # Content is not allowed and will be treated as normal content between two hr tags
         self.assertMarkdownRenders(
             self.dedent(


### PR DESCRIPTION
Fix various English typos in the docstrings or comments of the source code. 