### PR TITLE
Update PrettifyTreeprocessor `<pre><code>` handling (attempt 2)

### DIFF
--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -68,4 +68,4 @@ The following new features have been included in the 3.4 release:
 The following bug fixes are included in the 3.4 release:
 
 * Extension entry-points are only loaded if needed (#1216).
-* Added a `None` check to PrettifyTreeprocessor (#1261).
+* Added a `None` check to `PrettifyTreeprocessor` (#1261).

--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -68,3 +68,4 @@ The following new features have been included in the 3.4 release:
 The following bug fixes are included in the 3.4 release:
 
 * Extension entry-points are only loaded if needed (#1216).
+* Added a `None` check to PrettifyTreeprocessor (#1261).

--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -68,4 +68,4 @@ The following new features have been included in the 3.4 release:
 The following bug fixes are included in the 3.4 release:
 
 * Extension entry-points are only loaded if needed (#1216).
-* Added a `None` check to `PrettifyTreeprocessor` (#1261).
+* Added additional checks to the `<pre><code>` handling of `PrettifyTreeprocessor` (#1261, #1263).

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -432,5 +432,5 @@ class PrettifyTreeprocessor(Treeprocessor):
         # Clean up extra empty lines at end of code blocks.
         pres = root.iter('pre')
         for pre in pres:
-            if len(pre) and pre[0].tag == 'code':
+            if len(pre) and pre[0].tag == 'code' and pre[0].text is not None:
                 pre[0].text = util.AtomicString(pre[0].text.rstrip() + '\n')

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -432,5 +432,8 @@ class PrettifyTreeprocessor(Treeprocessor):
         # Clean up extra empty lines at end of code blocks.
         pres = root.iter('pre')
         for pre in pres:
-            if len(pre) and pre[0].tag == 'code' and pre[0].text is not None:
-                pre[0].text = util.AtomicString(pre[0].text.rstrip() + '\n')
+            if len(pre) and pre[0].tag == 'code':
+                code = pre[0]
+                # Only prettify code containing text only
+                if not len(code) and code.text is not None:
+                    code.text = util.AtomicString(code.text.rstrip() + '\n')

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -527,6 +527,7 @@ class testElementTailTests(unittest.TestCase):
 
 class testElementPreCodeTests(unittest.TestCase):
     """ Element PreCode Tests """
+    def setUp(self):
         md = markdown.Markdown()
         self.pretty = markdown.treeprocessors.PrettifyTreeprocessor(md)
 

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -525,6 +525,42 @@ class testElementTailTests(unittest.TestCase):
         self.assertEqual(br.tail, "\n")
 
 
+class testElementPreCodeTests(unittest.TestCase):
+    """ Element PreCode Tests """
+        md = markdown.Markdown()
+        self.pretty = markdown.treeprocessors.PrettifyTreeprocessor(md)
+
+    def prettify(self, xml):
+        root = etree.fromstring(xml)
+        self.pretty.run(root)
+        return etree.tostring(root, encoding="unicode", short_empty_elements=False)
+
+    def testPreCodeEmpty(self):
+        xml = "<pre><code></code></pre>"
+        expected = "<pre><code></code></pre>\n"
+        self.assertEqual(expected, self.prettify(xml))
+
+    def testPreCodeWithChildren(self):
+        xml = "<pre><code> <span /></code></pre>"
+        expected = "<pre><code> <span></span></code></pre>\n"
+        self.assertEqual(expected, self.prettify(xml))
+
+    def testPreCodeWithSpaceOnly(self):
+        xml = "<pre><code> </code></pre>"
+        expected = "<pre><code>\n</code></pre>\n"
+        self.assertEqual(expected, self.prettify(xml))
+
+    def testPreCodeWithText(self):
+        xml = "<pre><code> hello</code></pre>"
+        expected = "<pre><code> hello\n</code></pre>\n"
+        self.assertEqual(expected, self.prettify(xml))
+
+    def testPreCodeWithTrailingSpace(self):
+        xml = "<pre><code> hello </code></pre>"
+        expected = "<pre><code> hello\n</code></pre>\n"
+        self.assertEqual(expected, self.prettify(xml))
+
+
 class testSerializers(unittest.TestCase):
     """ Test the html and xhtml serializers. """
 


### PR DESCRIPTION
Fixes issue #1263 

Added some tests near the other `PrettifyTreeprocessor` tests, not sure if this is the correct place for them.

Let me know if additional edge cases should be included, or if the added ones should be changed.