### PR TITLE
Update documentation in file `toc.md` in `slugify` part.

### DIFF
--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -195,7 +195,7 @@ The following options are provided to configure the output:
 * **`slugify`**:
     Callable to generate anchors.
 
-    Default: `markdown.extensions.headerid.slugify`
+    Default: `markdown.extensions.toc.slugify`
 
     In order to use a different algorithm to define the id attributes, define  and
     pass in a callable which takes the following two arguments:
@@ -206,7 +206,7 @@ The following options are provided to configure the output:
     The callable must return a string appropriate for use in HTML `id` attributes.
 
     An alternate version of the default callable supporting Unicode strings is also
-    provided as `markdown.extensions.headerid.slugify_unicode`.
+    provided as `markdown.extensions.toc.slugify_unicode`.
 
 * **`separator`**:
     Word separator. Character which replaces white space in id. Defaults to "`-`".


### PR DESCRIPTION
Hello!

This pr fixes a bug in the documentation in file `toc.md` in `slugify` part.

If I use the setting as indicated in the documentation (`markdown.extensions.headerid.slugify`), then I get an error:

```
Error: MkDocs encountered an error parsing the configuration file: while constructing a Python object
cannot find module 'markdown.extensions.headerid' (No module named 'markdown.extensions.headerid')
```

Because this function `slugify_unicode` is moved to the module `markdown.extensions.toc`.

P.S.
Do you think it's worth putting a hint in the documentation that this setting should be used in conjunction with `!!python/name:`?
Like this:
```yaml
markdown_extensions:
  - toc:
      slugify: !!python/name:markdown.extensions.toc.slugify_unicode
```
