### PR TITLE
Officially support Python 3.11

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py37, py38, py39, py310, pypy37, pypy38, pypy39, pygments]
+        tox-env: [py37, py38, py39, py310, py311, pypy37, pypy38, pypy39, pygments]
         include:
           - tox-env: py37
             python-version: '3.7'
@@ -30,6 +30,8 @@ jobs:
             python-version: '3.9'
           - tox-env: py310
             python-version: '3.10'
+          - tox-env: py311
+            python-version: '3.11'
           - tox-env: pypy37
             python-version: pypy-3.7
           - tox-env: pypy38

--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -7,6 +7,7 @@ Python-Markdown Change Log
 
 * Improve standalone * and _ parsing (#1300).
 * Consider `<html>` HTML tag a block-level element (#1309).
+* Officially support for Python 3.11.
 
 July 15, 2022: version 3.4.1 (a bug-fix release).
 

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37, 38, 39, 310}, pypy{37, 38, 39}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{37, 38, 39, 310, 311}, pypy{37, 38, 39}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands = flake8 {toxinidir}/markdown {toxinidir}/tests {toxinidir}/setup.py
 skip_install = true
 
 [testenv:checkspelling]
+allowlist_externals = {toxinidir}/checkspelling.sh
 deps =
     mkdocs
     mkdocs_nature


### PR DESCRIPTION
Python 3.11 was released 2023-10-02.

I've added test here. I will merge if/when the tests pass.