### PR TITLE
Allow setting attributes on <ol> and <ul> tags with attr_list extension

### DIFF
--- a/docs/extensions/attr_list.md
+++ b/docs/extensions/attr_list.md
@@ -169,7 +169,7 @@ can be set. To still be able to set attributes on the full list itself the follo
 1. Item1
 {^ start=4 }
 2. Item2
-{: #item2 }
+{ #item2 }
 3. Item3
 {^ .inline }
 
@@ -181,7 +181,7 @@ can be set. To still be able to set attributes on the full list itself the follo
 {^ #myid }
 ```
 
-The use of `^` instead of `:` at the start of the attribute definition indicates that the attributes values are
+The use of `^` at the start of the attribute definition indicates that the attributes values are
 to be set on the parent of the list item, i.e. the implicitly generated list start tag (either `<ol>` or `<ul>`
 in the output HTML, depending on the type of list).
 

--- a/docs/extensions/attr_list.md
+++ b/docs/extensions/attr_list.md
@@ -158,6 +158,54 @@ assigned to the inline element (`<em>`) which immediately preceded it.
 
 Attribute lists may also be defined on table header cells (`<th>` elements) in the same manner.
 
+### Setting attributes on lists
+
+Unlike HTML there is no explicit start and end tag of a list in Markdown. A list begins when the first item
+is parsed, closed after the last item. So the list items are the only places on which an attribute can be set.
+To still be able to set attributes on the full list itself the following syntax can be used:
+
+
+```text
+1. Item1
+{^ start=4 }
+2. Item2
+{: #item2 }
+3. Item3
+{^ .inline }
+
+* Item1
+{^ .firstclass }
+* Item2
+{^ .secondclass }
+* Item3
+{^ #myid }
+```
+
+The use of `^` instead of `:` at the start of the attribute definition indicates that the attributes values are
+to be set on the parent of the list item, i.e. the implicitly generated list start tag (either `<ol>` or `<ul>`
+in the output HTML, depending on the type of list).
+
+The above example results in the following output, with the attribute values defined using the `{^ ... }`
+definition being "lifted" from the list items to the list start tag:
+
+```html
+<ol class="inline" start="4">
+<li>Item1, but start numbering at 4</li>
+<li id="item2">Item2</li>
+<li>Item3</li>
+</ol>
+<ul class="firstclass secondclass" id="myid">
+<li>Item1</li>
+<li>Item2</li>
+<li>Item3</li>
+</ul>
+
+```
+
+Note: the attribute definition syntax using `^` will only work for top-level lists, not for lists that are nested
+within other lists. Another limitation is that it's not possible to set an attribute on a list item and also define
+a parent attribute value using that same list item.
+
 ### Limitations
 
 There are a few types of elements which attribute lists do not work with. As a reminder, Markdown is a subset of HTML

--- a/docs/extensions/attr_list.md
+++ b/docs/extensions/attr_list.md
@@ -160,9 +160,9 @@ Attribute lists may also be defined on table header cells (`<th>` elements) in t
 
 ### Setting attributes on lists
 
-Unlike HTML there is no explicit start and end tag of a list in Markdown. A list begins when the first item
-is parsed, closed after the last item. So the list items are the only places on which an attribute can be set.
-To still be able to set attributes on the full list itself the following syntax can be used:
+Unlike HTML there is no explicit start and end tag of a list in Markdown. A list implicitly begins when the first item
+is parsed and is implicitly closed after the last item. But the list items are the only places on which attributes
+can be set. To still be able to set attributes on the full list itself the following syntax can be used:
 
 
 ```text

--- a/docs/extensions/attr_list.md
+++ b/docs/extensions/attr_list.md
@@ -166,45 +166,42 @@ can be set. To still be able to set attributes on the full list itself the follo
 
 
 ```text
-1. Item1
-{^ start=4 }
+1. Item1, but start numbering at 4
+{ #item1 ^ start=4 }
 2. Item2
 { #item2 }
-3. Item3
-{^ .inline }
+3. Item3, set inline class on table
+{ #item3 ^ .inline }
 
 * Item1
-{^ .firstclass }
+{ .itemclass ^ .listclass1 }
 * Item2
-{^ .secondclass }
+{ ^ .listclass2 }
 * Item3
-{^ #myid }
+{ #myid ^ #listid }
 ```
 
-The use of `^` at the start of the attribute definition indicates that the attributes values are
+The use of the `^` marker in the attribute definition signals that all attributes following it are
 to be set on the parent of the list item, i.e. the implicitly generated list start tag (either `<ol>` or `<ul>`
 in the output HTML, depending on the type of list).
 
-The above example results in the following output, with the attribute values defined using the `{^ ... }`
-definition being "lifted" from the list items to the list start tag:
+The above example results in the following output, with the attribute values defined after the `^` marker
+being "lifted" from the list items to the list start tag:
 
 ```html
 <ol class="inline" start="4">
-<li>Item1, but start numbering at 4</li>
+<li id="item1">Item1, but start numbering at 4</li>
 <li id="item2">Item2</li>
-<li>Item3</li>
+<li id="item3">Item3, set inline class on table</li>
 </ol>
-<ul class="firstclass secondclass" id="myid">
-<li>Item1</li>
+<ul class="listclass1 listclass2" id="listid">
+<li class="itemclass">Item1</li>
 <li>Item2</li>
-<li>Item3</li>
+<li id="myid">Item3</li>
 </ul>
-
 ```
 
-Note: the attribute definition syntax using `^` will only work for top-level lists, not for lists that are nested
-within other lists. Another limitation is that it's not possible to set an attribute on a list item and also define
-a parent attribute value using that same list item.
+Note: using the `^` marker will only work for top-level lists, not for lists that are nested within other lists.
 
 ### Limitations
 

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -79,7 +79,6 @@ class AttrListTreeprocessor(Treeprocessor):
         for elem in doc.iter():
             if elem.tag in ['ol', 'ul']:
                 for child in elem:
-                    assert child not in li_parents
                     li_parents[child] = elem
             if self.md.is_block_level(elem.tag):
                 # Block level: check for attrs on last line of text

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -143,21 +143,21 @@ class AttrListTreeprocessor(Treeprocessor):
 
     def assign_attrs(self, elem, attrs, parent=None):
         """ Assign attrs to element. """
-        real_elem = elem
+        apply_elem = elem
         for k, v in get_attrs(attrs):
             if k == '.':
                 # add to class
-                cls = real_elem.get('class')
+                cls = apply_elem.get('class')
                 if cls:
-                    real_elem.set('class', '{} {}'.format(cls, v))
+                    apply_elem.set('class', '{} {}'.format(cls, v))
                 else:
-                    real_elem.set('class', v)
+                    apply_elem.set('class', v)
             elif k == '^' and parent is not None:
                 # set on parent from now on
-                real_elem = parent
+                apply_elem = parent
             else:
                 # assign attr k with v
-                real_elem.set(self.sanitize_name(k), v)
+                apply_elem.set(self.sanitize_name(k), v)
 
     def sanitize_name(self, name):
         """

--- a/tests/extensions/attr_list.html
+++ b/tests/extensions/attr_list.html
@@ -67,3 +67,15 @@ And a <strong class="nest">nested <a class="linky2" href="http://example.com" ti
 <p>This should not cause a <em foo="a">crash</em></p>
 <p>Attr_lists do not contain <em>newlines</em>{ foo=bar
 key=value }</p>
+<h1>Setting list item parent attributes</h1>
+<ol class="inline" start="4">
+<li>Item1, but start numbering at 4</li>
+<li id="item2">Item2</li>
+<li>Item3</li>
+</ol>
+<h2>Unordered list</h2>
+<ul class="firstclass secondclass" id="myid">
+<li>Item1</li>
+<li>Item2</li>
+<li>Item3</li>
+</ul>

--- a/tests/extensions/attr_list.html
+++ b/tests/extensions/attr_list.html
@@ -69,13 +69,13 @@ And a <strong class="nest">nested <a class="linky2" href="http://example.com" ti
 key=value }</p>
 <h1>Setting list item parent attributes</h1>
 <ol class="inline" start="4">
-<li>Item1, but start numbering at 4</li>
+<li id="item1">Item1, but start numbering at 4</li>
 <li id="item2">Item2</li>
-<li>Item3</li>
+<li id="item3">Item3, set inline class on table</li>
 </ol>
 <h2>Unordered list</h2>
-<ul class="firstclass secondclass" id="myid">
-<li>Item1</li>
+<ul class="listclass1 listclass2" id="listid">
+<li class="itemclass">Item1</li>
 <li>Item2</li>
-<li>Item3</li>
+<li id="myid">Item3</li>
 </ul>

--- a/tests/extensions/attr_list.txt
+++ b/tests/extensions/attr_list.txt
@@ -98,7 +98,7 @@ key=value }
 1. Item1, but start numbering at 4
 {^ start=4 }
 2. Item2
-{: #item2 }
+{ #item2 }
 3. Item3
 {^ .inline }
 

--- a/tests/extensions/attr_list.txt
+++ b/tests/extensions/attr_list.txt
@@ -92,3 +92,21 @@ This should not cause a *crash*{ foo=a=b }
 
 Attr_lists do not contain *newlines*{ foo=bar
 key=value }
+
+# Setting list item parent attributes
+
+1. Item1, but start numbering at 4
+{^ start=4 }
+2. Item2
+{: #item2 }
+3. Item3
+{^ .inline }
+
+## Unordered list
+
+* Item1
+{^ .firstclass }
+* Item2
+{^ .secondclass }
+* Item3
+{^ #myid }

--- a/tests/extensions/attr_list.txt
+++ b/tests/extensions/attr_list.txt
@@ -96,17 +96,17 @@ key=value }
 # Setting list item parent attributes
 
 1. Item1, but start numbering at 4
-{^ start=4 }
+{ #item1 ^ start=4 }
 2. Item2
 { #item2 }
-3. Item3
-{^ .inline }
+3. Item3, set inline class on table
+{ #item3 ^ .inline }
 
 ## Unordered list
 
 * Item1
-{^ .firstclass }
+{ .itemclass ^ .listclass1 }
 * Item2
-{^ .secondclass }
+{ ^ .listclass2 }
 * Item3
-{^ #myid }
+{ #myid ^ #listid }


### PR DESCRIPTION
This adds a way for the attr_list extension to lift attribute values set on list items to their parent list element (i.e. `<li>` attribute to `<ul>` or `<ol>`). This allows list-wide attributes, such as list start number or class to be set by setting them on list items with the appropriate syntax.

Contains additions to the docs describing it, as well extra test input (plus all existing unit tests still pass)

Should be able to solve #227, #668 and many of the other requests for a similar feature, including my own quest to get this feature.