### PR TITLE
Add markdown-link-check guthub action.

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        use-quiet-mode: yes
+        # use-quiet-mode: yes
         use-verbose-mode: yes
         check-modified-files-only: yes
         base-branch: master

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        # use-quiet-mode: yes
+        use-quiet-mode: yes
         use-verbose-mode: yes
         check-modified-files-only: yes
         base-branch: master

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -22,3 +22,14 @@ jobs:
           change log describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
           Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#pull-requests) for details.
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: yes
+        use-verbose-mode: yes
+        check-modified-files-only: yes
+        base-branch: master

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -67,13 +67,10 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [flake8, pep517check, checkspelling, checklinks]
+        tox-env: [flake8, pep517check, checkspelling]
 
     env:
       TOXENV: ${{ matrix.tox-env }}
-
-    # Allow checklinks to fail
-    continue-on-error: ${{ matrix.tox-env == 'checklinks' }}
 
     steps:
     - uses: actions/checkout@v2
@@ -81,16 +78,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Setup Node
-      if: ${{ matrix.tox-env == 'checklinks' }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: '10'
-        # cache: npm
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox
-        if [[ "$TOXENV" == 'checklinks' ]]; then npm install -g markdown-link-check; fi
         if [[ "$TOXENV" == 'checkspelling' ]]; then sudo apt-get install aspell aspell-en; fi
     - name: Run tox
       run: python -m tox

--- a/README.md
+++ b/README.md
@@ -62,4 +62,3 @@ Code of Conduct
 
 Everyone interacting in the Python-Markdown project's codebases, issue trackers,
 and mailing lists is expected to follow the [Code of Conduct].
-

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Support
 
 You may report bugs, ask for help, and discuss various other issues on the [bug tracker][].
 
-[bug tracker]: https://ithub.com/Python-Markdown/markdown/issues
+[bug tracker]: https://github.com/Python-Markdown/markdown/issues
 
 Code of Conduct
 ---------------

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Support
 
 You may report bugs, ask for help, and discuss various other issues on the [bug tracker][].
 
-[bug tracker]: https://github.com/Python-Markdown/markdown/issues
+[bug tracker]: https://ithub.com/Python-Markdown/markdown/issues
 
 Code of Conduct
 ---------------


### PR DESCRIPTION
This is experimental to compare to running the CLI which we run form tox. It gives us the additional option of only running against changed files, which would eliminate the frustration contributors face when a file they didn't touch results in a failure.