### PR TITLE
Improve standalone * and _ parsing.

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,6 +3,10 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
+*under development*: version 3.4.1 (a bug-fix release).
+
+* Improve standalone * and _ parsing (#1300).
+
 July 15, 2022: version 3.4.1 (a bug-fix release).
 
 * Fix an import issue with `importlib.util` (#1274).

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -154,7 +154,7 @@ REFERENCE_RE = LINK_RE
 IMAGE_REFERENCE_RE = IMAGE_LINK_RE
 
 # stand-alone * or _
-NOT_STRONG_RE = r'((^|\s)(\*|_)(\s|$))'
+NOT_STRONG_RE = r'((^|(?<=\s))(\*{1,3}|_{1,3})(?=\s|$))'
 
 # <http://www.123.com>
 AUTOLINK_RE = r'<((?:[Ff]|[Hh][Tt])[Tt][Pp][Ss]?://[^<>]*)>'

--- a/tests/test_syntax/inline/test_emphasis.py
+++ b/tests/test_syntax/inline/test_emphasis.py
@@ -36,6 +36,42 @@ class TestNotEmphasis(TestCase):
             '<p>_</p>'
         )
 
+    def test_standalone_asterisks_consecutive(self):
+        self.assertMarkdownRenders(
+            'Foo * * * *',
+            '<p>Foo * * * *</p>'
+        )
+
+    def test_standalone_understore_consecutive(self):
+        self.assertMarkdownRenders(
+            'Foo _ _ _ _',
+            '<p>Foo _ _ _ _</p>'
+        )
+
+    def test_standalone_asterisks_pairs(self):
+        self.assertMarkdownRenders(
+            'Foo ** ** ** **',
+            '<p>Foo ** ** ** **</p>'
+        )
+
+    def test_standalone_understore_pairs(self):
+        self.assertMarkdownRenders(
+            'Foo __ __ __ __',
+            '<p>Foo __ __ __ __</p>'
+        )
+
+    def test_standalone_asterisks_triples(self):
+        self.assertMarkdownRenders(
+            'Foo *** *** *** ***',
+            '<p>Foo *** *** *** ***</p>'
+        )
+
+    def test_standalone_understore_triples(self):
+        self.assertMarkdownRenders(
+            'Foo ___ ___ ___ ___',
+            '<p>Foo ___ ___ ___ ___</p>'
+        )
+
     def test_standalone_asterisk_in_text(self):
         self.assertMarkdownRenders(
             'foo * bar',
@@ -72,10 +108,16 @@ class TestNotEmphasis(TestCase):
             '<p>foo\n_ bar _\nbaz</p>'
         )
 
-    def test_standalone_asterisks_at_end(self):
+    def test_standalone_underscore_at_begin(self):
         self.assertMarkdownRenders(
-            'foo * bar *',
-            '<p>foo * bar *</p>'
+            '_ foo_ bar',
+            '<p>_ foo_ bar</p>'
+        )
+
+    def test_standalone_asterisk_at_end(self):
+        self.assertMarkdownRenders(
+            'foo *bar *',
+            '<p>foo *bar *</p>'
         )
 
     def test_standalone_understores_at_begin_end(self):


### PR DESCRIPTION
The `NOT_STRONG_RE` regex matchs 1, 2, or 3 * or _ which are surrounded by white space to prevent them from being parsed as tokens. However, the surrounding white space should not be consumed by the regex, which is why lookhead and lookbehind assertions are used. As `^` cannot be matched in a lookbehind assertion, it is left outside the assertion, but as it is zero length, that should not matter.

Tests added and/or updated to cover various edge cases. Fixes #1300.