### PR TITLE
modernized syntax allowed for py37+

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -259,7 +259,7 @@ class CodeBlockProcessor(BlockProcessor):
             code = sibling[0]
             block, theRest = self.detab(block)
             code.text = util.AtomicString(
-                '{}\n{}\n'.format(code.text, util.code_escape(block.rstrip()))
+                f'{code.text}\n{util.code_escape(block.rstrip())}\n'
             )
         else:
             # This is a new codeblock. Create the elements and insert text.
@@ -421,12 +421,12 @@ class OListProcessor(BlockProcessor):
                 # This is an indented (possibly nested) item.
                 if items[-1].startswith(' '*self.tab_length):
                     # Previous item was indented. Append to that item.
-                    items[-1] = '{}\n{}'.format(items[-1], line)
+                    items[-1] = f'{items[-1]}\n{line}'
                 else:
                     items.append(line)
             else:
                 # This is another line of previous item. Append to that item.
-                items[-1] = '{}\n{}'.format(items[-1], line)
+                items[-1] = f'{items[-1]}\n{line}'
         return items
 
 
@@ -552,7 +552,7 @@ class EmptyBlockProcessor(BlockProcessor):
            len(sibling) and sibling[0].tag == 'code'):
             # Last block is a codeblock. Append to preserve whitespace.
             sibling[0].text = util.AtomicString(
-                '{}{}'.format(sibling[0].text, filler)
+                f'{sibling[0].text}{filler}'
             )
 
 
@@ -608,13 +608,13 @@ class ParagraphProcessor(BlockProcessor):
                 if sibling is not None:
                     # Insetrt after sibling.
                     if sibling.tail:
-                        sibling.tail = '{}\n{}'.format(sibling.tail, block)
+                        sibling.tail = f'{sibling.tail}\n{block}'
                     else:
                         sibling.tail = '\n%s' % block
                 else:
                     # Append to parent.text
                     if parent.text:
-                        parent.text = '{}\n{}'.format(parent.text, block)
+                        parent.text = f'{parent.text}\n{block}'
                     else:
                         parent.text = block.lstrip()
             else:

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -128,7 +128,7 @@ class AdmonitionProcessor(BlockProcessor):
         if m:
             klass, title = self.get_class_and_title(m)
             div = etree.SubElement(parent, 'div')
-            div.set('class', '{} {}'.format(self.CLASSNAME, klass))
+            div.set('class', f'{self.CLASSNAME} {klass}')
             if title:
                 p = etree.SubElement(div, 'p')
                 p.text = title

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -65,9 +65,9 @@ def isheader(elem):
 class AttrListTreeprocessor(Treeprocessor):
 
     BASE_RE = r'\{\:?[ ]*([^\}\n ][^\}\n]*)[ ]*\}'
-    HEADER_RE = re.compile(r'[ ]+{}[ ]*$'.format(BASE_RE))
-    BLOCK_RE = re.compile(r'\n[ ]*{}[ ]*$'.format(BASE_RE))
-    INLINE_RE = re.compile(r'^{}'.format(BASE_RE))
+    HEADER_RE = re.compile(fr'[ ]+{BASE_RE}[ ]*$')
+    BLOCK_RE = re.compile(fr'\n[ ]*{BASE_RE}[ ]*$')
+    INLINE_RE = re.compile(fr'^{BASE_RE}')
     NAME_RE = re.compile(r'[^A-Z_a-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02ff'
                          r'\u0370-\u037d\u037f-\u1fff\u200c-\u200d'
                          r'\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff'
@@ -141,7 +141,7 @@ class AttrListTreeprocessor(Treeprocessor):
                 # add to class
                 cls = elem.get('class')
                 if cls:
-                    elem.set('class', '{} {}'.format(cls, v))
+                    elem.set('class', f'{cls} {v}')
                 else:
                     elem.set('class', v)
             else:

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -167,7 +167,7 @@ class CodeHilite:
             txt = txt.replace('"', '&quot;')
             classes = []
             if self.lang:
-                classes.append('{}{}'.format(self.lang_prefix, self.lang))
+                classes.append(f'{self.lang_prefix}{self.lang}')
             if self.options['linenos']:
                 classes.append('linenums')
             class_str = ''

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -43,7 +43,7 @@ class DefListProcessor(BlockProcessor):
         else:
             d, theRest = self.detab(block)
         if d:
-            d = '{}\n{}'.format(m.group(2), d)
+            d = f'{m.group(2)}\n{d}'
         else:
             d = m.group(2)
         sibling = self.lastChild(parent)

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -153,14 +153,14 @@ class FootnoteExtension(Extension):
         if self.getConfig("UNIQUE_IDS"):
             return 'fn%s%d-%s' % (self.get_separator(), self.unique_prefix, id)
         else:
-            return 'fn{}{}'.format(self.get_separator(), id)
+            return f'fn{self.get_separator()}{id}'
 
     def makeFootnoteRefId(self, id, found=False):
         """ Return footnote back-link id. """
         if self.getConfig("UNIQUE_IDS"):
             return self.unique_ref('fnref%s%d-%s' % (self.get_separator(), self.unique_prefix, id), found)
         else:
-            return self.unique_ref('fnref{}{}'.format(self.get_separator(), id), found)
+            return self.unique_ref(f'fnref{self.get_separator()}{id}', found)
 
     def makeFootnotesDiv(self, root):
         """ Return div of footnotes as et Element. """
@@ -347,7 +347,7 @@ class FootnotePostTreeprocessor(Treeprocessor):
     def get_num_duplicates(self, li):
         """ Get the number of duplicate refs of the footnote. """
         fn, rest = li.attrib.get('id', '').split(self.footnotes.get_separator(), 1)
-        link_id = '{}ref{}{}'.format(fn, self.footnotes.get_separator(), rest)
+        link_id = f'{fn}ref{self.footnotes.get_separator()}{rest}'
         return self.footnotes.found_refs.get(link_id, 0)
 
     def handle_duplicates(self, parent):

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -32,11 +32,11 @@ class HTMLExtractorExtra(HTMLExtractor):
         # All block-level tags.
         self.block_level_tags = set(md.block_level_elements.copy())
         # Block-level tags in which the content only gets span level parsing
-        self.span_tags = set(
-            ['address', 'dd', 'dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'legend', 'li', 'p', 'summary', 'td', 'th']
-        )
+        self.span_tags = {
+            'address', 'dd', 'dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'legend', 'li', 'p', 'summary', 'td', 'th'
+        }
         # Block-level tags which never get their content parsed.
-        self.raw_tags = set(['canvas', 'math', 'option', 'pre', 'script', 'style', 'textarea'])
+        self.raw_tags = {'canvas', 'math', 'option', 'pre', 'script', 'style', 'textarea'}
 
         super().__init__(md, *args, **kwargs)
 

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -30,7 +30,7 @@ def slugify(value, separator, unicode=False):
         value = unicodedata.normalize('NFKD', value)
         value = value.encode('ascii', 'ignore').decode('ascii')
     value = re.sub(r'[^\w\s-]', '', value).strip().lower()
-    return re.sub(r'[{}\s]+'.format(separator), separator, value)
+    return re.sub(fr'[{separator}\s]+', separator, value)
 
 
 def slugify_unicode(value, separator):
@@ -170,7 +170,7 @@ class TocTreeprocessor(Treeprocessor):
         self.permalink_title = config["permalink_title"]
         self.header_rgx = re.compile("[Hh][123456]")
         if isinstance(config["toc_depth"], str) and '-' in config["toc_depth"]:
-            self.toc_top, self.toc_bottom = [int(x) for x in config["toc_depth"].split('-')]
+            self.toc_top, self.toc_bottom = (int(x) for x in config["toc_depth"].split('-'))
         else:
             self.toc_top = 1
             self.toc_bottom = int(config["toc_depth"])

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -24,7 +24,7 @@ import re
 def build_url(label, base, end):
     """ Build a url from the label, a base, and an end. """
     clean_label = re.sub(r'([ ]+_)|(_[ ]+)|([ ]+)', '_', label)
-    return '{}{}{}'.format(base, clean_label, end)
+    return f'{base}{clean_label}{end}'
 
 
 class WikiLinkExtension(Extension):

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -74,7 +74,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
             kwargs['convert_charrefs'] = False
 
         # Block tags that should contain no content (self closing)
-        self.empty_tags = set(['hr'])
+        self.empty_tags = {'hr'}
 
         # This calls self.reset
         super().__init__(*args, **kwargs)
@@ -108,7 +108,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
     def line_offset(self):
         """Returns char index in self.rawdata for the start of the current line. """
         if self.lineno > 1 and '\n' in self.rawdata:
-            m = re.match(r'([^\n]*\n){{{}}}'.format(self.lineno-1), self.rawdata)
+            m = re.match(fr'([^\n]*\n){{{self.lineno-1}}}', self.rawdata)
             if m:
                 return m.end()
             else:  # pragma: no cover
@@ -143,7 +143,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
             return self.rawdata[start:m.end()]
         else:  # pragma: no cover
             # Failed to extract from raw data. Assume well formed and lowercase.
-            return '</{}>'.format(tag)
+            return f'</{tag}>'
 
     def handle_starttag(self, tag, attrs):
         # Handle tags that should always be empty and do not specify a closing tag
@@ -228,23 +228,23 @@ class HTMLExtractor(htmlparser.HTMLParser):
         self.handle_empty_tag(self.get_starttag_text(), is_block=self.md.is_block_level(tag))
 
     def handle_charref(self, name):
-        self.handle_empty_tag('&#{};'.format(name), is_block=False)
+        self.handle_empty_tag(f'&#{name};', is_block=False)
 
     def handle_entityref(self, name):
-        self.handle_empty_tag('&{};'.format(name), is_block=False)
+        self.handle_empty_tag(f'&{name};', is_block=False)
 
     def handle_comment(self, data):
-        self.handle_empty_tag('<!--{}-->'.format(data), is_block=True)
+        self.handle_empty_tag(f'<!--{data}-->', is_block=True)
 
     def handle_decl(self, data):
-        self.handle_empty_tag('<!{}>'.format(data), is_block=True)
+        self.handle_empty_tag(f'<!{data}>', is_block=True)
 
     def handle_pi(self, data):
-        self.handle_empty_tag('<?{}?>'.format(data), is_block=True)
+        self.handle_empty_tag(f'<?{data}?>', is_block=True)
 
     def unknown_decl(self, data):
         end = ']]>' if data.startswith('CDATA[') else ']>'
-        self.handle_empty_tag('<![{}{}'.format(data, end), is_block=True)
+        self.handle_empty_tag(f'<![{data}{end}', is_block=True)
 
     def parse_pi(self, i):
         if self.at_line_start() or self.intail:

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -316,7 +316,7 @@ class EscapeInlineProcessor(InlineProcessor):
     def handleMatch(self, m, data):
         char = m.group(1)
         if char in self.md.ESCAPED_CHARS:
-            return '{}{}{}'.format(util.STX, ord(char), util.ETX), m.start(0), m.end(0)
+            return f'{util.STX}{ord(char)}{util.ETX}', m.start(0), m.end(0)
         else:
             return None, m.start(0), m.end(0)
 
@@ -872,7 +872,7 @@ class AutomailInlineProcessor(InlineProcessor):
             """Return entity definition by code, or the code if not defined."""
             entity = entities.codepoint2name.get(code)
             if entity:
-                return "{}{};".format(util.AMP_SUBSTITUTE, entity)
+                return f"{util.AMP_SUBSTITUTE}{entity};"
             else:
                 return "%s#%d;" % (util.AMP_SUBSTITUTE, code)
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -128,7 +128,7 @@ class AndSubstitutePostprocessor(Postprocessor):
 class UnescapePostprocessor(Postprocessor):
     """ Restore escaped chars """
 
-    RE = re.compile(r'{}(\d+){}'.format(util.STX, util.ETX))
+    RE = re.compile(fr'{util.STX}(\d+){util.ETX}')
 
     def unescape(self, m):
         return chr(int(m.group(1)))

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -55,7 +55,7 @@ except NameError:  # pragma: no cover
 
 def _raise_serialization_error(text):  # pragma: no cover
     raise TypeError(
-        "cannot serialize {!r} (type {})".format(text, type(text).__name__)
+        f"cannot serialize {text!r} (type {type(text).__name__})"
         )
 
 
@@ -150,7 +150,7 @@ def _serialize_html(write, elem, format):
                     # handle boolean attributes
                     write(" %s" % v)
                 else:
-                    write(' {}="{}"'.format(k, v))
+                    write(f' {k}="{v}"')
         if namespace_uri:
             write(' xmlns="%s"' % (_escape_attrib(namespace_uri)))
         if format == "xhtml" and tag.lower() in HTML_EMPTY:

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -436,7 +436,7 @@ class PrettifyTreeprocessor(Treeprocessor):
 class UnescapeTreeprocessor(Treeprocessor):
     """ Restore escaped chars """
 
-    RE = re.compile(r'{}(\d+){}'.format(util.STX, util.ETX))
+    RE = re.compile(fr'{util.STX}(\d+){util.ETX}')
 
     def _unescape(self, m):
         return chr(int(m.group(1)))

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -297,7 +297,7 @@ class Registry:
         return len(self._priority)
 
     def __repr__(self):
-        return '<{}({})>'.format(self.__class__.__name__, list(self))
+        return f'<{self.__class__.__name__}({list(self)})>'
 
     def get_index_for_name(self, name):
         """
@@ -308,7 +308,7 @@ class Registry:
             return self._priority.index(
                 [x for x in self._priority if x.name == name][0]
             )
-        raise ValueError('No item named "{}" exists.'.format(name))
+        raise ValueError(f'No item named "{name}" exists.')
 
     def register(self, item, name, priority):
         """

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Python Markdown
 

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Python Markdown
 

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Python Markdown
 

--- a/tests/test_syntax/extensions/test_smarty.py
+++ b/tests/test_syntax/extensions/test_smarty.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Python Markdown
 


### PR DESCRIPTION
This pr modernizes the syntax for things that are allowed for pyhton3.7+. It is mostly

* ''.format -> f''
* set() -> {}
* removal of explicit utf8 encoding of files

this is related to #760