### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/extensions/fenced_code_blocks.md
+++ b/docs/extensions/fenced_code_blocks.md
@@ -37,7 +37,7 @@ a one-line code block
 ````
 
 To include a set of backticks (or tildes) within a code block, use a different number of backticks for the
-deliminators.
+delimiters.
 
 `````md
 ````

--- a/docs/extensions/meta_data.md
+++ b/docs/extensions/meta_data.md
@@ -45,11 +45,11 @@ many lines as desired.
 The first blank line ends all meta-data for the document. Therefore, the first
 line of a document must not be blank.
 
-Alternatively, You may use YAML style deliminators to mark the start and/or end
+Alternatively, You may use YAML style delimiters to mark the start and/or end
 of your meta-data. When doing so, the first line of your document must be `---`.
 The meta-data ends at the first blank line or the first line containing an end
 deliminator (either `---` or `...`), whichever comes first. Even though YAML
-deliminators are supported, meta-data is not parsed as YAML.
+delimiters are supported, meta-data is not parsed as YAML.
 
 All meta-data is stripped from the document prior to any further processing
 by Markdown.

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -182,7 +182,7 @@ class CodeHilite:
     def _parseHeader(self):
         """
         Determines language of a code block from shebang line and whether the
-        said line should be removed or left in place. If the sheband line
+        said line should be removed or left in place. If the shebang line
         contains a path (even a single /) then it is assumed to be a real
         shebang line and left alone. However, if no path is given
         (e.i.: #!python or :::python) then it is assumed to be a mock shebang

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -256,7 +256,7 @@ class FootnoteBlockProcessor(BlockProcessor):
         return False
 
     def detectTabbed(self, blocks):
-        """ Find indented text and remove indent before further proccesing.
+        """ Find indented text and remove indent before further processing.
 
         Returns: a list of blocks with indentation removed.
         """

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -66,7 +66,7 @@ class TestPhp(LegacyTestCase):
     Code block in a list item: We match markdown.pl - not sure how php gets that output??
 
     PHP-Specific Bugs: Not sure what to make of the escaping stuff here.
-    Why is PHP not removing a blackslash?
+    Why is PHP not removing a backslash?
     """
     location = os.path.join(parent_test_dir, 'php')
     normalize = True


### PR DESCRIPTION
There are small typos in:
- docs/extensions/fenced_code_blocks.md
- docs/extensions/meta_data.md
- markdown/extensions/codehilite.py
- markdown/extensions/footnotes.py
- tests/test_legacy.py

Fixes:
- Should read `delimiters` rather than `deliminators`.
- Should read `shebang` rather than `sheband`.
- Should read `processing` rather than `proccesing`.
- Should read `backslash` rather than `blackslash`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md