### PR TITLE
Change BlockProcessor to Blockprocessor

### DIFF
--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -60,7 +60,7 @@ class State(list):
 class BlockParser:
     """ Parse Markdown blocks into an ElementTree object.
 
-    A wrapper class that stitches the various BlockProcessors together,
+    A wrapper class that stitches the various Blockprocessors together,
     looping through them and creating an ElementTree object.
     """
 
@@ -107,7 +107,7 @@ class BlockParser:
         internally.
 
         This is a public method as an extension may need to add/alter
-        additional BlockProcessors which call this method to recursively
+        additional Blockprocessors which call this method to recursively
         parse a nested block.
 
         """

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -25,8 +25,8 @@ This parser handles basic parsing of Markdown blocks.  It doesn't concern
 itself with inline elements such as **bold** or *italics*, but rather just
 catches blocks, lists, quotes, etc.
 
-The BlockParser is made up of a bunch of BlockProcessors, each handling a
-different type of block. Extensions may add/replace/remove BlockProcessors
+The BlockParser is made up of a bunch of Blockprocessors, each handling a
+different type of block. Extensions may add/replace/remove Blockprocessors
 as they need to alter how markdown blocks are parsed.
 """
 
@@ -56,7 +56,7 @@ def build_block_parser(md, **kwargs):
     return parser
 
 
-class BlockProcessor:
+class Blockprocessor:
     """ Base class for block processors.
 
     Each subclass will provide the methods below to work with the source and
@@ -146,7 +146,11 @@ class BlockProcessor:
         pass  # pragma: no cover
 
 
-class ListIndentProcessor(BlockProcessor):
+# this alias is for backwards compatibility with the old BlockProcessor
+BlockProcessor = Blockprocessor
+
+
+class ListIndentProcessor(Blockprocessor):
     """ Process children of list items.
 
     Example:
@@ -241,7 +245,7 @@ class ListIndentProcessor(BlockProcessor):
         return level, parent
 
 
-class CodeBlockProcessor(BlockProcessor):
+class CodeBlockProcessor(Blockprocessor):
     """ Process code blocks. """
 
     def test(self, parent, block):
@@ -274,7 +278,7 @@ class CodeBlockProcessor(BlockProcessor):
             blocks.insert(0, theRest)
 
 
-class BlockQuoteProcessor(BlockProcessor):
+class BlockQuoteProcessor(Blockprocessor):
 
     RE = re.compile(r'(^|\n)[ ]{0,3}>[ ]?(.*)')
 
@@ -316,7 +320,7 @@ class BlockQuoteProcessor(BlockProcessor):
             return line
 
 
-class OListProcessor(BlockProcessor):
+class OListProcessor(Blockprocessor):
     """ Process ordered list blocks. """
 
     TAG = 'ol'
@@ -441,7 +445,7 @@ class UListProcessor(OListProcessor):
         self.RE = re.compile(r'^[ ]{0,%d}[*+-][ ]+(.*)' % (self.tab_length - 1))
 
 
-class HashHeaderProcessor(BlockProcessor):
+class HashHeaderProcessor(Blockprocessor):
     """ Process Hash Headers. """
 
     # Detect a header at start of any line in block
@@ -472,7 +476,7 @@ class HashHeaderProcessor(BlockProcessor):
             logger.warn("We've got a problem header: %r" % block)
 
 
-class SetextHeaderProcessor(BlockProcessor):
+class SetextHeaderProcessor(Blockprocessor):
     """ Process Setext-style Headers. """
 
     # Detect Setext-style header. Must be first 2 lines of block.
@@ -495,7 +499,7 @@ class SetextHeaderProcessor(BlockProcessor):
             blocks.insert(0, '\n'.join(lines[2:]))
 
 
-class HRProcessor(BlockProcessor):
+class HRProcessor(Blockprocessor):
     """ Process Horizontal Rules. """
 
     # Python's re module doesn't officially support atomic grouping. However you can fake it.
@@ -529,7 +533,7 @@ class HRProcessor(BlockProcessor):
             blocks.insert(0, postlines)
 
 
-class EmptyBlockProcessor(BlockProcessor):
+class EmptyBlockProcessor(Blockprocessor):
     """ Process blocks that are empty or start with an empty line. """
 
     def test(self, parent, block):
@@ -556,7 +560,7 @@ class EmptyBlockProcessor(BlockProcessor):
             )
 
 
-class ReferenceProcessor(BlockProcessor):
+class ReferenceProcessor(Blockprocessor):
     """ Process link references. """
     RE = re.compile(
         r'^[ ]{0,3}\[([^\[\]]*)\]:[ ]*\n?[ ]*([^\s]+)[ ]*(?:\n[ ]*)?((["\'])(.*)\4[ ]*|\((.*)\)[ ]*)?$', re.MULTILINE
@@ -585,7 +589,7 @@ class ReferenceProcessor(BlockProcessor):
         return False
 
 
-class ParagraphProcessor(BlockProcessor):
+class ParagraphProcessor(Blockprocessor):
     """ Process Paragraph blocks. """
 
     def test(self, parent, block):

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -17,7 +17,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 '''
 
 from . import Extension
-from ..blockprocessors import BlockProcessor
+from ..blockprocessors import Blockprocessor
 from ..inlinepatterns import InlineProcessor
 from ..util import AtomicString
 import re
@@ -32,7 +32,7 @@ class AbbrExtension(Extension):
         md.parser.blockprocessors.register(AbbrPreprocessor(md.parser), 'abbr', 16)
 
 
-class AbbrPreprocessor(BlockProcessor):
+class AbbrPreprocessor(Blockprocessor):
     """ Abbreviation Preprocessor - parse text for abbr references. """
 
     RE = re.compile(r'^[*]\[(?P<abbr>[^\]]*)\][ ]?:[ ]*\n?[ ]*(?P<title>.*)$', re.MULTILINE)

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -18,7 +18,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 """
 
 from . import Extension
-from ..blockprocessors import BlockProcessor
+from ..blockprocessors import Blockprocessor
 import xml.etree.ElementTree as etree
 import re
 
@@ -33,7 +33,7 @@ class AdmonitionExtension(Extension):
         md.parser.blockprocessors.register(AdmonitionProcessor(md.parser), 'admonition', 105)
 
 
-class AdmonitionProcessor(BlockProcessor):
+class AdmonitionProcessor(Blockprocessor):
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -16,12 +16,12 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 """
 
 from . import Extension
-from ..blockprocessors import BlockProcessor, ListIndentProcessor
+from ..blockprocessors import Blockprocessor, ListIndentProcessor
 import xml.etree.ElementTree as etree
 import re
 
 
-class DefListProcessor(BlockProcessor):
+class DefListProcessor(Blockprocessor):
     """ Process Definition Lists. """
 
     RE = re.compile(r'(^|\n)[ ]{0,3}:[ ]{1,3}(.*?)(\n|$)')

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -14,7 +14,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 """
 
 from . import Extension
-from ..blockprocessors import BlockProcessor
+from ..blockprocessors import Blockprocessor
 from ..inlinepatterns import InlineProcessor
 from ..treeprocessors import Treeprocessor
 from ..postprocessors import Postprocessor
@@ -207,7 +207,7 @@ class FootnoteExtension(Extension):
         return div
 
 
-class FootnoteBlockProcessor(BlockProcessor):
+class FootnoteBlockProcessor(Blockprocessor):
     """ Find all footnote references and store for later use. """
 
     RE = re.compile(r'^[ ]{0,3}\[\^([^\]]*)\]:[ ]*(.*)$', re.MULTILINE)

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -15,7 +15,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 """
 
 from . import Extension
-from ..blockprocessors import BlockProcessor
+from ..blockprocessors import Blockprocessor
 from ..preprocessors import Preprocessor
 from ..postprocessors import RawHtmlPostprocessor
 from .. import util
@@ -239,7 +239,7 @@ class HtmlBlockPreprocessor(Preprocessor):
         return ''.join(parser.cleandoc).split('\n')
 
 
-class MarkdownInHtmlProcessor(BlockProcessor):
+class MarkdownInHtmlProcessor(Blockprocessor):
     """Process Markdown Inside HTML Blocks which have been stored in the HtmlStash."""
 
     def test(self, parent, block):

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -16,7 +16,7 @@ License: [BSD](https://opensource.org/licenses/bsd-license.php)
 """
 
 from . import Extension
-from ..blockprocessors import BlockProcessor
+from ..blockprocessors import Blockprocessor
 import xml.etree.ElementTree as etree
 import re
 PIPE_NONE = 0
@@ -24,7 +24,7 @@ PIPE_LEFT = 1
 PIPE_RIGHT = 2
 
 
-class TableProcessor(BlockProcessor):
+class TableProcessor(Blockprocessor):
     """ Process Tables. """
 
     RE_CODE_PIPES = re.compile(r'(?:(\\\\)|(\\`+)|(`+)|(\\\|)|(\|))')


### PR DESCRIPTION
this makes it consistent with the spelling of the other processors.

This PR also adds an alias of the old BlockProcessor to the new
Blockprocessor for backwards compatibility.