### PR TITLE
Update the year in copyright — It's 2023!

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Python-Markdown
 site_url: https://Python-Markdown.github.io/
 repo_url: https://github.com/Python-Markdown/markdown
 site_author: "The Python-Markdown Project"
-copyright: "Copyright &copy; 2010-2017"
+copyright: "Copyright &copy; 2010-2023"
 
 use_directory_urls: true
 


### PR DESCRIPTION
At the footer of [the doc site](https://python-markdown.github.io/), [`copyright`](https://www.mkdocs.org/user-guide/configuration/#copyright) is shown.

https://github.com/Python-Markdown/markdown/blob/4dab9a7436357173fad08a0f4e67a63daaaa15a6/mkdocs.yml#L5