### PR TITLE
Add a new option of CodeHilite to assign lang class when Pygments is in use

### DIFF
--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -62,7 +62,7 @@ The following new features have been included in the 3.4 release:
       formatter instance.
 
 * The CodeHilite extension now supports a `pygments_add_lang_class` option that assigns
-    the language of a code block to its enclosing `<code>` tag in the Pygment generated
+    the language of a code block to its enclosing `<code>` tag in the Pygments generated
     output, so the output is [HTML5 compliant].
 
 [code-lang-spec5]: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element

--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -10,7 +10,7 @@ PyPy3.
 ### The `table` extension now uses a `style` attribute instead of `align` attribute for alignment.
 
 The [HTML4 spec][spec4] specifically
-deprecates the use of the `align` attribute and it does not appear at all in the 
+deprecates the use of the `align` attribute and it does not appear at all in the
 [HTML5 spec][spec5]. Therefore, by default, the [table] extension will now use the `style`
 attribute (setting just the `text-align` property) in `td` and `th` blocks.
 
@@ -55,11 +55,17 @@ The following new features have been included in the 3.4 release:
   parameter which can be used to set the CSS class(es) on the `<div>` that contains the
   Table of Contents (#1224).
 
-* The Codehilite extension now supports a `pygments_formatter` option that can be set to
+* The CodeHilite extension now supports a `pygments_formatter` option that can be set to
     use a custom formatter class with Pygments.
     - If set to a string like `'html'`, we get the default formatter by that name.
     - If set to a class (or any callable), it is called with all the options to get a
       formatter instance.
+
+* The CodeHilite extension now supports a `pygments_add_lang_class` option that assigns
+    the language of a code block to its enclosing `<code>` tag in the Pygment generated
+    output, so the output is [HTML5 compliant].
+
+[code-lang-spec5]: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element
 
 ## Bug fixes
 

--- a/docs/extensions/code_hilite.md
+++ b/docs/extensions/code_hilite.md
@@ -228,11 +228,13 @@ The following options are provided to configure the output:
     `<code>` tag as a class in the manner suggested by the [HTML5 spec][spec] and may be used by a JavaScript library
     in the browser to highlight the code block. See the [`lang_prefix`](#lang_prefix) option to customize the prefix.
 
+* **`pygments_add_lang_class`**{ #pygments_add_lang_class }:
+    When `pygments_add_lang_class` is `True`, the language of a code block will be assigned to the `<code>` tag as a
+    class in the manner suggested by the [HTML5 spec][spec]. The language can be defined by the code block or guessed by
+    Pygments when `guess_lang` is `True`.
+
 * **`lang_prefix`**{ #lang_prefix }:
     The prefix prepended to the language class assigned to the HTML `<code>` tag. Default: `language-`.
-
-    This option only applies when `use_pygments` is `False` as Pygments does not provide an option to include a
-    language prefix.
 
 * **`pygments_formatter`**{ #pygments_formatter }:
     This option can be used to change the Pygments formatter used for highlighting the code blocks. By default, this

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -45,7 +45,7 @@ if pygments:
         def _wrap_code(self, inner):
             if self.lang:
                 yield 0, f'<code class="{self.lang_prefix}{self.lang}">'
-            else:
+            else:  # pragma: no cover
                 yield 0, '<code>'
             yield from inner
             yield 0, '</code>'

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -52,6 +52,9 @@ if pygments:
             yield from inner
             yield 0, '</code>'
 
+else:
+    HtmlAddLangClassFormatter = None
+
 
 def parse_hl_lines(expr):
     """Support our syntax for emphasizing certain lines of code.

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -15,8 +15,6 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 
 """
 
-from multiprocessing.sharedctypes import Value
-from random import lognormvariate
 from . import Extension
 from ..treeprocessors import Treeprocessor
 from ..util import parseBoolValue

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -515,9 +515,15 @@ class TestCodeHiliteExtension(TestCase):
         )
 
     def testPygmentsAddLangClass(self):
-        expected = self.dedent('''
+        if has_pygments:
+            expected = self.dedent('''
             <div class="codehilite"><pre><span></span><code class="language-python"><span class="c1"># A Code Comment</span>
             </code></pre></div>
+            ''')
+        else:
+            expected = self.dedent('''
+            <pre class="codehilite"><code class="language-python"># A Code Comment
+            </code></pre>
             ''')
 
         self.assertMarkdownRenders(

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -566,6 +566,30 @@ class TestCodeHiliteExtension(TestCase):
             ]
         )
 
+    def testPygmentsAddLangClassEmptyLang(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite"><pre><span></span>'
+                '<code class="language-text"># A Code Comment\n'
+                '</code></pre></div>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code># A Code Comment\n'
+                '</code></pre>'
+            )
+        # Use PHP as the the starting `<?php` tag ensures an accurate guess.
+        self.assertMarkdownRenders(
+            '\t# A Code Comment',
+            expected,
+            extensions=[
+                CodeHiliteExtension(
+                    guess_lang=False,
+                    pygments_add_lang_class=True,
+                )
+            ]
+        )
+
     def testUsePygmentsFalse(self):
         self.assertMarkdownRenders(
             (

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -514,6 +514,24 @@ class TestCodeHiliteExtension(TestCase):
             extensions=['codehilite']
         )
 
+    def testPygmentsAddLangClass(self):
+        expected = self.dedent('''
+            <div class="codehilite"><pre><span></span><code class="language-python"><span class="c1"># A Code Comment</span>
+            </code></pre></div>
+            ''')
+
+        self.assertMarkdownRenders(
+            '\t:::Python\n'
+            '\t# A Code Comment',
+            expected,
+            extensions=[
+                CodeHiliteExtension(
+                    guess_lang=False,
+                    pygments_add_lang_class=True,
+                )
+            ]
+        )
+
     def testUsePygmentsFalse(self):
         self.assertMarkdownRenders(
             (

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -519,13 +519,15 @@ class TestCodeHiliteExtension(TestCase):
             expected = (
                 '<div class="codehilite"><pre><span></span><code class="language-python">'
                 '<span class="c1"># A Code Comment</span>\n'
-                '</code></pre></div>\n'
+                '</code></pre></div>'
             )
         else:
             expected = (
                 '<pre class="codehilite"><code class="language-python"># A Code Comment\n'
-                '</code></pre>\n'
+                '</code></pre>'
             )
+            from markdown.extensions.codehilite import HtmlAddLangClassFormatter
+            assert HtmlAddLangClassFormatter is None
 
         self.assertMarkdownRenders(
             '\t:::Python\n'
@@ -534,6 +536,30 @@ class TestCodeHiliteExtension(TestCase):
             extensions=[
                 CodeHiliteExtension(
                     guess_lang=False,
+                    pygments_add_lang_class=True,
+                )
+            ]
+        )
+
+    def testPygmentsAddLangClassGuessLang(self):
+        if has_pygments:
+            expected = (
+                '<div class="codehilite"><pre><span></span><code class="language-js+php"><span class="cp">&lt;?php</span> '
+                '<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Hello World&quot;</span>'
+                '<span class="p">);</span> <span class="cp">?&gt;</span>\n'
+                '</code></pre></div>'
+            )
+        else:
+            expected = (
+                '<pre class="codehilite"><code>&lt;?php print(&quot;Hello World&quot;); ?&gt;\n'
+                '</code></pre>'
+            )
+        # Use PHP as the the starting `<?php` tag ensures an accurate guess.
+        self.assertMarkdownRenders(
+            '\t<?php print("Hello World"); ?>',
+            expected,
+            extensions=[
+                CodeHiliteExtension(
                     pygments_add_lang_class=True,
                 )
             ]

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -544,7 +544,8 @@ class TestCodeHiliteExtension(TestCase):
     def testPygmentsAddLangClassGuessLang(self):
         if has_pygments:
             expected = (
-                '<div class="codehilite"><pre><span></span><code class="language-js+php"><span class="cp">&lt;?php</span> '
+                '<div class="codehilite"><pre><span></span>'
+                '<code class="language-js+php"><span class="cp">&lt;?php</span> '
                 '<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Hello World&quot;</span>'
                 '<span class="p">);</span> <span class="cp">?&gt;</span>\n'
                 '</code></pre></div>'

--- a/tests/test_syntax/extensions/test_code_hilite.py
+++ b/tests/test_syntax/extensions/test_code_hilite.py
@@ -516,15 +516,16 @@ class TestCodeHiliteExtension(TestCase):
 
     def testPygmentsAddLangClass(self):
         if has_pygments:
-            expected = self.dedent('''
-            <div class="codehilite"><pre><span></span><code class="language-python"><span class="c1"># A Code Comment</span>
-            </code></pre></div>
-            ''')
+            expected = (
+                '<div class="codehilite"><pre><span></span><code class="language-python">'
+                '<span class="c1"># A Code Comment</span>\n'
+                '</code></pre></div>\n'
+            )
         else:
-            expected = self.dedent('''
-            <pre class="codehilite"><code class="language-python"># A Code Comment
-            </code></pre>
-            ''')
+            expected = (
+                '<pre class="codehilite"><code class="language-python"># A Code Comment\n'
+                '</code></pre>\n'
+            )
 
         self.assertMarkdownRenders(
             '\t:::Python\n'

--- a/tests/test_syntax/extensions/test_fenced_code.py
+++ b/tests/test_syntax/extensions/test_fenced_code.py
@@ -896,17 +896,24 @@ class TestFencedCodeWithCodehilite(TestCase):
             ]
         )
 
-    def testCodeLangPygmentsFormatter(self):
-        expected = '''
-            <div class="codehilite"><pre><span></span><code class="language-text">hello world
-            hello another world
-            </code></pre></div>
-            '''
+    def testPygmentsAddLangClassFormatter(self):
+        if has_pygments:
+            expected = '''
+                <div class="codehilite"><pre><span></span><code class="language-text">hello world
+                hello another world
+                </code></pre></div>
+                '''
+        else:
+            expected = '''
+                <pre class="codehilite"><code class="language-text">hello world
+                hello another world
+                </code></pre>
+                '''
 
         self.assertMarkdownRenders(
             self.dedent(
                 '''
-                ```
+                ```text
                 hello world
                 hello another world
                 ```

--- a/tests/test_syntax/extensions/test_fenced_code.py
+++ b/tests/test_syntax/extensions/test_fenced_code.py
@@ -896,6 +896,34 @@ class TestFencedCodeWithCodehilite(TestCase):
             ]
         )
 
+    def testCodeLangPygmentsFormatter(self):
+        expected = '''
+            <div class="codehilite"><pre><span></span><code class="language-text">hello world
+            hello another world
+            </code></pre></div>
+            '''
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                ```
+                hello world
+                hello another world
+                ```
+                '''
+            ),
+            self.dedent(
+                expected
+            ),
+            extensions=[
+                markdown.extensions.codehilite.CodeHiliteExtension(
+                    guess_lang=False,
+                    pygments_add_lang_class=True,
+                ),
+                'fenced_code'
+            ]
+        )
+
     def testSvgCustomPygmentsFormatter(self):
         if has_pygments:
             expected = '''


### PR DESCRIPTION
This change adds a new option`pygments_add_lang_class` to the CodeHilite extension. When Pygments and this option are enabled, the language of the code block is assigned to the generated `<code>` tag. The option respects options `lang` and `lang_prefix` like the existing behavior. If the language of the code block is guessed by Pygments, the name of the guessed lexer is used as the language name (technically the first alias of the lexer). 

In short, with this option enabled, CodeHilite's generated output will always be [HTML5 compliant][spec] with or without Pygments.

The generated HTML output of the following code block:

``````md
```python
 print('hello world')
```
``````

will become:

``````html
<pre><code class="language-python">...
</pre></code>
``````

Regarding the implementation, this option utilizes the new behavior of `pygments_formatter` that can take in a custom Pygments formatter introduced in PR #1187. We create a custom HTML formatter class that takes in the language and the prefix. User can still override to use their custom formatter when they specify `pygments_formatter`.

I am open to any suggestions and feedbacks. Thank you for making this package! 

[spec]: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element