### PR TITLE
Move backslash unescaping to treeprocessor

### DIFF
--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -30,10 +30,18 @@ markdown.markdown(src, extensions=[TableExtension(use_align_attribute=True)])
 
 In addition, tests were moved to the modern test environment.
 
+### `UnescapePostprocessor` deprecated and replaced with `UnescapeTreeprocessor` (#1131).
+
+Unescaping backslash escapes has been moved to a treeprocessor. However, it is
+recognized that varous third-party extensions may be calling the old class at
+`postprocessors.UnescapePostprocessor`. Therefore, the old class remains in the
+codebase, but has been deprecated and will be removed in a future release. The
+new class `treeprocessors.UnescapeTreeprocessor` should be used instead.
+
 ### Previously deprecated objects have been removed
 
 Various objects were deprecated in version 3.0 and began raising deprecation
-warnings (see the [version 3.0 release notes] for details). Any of those object
+warnings (see the [version 3.0 release notes] for details). Any of those objects
 which remained in version 3.3 have been removed from the code base in version 3.4
 and will now raise errors. A summary of the objects are provided below.
 

--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -30,12 +30,12 @@ markdown.markdown(src, extensions=[TableExtension(use_align_attribute=True)])
 
 In addition, tests were moved to the modern test environment.
 
-### `UnescapePostprocessor` deprecated and replaced with `UnescapeTreeprocessor` (#1131).
+### Backslash unescaping moved to Treeprocessor (#1131).
 
-Unescaping backslash escapes has been moved to a treeprocessor. However, it is
-recognized that varous third-party extensions may be calling the old class at
+Unescaping backslash escapes has been moved to a Treeprocessor. However, it is
+recognized that various third-party extensions may be calling the old class at
 `postprocessors.UnescapePostprocessor`. Therefore, the old class remains in the
-codebase, but has been deprecated and will be removed in a future release. The
+code base, but has been deprecated and will be removed in a future release. The
 new class `treeprocessors.UnescapeTreeprocessor` should be used instead.
 
 ### Previously deprecated objects have been removed

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -16,7 +16,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 from . import Extension
 from ..treeprocessors import Treeprocessor
 from ..util import code_escape, parseBoolValue, AMP_SUBSTITUTE, HTML_PLACEHOLDER_RE, AtomicString
-from ..postprocessors import UnescapePostprocessor
+from ..treeprocessors import UnescapeTreeprocessor
 import re
 import html
 import unicodedata
@@ -84,8 +84,8 @@ def stashedHTML2text(text, md, strip_entities=True):
 
 def unescape(text):
     """ Unescape escaped text. """
-    c = UnescapePostprocessor()
-    return c.run(text)
+    c = UnescapeTreeprocessor()
+    return c.unescape(text)
 
 
 def nest_toc_tokens(toc_list):

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -289,10 +289,10 @@ class TocTreeprocessor(Treeprocessor):
                     toc_tokens.append({
                         'level': int(el.tag[-1]),
                         'id': el.attrib["id"],
-                        'name': unescape(stashedHTML2text(
+                        'name': stashedHTML2text(
                             code_escape(el.attrib.get('data-toc-label', text)),
                             self.md, strip_entities=False
-                        ))
+                        )
                     })
 
                 # Remove the data-toc-label attribute as it is no longer needed

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -120,6 +120,7 @@ class AndSubstitutePostprocessor(Postprocessor):
         text = text.replace(util.AMP_SUBSTITUTE, "&")
         return text
 
+
 @util.deprecated(
     "This class will be removed in the future; "
     "use 'treeprocessors.UnescapeTreeprocessor' instead."

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -37,7 +37,6 @@ def build_postprocessors(md, **kwargs):
     postprocessors = util.Registry()
     postprocessors.register(RawHtmlPostprocessor(md), 'raw_html', 30)
     postprocessors.register(AndSubstitutePostprocessor(), 'amp_substitute', 20)
-    postprocessors.register(UnescapePostprocessor(), 'unescape', 10)
     return postprocessors
 
 
@@ -121,7 +120,10 @@ class AndSubstitutePostprocessor(Postprocessor):
         text = text.replace(util.AMP_SUBSTITUTE, "&")
         return text
 
-
+@util.deprecated(
+    "This class will be removed in the future; "
+    "use 'treeprocessors.UnescapeTreeprocessor' instead."
+)
 class UnescapePostprocessor(Postprocessor):
     """ Restore escaped chars """
 

--- a/tests/basic/backlash-escapes.html
+++ b/tests/basic/backlash-escapes.html
@@ -9,7 +9,7 @@
 <p>Right bracket: ]</p>
 <p>Left paren: (</p>
 <p>Right paren: )</p>
-<p>Greater-than: ></p>
+<p>Greater-than: &gt;</p>
 <p>Hash: #</p>
 <p>Period: .</p>
 <p>Bang: !</p>

--- a/tests/test_syntax/extensions/test_smarty.py
+++ b/tests/test_syntax/extensions/test_smarty.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Python Markdown
+
+A Python implementation of John Gruber's Markdown.
+
+Documentation: https://python-markdown.github.io/
+GitHub: https://github.com/Python-Markdown/markdown/
+PyPI: https://pypi.org/project/Markdown/
+
+Started by Manfred Stienstra (http://www.dwerg.net/).
+Maintained for a few years by Yuri Takhteyev (http://www.freewisdom.org).
+Currently maintained by Waylan Limberg (https://github.com/waylan),
+Dmitry Shachnev (https://github.com/mitya57) and Isaac Muse (https://github.com/facelessuser).
+
+Copyright 2007-2022 The Python Markdown Project (v. 1.7 and later)
+Copyright 2004, 2005, 2006 Yuri Takhteyev (v. 0.2-1.6b)
+Copyright 2004 Manfred Stienstra (the original version)
+
+License: BSD (see LICENSE.md for details).
+"""
+
+from markdown.test_tools import TestCase
+
+
+class TestSmarty(TestCase):
+
+    default_kwargs = {'extensions': ['smarty']}
+
+    def test_escaped_attr(self):
+        self.assertMarkdownRenders(
+            '![x\"x](x)',
+            '<p><img alt="x&quot;x" src="x" /></p>'
+        )
+
+    # TODO: Move rest of smarty tests here.


### PR DESCRIPTION
By unescaping backslash escapes in a treeprocessor, the text is properly
escaped during serialization. Fixes #1131.

As it is recognized that varous third-party extensions may be calling the
old class at `postprocessors.UnescapePostprocessor` the old class remains
in the codebase, but has been deprecated and will be removed in a future
release. The new class `treeprocessors.UnescapeTreeprocessor` should be
used instead.