### PR TITLE
Remove previously deprecated objects.

### DIFF
--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -32,7 +32,7 @@ In addition, tests were moved to the modern test environment.
 
 ### Previously deprecated objects have been removed
 
-Various objects were dreprecated in version 3.0 and began raising deprecation
+Various objects were deprecated in version 3.0 and began raising deprecation
 warnings (see the [version 3.0 release notes] for details). Any of those object
 which remained in version 3.3 have been removed from the codebase in version 3.4
 and will now raise errors. A summary of the objects are provided below.

--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -30,6 +30,34 @@ markdown.markdown(src, extensions=[TableExtension(use_align_attribute=True)])
 
 In addition, tests were moved to the modern test environment.
 
+### Previously deprecated objects have been removed
+
+Various objects were dreprecated in version 3.0 and began raising deprecation
+warnings (see the [version 3.0 release notes] for details). Any of those object
+which remained in version 3.3 have been removed from the codebase in version 3.4
+and will now raise errors. A summary of the objects are provided below.
+
+[version 3.0 release notes]: release-3.0.md
+
+| Deprecated Object                      | Replacement Object                  |
+|----------------------------------------|-------------------------------------|
+| `markdown.version`                     | `markdown.__version__`              |
+| `markdown.version_info`                | `markdown.__version_info__`         |
+| `markdown.util.etree`                  | `xml.etree.ElementTree`             |
+| `markdown.util.string_type`            | `str`                               |
+| `markdown.util.text_type`              | `str`                               |
+| `markdown.util.int2str`                | `chr`                               |
+| `markdown.util.iterrange`              | `range`                             |
+| `markdown.util.isBlockLevel`           | `markdown.Markdown.is_block_level`  |
+| `markdown.util.Processor().markdown`   | `markdown.util.Processor().md`      |
+| `markdown.util.Registry().__setitem__` | `markdown.util.Registry().register` |
+| `markdown.util.Registry().__delitem__` |`markdown.util.Registry().deregister`|
+| `markdown.util.Registry().add`         | `markdown.util.Registry().register` |
+
+In addition, the `md_globals` parameter of
+`Markdown.extensions.Extension.extendMarkdown()` is no longer recognized as a
+valid parameter and will raise an error if provided.
+
 ## New features
 
 The following new features have been included in the 3.4 release:

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -19,37 +19,10 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import sys
-
-# TODO: Remove this check at some point in the future.
-# (also remove flake8's 'ignore E402' comments below)
-if sys.version_info[0] < 3:  # pragma: no cover
-    raise ImportError('A recent version of Python 3 is required.')
-
-from .core import Markdown, markdown, markdownFromFile  # noqa: E402
-from .__meta__ import __version__, __version_info__     # noqa: E402
-import warnings                                         # noqa: E402
+from .core import Markdown, markdown, markdownFromFile
+from .__meta__ import __version__, __version_info__  # noqa
 
 # For backward compatibility as some extensions expect it...
 from .extensions import Extension  # noqa
 
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
-
-__deprecated__ = {
-    "version": ("__version__", __version__),
-    "version_info": ("__version_info__", __version_info__)
-}
-
-
-def __getattr__(name):
-    """Get attribute."""
-
-    deprecated = __deprecated__.get(name)
-    if deprecated:
-        warnings.warn(
-            "'{}' is deprecated. Use '{}' instead.".format(name, deprecated[0]),
-            category=DeprecationWarning,
-            stacklevel=(3 if (3, 7) <= sys.version_info else 4)
-        )
-        return deprecated[1]
-    raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))

--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -69,12 +69,6 @@ class BlockParser:
         self.state = State()
         self.md = md
 
-    @property
-    @util.deprecated("Use 'md' instead.")
-    def markdown(self):
-        # TODO: remove this later
-        return self.md
-
     def parseDocument(self, lines):
         """ Parse a markdown document into an ElementTree.
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -122,7 +122,7 @@ class Markdown:
             if isinstance(ext, str):
                 ext = self.build_extension(ext, configs.get(ext, {}))
             if isinstance(ext, Extension):
-                ext._extendMarkdown(self)
+                ext.extendMarkdown(self)
                 logger.debug(
                     'Successfully loaded extension "%s.%s".'
                     % (ext.__class__.__module__, ext.__class__.__name__)

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -19,7 +19,6 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import warnings
 from ..util import parseBoolValue
 
 

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -70,24 +70,6 @@ class Extension:
         for key, value in items:
             self.setConfig(key, value)
 
-    def _extendMarkdown(self, *args):
-        """ Private wrapper around extendMarkdown. """
-        md = args[0]
-        try:
-            self.extendMarkdown(md)
-        except TypeError as e:
-            if "missing 1 required positional argument" in str(e):
-                # Must be a 2.x extension. Pass in a dumby md_globals.
-                self.extendMarkdown(md, {})
-                warnings.warn(
-                    "The 'md_globals' parameter of '{}.{}.extendMarkdown' is "
-                    "deprecated.".format(self.__class__.__module__, self.__class__.__name__),
-                    category=DeprecationWarning,
-                    stacklevel=2
-                )
-            else:
-                raise
-
     def extendMarkdown(self, md):
         """
         Add the various processors and patterns to the Markdown Instance.
@@ -97,8 +79,6 @@ class Extension:
         Keyword arguments:
 
         * md: The Markdown instance.
-
-        * md_globals: Global variables in the markdown module namespace.
 
         """
         raise NotImplementedError(

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -83,7 +83,7 @@ smartypants.py license:
 from . import Extension
 from ..inlinepatterns import HtmlInlineProcessor, HTML_RE
 from ..treeprocessors import InlineProcessor
-from ..util import Registry, deprecated
+from ..util import Registry
 
 
 # Constants for quote education.
@@ -154,12 +154,6 @@ class SubstituteTextPattern(HtmlInlineProcessor):
         HtmlInlineProcessor.__init__(self, pattern)
         self.replace = replace
         self.md = md
-
-    @property
-    @deprecated("Use 'md' instead.")
-    def markdown(self):
-        # TODO: remove this later
-        return self.md
 
     def handleMatch(self, m, data):
         result = ''

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -211,12 +211,6 @@ class Pattern:  # pragma: no cover
 
         self.md = md
 
-    @property
-    @util.deprecated("Use 'md' instead.")
-    def markdown(self):
-        # TODO: remove this later
-        return self.md
-
     def getCompiledRegExp(self):
         """ Return a compiled regular expression. """
         return self.compiled_re

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -75,12 +75,6 @@ class InlineProcessor(Treeprocessor):
         self.inlinePatterns = md.inlinePatterns
         self.ancestors = []
 
-    @property
-    @util.deprecated("Use 'md' instead.")
-    def markdown(self):
-        # TODO: remove this later
-        return self.md
-
     def __makePlaceholder(self, type):
         """ Generate a placeholder """
         id = "%04d" % len(self.stashed_nodes)

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -22,7 +22,6 @@ License: BSD (see LICENSE.md for details).
 import re
 import sys
 import warnings
-import xml.etree.ElementTree
 from collections import namedtuple
 from functools import wraps, lru_cache
 from itertools import count

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -316,50 +316,16 @@ class RegistryTests(unittest.TestCase):
         r = markdown.util.Registry()
         with self.assertRaises(TypeError):
             r[0] = 'a'
-        # TODO: restore this when deprecated __setitem__ is removed.
-        # with self.assertRaises(TypeError):
-        #     r['a'] = 'a'
-        # TODO: remove this when deprecated __setitem__ is removed.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            r['a'] = Item('a')
-            self.assertEqual(list(r), ['a'])
-            r['b'] = Item('b')
-            self.assertEqual(list(r), ['a', 'b'])
-            r['a'] = Item('a1')
-            self.assertEqual(list(r), ['a1', 'b'])
-
-            # Check the warnings
-            self.assertEqual(len(w), 3)
-            self.assertTrue(all(issubclass(x.category, DeprecationWarning) for x in w))
+        with self.assertRaises(TypeError):
+            r['a'] = 'a'
 
     def testRegistryDelItem(self):
         r = markdown.util.Registry()
         r.register(Item('a'), 'a', 20)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(TypeError):
             del r[0]
-        # TODO: restore this when deprecated __del__ is removed.
-        # with self.assertRaises(TypeError):
-        #     del r['a']
-        # TODO: remove this when deprecated __del__ is removed.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            r.register(Item('b'), 'b', 15)
-            r.register(Item('c'), 'c', 10)
-            del r['b']
-            self.assertEqual(list(r), ['a', 'c'])
+        with self.assertRaises(TypeError):
             del r['a']
-            self.assertEqual(list(r), ['c'])
-            with self.assertRaises(KeyError):
-                del r['badname']
-            del r['c']
-            self.assertEqual(list(r), [])
-
-            # Check the warnings
-            self.assertEqual(len(w), 4)
-            self.assertTrue(all(issubclass(x.category, DeprecationWarning) for x in w))
 
     def testRegistrySlice(self):
         r = markdown.util.Registry()
@@ -389,39 +355,6 @@ class RegistryTests(unittest.TestCase):
         r.register(Item('b2'), 'b', 30)
         self.assertEqual(len(r), 2)
         self.assertEqual(list(r), ['b2', 'a'])
-
-    def testRegistryDeprecatedAdd(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            r = markdown.util.Registry()
-            # Add first item
-            r.add('c', Item('c'), '_begin')
-            self.assertEqual(list(r), ['c'])
-            # Added to beginning
-            r.add('b', Item('b'), '_begin')
-            self.assertEqual(list(r), ['b', 'c'])
-            # Add before first item
-            r.add('a', Item('a'), '<b')
-            self.assertEqual(list(r), ['a', 'b', 'c'])
-            # Add before non-first item
-            r.add('a1', Item('a1'), '<b')
-            self.assertEqual(list(r), ['a', 'a1', 'b', 'c'])
-            # Add after non-last item
-            r.add('b1', Item('b1'), '>b')
-            self.assertEqual(list(r), ['a', 'a1', 'b', 'b1', 'c'])
-            # Add after last item
-            r.add('d', Item('d'), '>c')
-            self.assertEqual(list(r), ['a', 'a1', 'b', 'b1', 'c', 'd'])
-            # Add to end
-            r.add('e', Item('e'), '_end')
-            self.assertEqual(list(r), ['a', 'a1', 'b', 'b1', 'c', 'd', 'e'])
-            with self.assertRaises(ValueError):
-                r.add('f', Item('f'), 'badlocation')
-
-            # Check the warnings
-            self.assertEqual(len(w), 8)
-            self.assertTrue(all(issubclass(x.category, DeprecationWarning) for x in w))
 
 
 class TestErrors(unittest.TestCase):
@@ -985,42 +918,3 @@ Some +test+ and a [+link+](http://test.com)
 
         self.md.reset()
         self.assertEqual(self.md.convert(test), result)
-
-
-class TestGeneralDeprecations(unittest.TestCase):
-    """Test general deprecations."""
-
-    def test_version_deprecation(self):
-        """Test that version is deprecated."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            version = markdown.version
-            # Verify some things
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertEqual(version, markdown.__version__)
-
-    def test_version_info_deprecation(self):
-        """Test that version info is deprecated."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            version_info = markdown.version_info
-            # Verify some things
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertEqual(version_info, markdown.__version_info__)
-
-    def test_deprecation_wrapper_dir(self):
-        """Tests the `__dir__` attribute of the class as it replaces the module's."""
-
-        dir_attr = dir(markdown)
-        self.assertNotIn('version', dir_attr)
-        self.assertIn('__version__', dir_attr)
-        self.assertNotIn('version_info', dir_attr)
-        self.assertIn('__version_info__', dir_attr)


### PR DESCRIPTION
This completely removes all objects which were deprecated back on version 3.0. We are now working on 3.4 so I think perhaps we can move forward with this. The one hesitation I have is that it is possible some older (unmaintained) extensions could stop working. However, given the time that has passed, and the fact that those extensions probably don't even support the new minimum Python version, I expect this to mostly be a non-issue.

So far, I have only made changes to the code. I still need to add something to the release notes.