### PR TITLE
extensions: copy config dict on each highlighted block

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -6,6 +6,7 @@ Python-Markdown Change Log
 (under development): version 3.3.7 (a bug-fix release).
 
 * Disallow square brackets in reference link ids (#1209).
+* Retain configured `pygments_style` after first code block (#1240).
 
 Nov 17, 2021: version 3.3.6 (a bug-fix release).
 

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -237,11 +237,12 @@ class HiliteTreeprocessor(Treeprocessor):
         blocks = root.iter('pre')
         for block in blocks:
             if len(block) == 1 and block[0].tag == 'code':
+                local_config = self.config.copy()
                 code = CodeHilite(
                     self.code_unescape(block[0].text),
                     tab_length=self.md.tab_length,
-                    style=self.config.pop('pygments_style', 'default'),
-                    **self.config
+                    style=local_config.pop('pygments_style', 'default'),
+                    **local_config
                 )
                 placeholder = self.md.htmlStash.store(code.hilite())
                 # Clear codeblock in etree instance

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -644,3 +644,35 @@ class TestCodeHiliteExtension(TestCase):
             expected,
             extensions=[CodeHiliteExtension(unknown='some value')],
         )
+
+    def testMultipleBlocksSameStyle(self):
+        if has_pygments:
+            # See also: https://github.com/Python-Markdown/markdown/issues/1240
+            expected = (
+                '<div class="codehilite" style="background: #202020"><pre style="line-height: 125%; margin: 0;">'
+                '<span></span><code><span style="color: #999999; font-style: italic"># First Code Block</span>\n'
+                '</code></pre></div>\n\n'
+                '<p>Normal paragraph</p>\n'
+                '<div class="codehilite" style="background: #202020"><pre style="line-height: 125%; margin: 0;">'
+                '<span></span><code><span style="color: #999999; font-style: italic"># Second Code Block</span>\n'
+                '</code></pre></div>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code class="language-python"># First Code Block\n'
+                '</code></pre>\n\n'
+                '<p>Normal paragraph</p>\n'
+                '<pre class="codehilite"><code class="language-python"># Second Code Block\n'
+                '</code></pre>'
+            )
+        self.assertMarkdownRenders(
+            (
+                '\t:::Python\n'
+                '\t# First Code Block\n\n'
+                'Normal paragraph\n\n'
+                '\t:::Python\n'
+                '\t# Second Code Block'
+            ),
+            expected,
+            extensions=[CodeHiliteExtension(pygments_style="native", noclasses=True)]
+        )

--- a/tests/test_syntax/extensions/test_fenced_code.py
+++ b/tests/test_syntax/extensions/test_fenced_code.py
@@ -781,3 +781,48 @@ class TestFencedCodeWithCodehilite(TestCase):
             expected,
             extensions=['codehilite', 'fenced_code']
         )
+
+    def testFencedMultpleBlocksSameStyle(self):
+        if has_pygments:
+            # See also: https://github.com/Python-Markdown/markdown/issues/1240
+            expected = (
+                '<div class="codehilite" style="background: #202020"><pre style="line-height: 125%; margin: 0;">'
+                '<span></span><code><span style="color: #999999; font-style: italic"># First Code Block</span>\n'
+                '</code></pre></div>\n\n'
+                '<p>Normal paragraph</p>\n'
+                '<div class="codehilite" style="background: #202020"><pre style="line-height: 125%; margin: 0;">'
+                '<span></span><code><span style="color: #999999; font-style: italic"># Second Code Block</span>\n'
+                '</code></pre></div>'
+            )
+        else:
+            expected = '''
+            <pre class="codehilite"><code class="language-python"># First Code Block
+            </code></pre>
+
+            <p>Normal paragraph</p>
+            <pre class="codehilite"><code class="language-python"># Second Code Block
+            </code></pre>
+            '''
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ``` { .python }
+                # First Code Block
+                ```
+
+                Normal paragraph
+
+                ``` { .python }
+                # Second Code Block
+                ```
+                '''
+            ),
+            self.dedent(
+                expected
+            ),
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(pygments_style="native", noclasses=True),
+                'fenced_code'
+            ]
+        )


### PR DESCRIPTION
This fixes a bug where any subsequent highlighted block with codehilite would result in the omission of the style setting, falling back to default.

Fixes #1240