### PR TITLE
Consider <html> a block-level HTML element

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -6,6 +6,7 @@ Python-Markdown Change Log
 *under development*: version 3.4.1 (a bug-fix release).
 
 * Improve standalone * and _ parsing (#1300).
+* Consider `<html>` HTML tag a block-level element (#1309).
 
 July 15, 2022: version 3.4.1 (a bug-fix release).
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -31,6 +31,7 @@ from .inlinepatterns import build_inlinepatterns
 from .postprocessors import build_postprocessors
 from .extensions import Extension
 from .serializers import to_html_string, to_xhtml_string
+from .util import BLOCK_LEVEL_ELEMENTS
 
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
 
@@ -72,18 +73,7 @@ class Markdown:
         self.ESCAPED_CHARS = ['\\', '`', '*', '_', '{', '}', '[', ']',
                               '(', ')', '>', '#', '+', '-', '.', '!']
 
-        self.block_level_elements = [
-            # Elements which are invalid to wrap in a `<p>` tag.
-            # See https://w3c.github.io/html/grouping-content.html#the-p-element
-            'address', 'article', 'aside', 'blockquote', 'details', 'div', 'dl',
-            'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
-            'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'main', 'menu', 'nav', 'ol',
-            'p', 'pre', 'section', 'table', 'ul',
-            # Other elements which Markdown should not be mucking up the contents of.
-            'canvas', 'colgroup', 'dd', 'html', 'body', 'dt', 'group', 'iframe', 'li', 'legend',
-            'math', 'map', 'noscript', 'output', 'object', 'option', 'progress', 'script',
-            'style', 'summary', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
-        ]
+        self.block_level_elements = BLOCK_LEVEL_ELEMENTS.copy()
 
         self.registeredExtensions = []
         self.docType = ""

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -80,7 +80,7 @@ class Markdown:
             'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'main', 'menu', 'nav', 'ol',
             'p', 'pre', 'section', 'table', 'ul',
             # Other elements which Markdown should not be mucking up the contents of.
-            'canvas', 'colgroup', 'dd', 'body', 'dt', 'group', 'iframe', 'li', 'legend',
+            'canvas', 'colgroup', 'dd', 'html', 'body', 'dt', 'group', 'iframe', 'li', 'legend',
             'math', 'map', 'noscript', 'output', 'object', 'option', 'progress', 'script',
             'style', 'summary', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
         ]

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -43,7 +43,7 @@ BLOCK_LEVEL_ELEMENTS = [
     # Other elements which Markdown should not be mucking up the contents of.
     'canvas', 'colgroup', 'dd', 'body', 'dt', 'group', 'html', 'iframe', 'li', 'legend',
     'math', 'map', 'noscript', 'output', 'object', 'option', 'progress', 'script',
-    'style', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
+    'style', 'summary', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
 ]
 
 # Placeholders

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -41,7 +41,7 @@ BLOCK_LEVEL_ELEMENTS = [
     'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'main', 'menu', 'nav', 'ol',
     'p', 'pre', 'section', 'table', 'ul',
     # Other elements which Markdown should not be mucking up the contents of.
-    'canvas', 'colgroup', 'dd', 'body', 'dt', 'group', 'iframe', 'li', 'legend',
+    'canvas', 'colgroup', 'dd', 'body', 'dt', 'group', 'html', 'iframe', 'li', 'legend',
     'math', 'map', 'noscript', 'output', 'object', 'option', 'progress', 'script',
     'style', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'video'
 ]


### PR DESCRIPTION
Fixes https://github.com/Python-Markdown/markdown/issues/1308

I'm obviously :﻿+1: on adding `<html>` to block-level elements. Literal HTML is valid syntax in markdown, and the [specification for `DocumentFragment`](https://dom.spec.whatwg.org/#interface-documentfragment) doesn't mention any limits wrt what particular nodes the fragment is or isn't allowed to consist of ...