### PR TITLE
Remove redundant lines from PrettifyTreeprocessor

### DIFF
--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -406,8 +406,6 @@ class PrettifyTreeprocessor(Treeprocessor):
             for e in elem:
                 if self.md.is_block_level(e.tag):
                     self._prettifyETree(e)
-            if not elem.tail or not elem.tail.strip():
-                elem.tail = i
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
 


### PR DESCRIPTION
This MR removes redundant code and fixes https://github.com/Python-Markdown/markdown/issues/1267

Lines in 409 and 410 are part of an if-condition-block. However, they are called identically L411 and L412 outside of the if-block anyways.