### PR TITLE
Add "&gt;" support for blockquote

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -276,7 +276,7 @@ class CodeBlockProcessor(BlockProcessor):
 
 class BlockQuoteProcessor(BlockProcessor):
 
-    RE = re.compile(r'(^|\n)[ ]{0,3}>[ ]?(.*)')
+    RE = re.compile(r'(^|\n)[ ]{0,3}(>|&gt;)[ ]?(.*)')
 
     def test(self, parent, block):
         return bool(self.RE.search(block)) and not util.nearing_recursion_limit()
@@ -311,7 +311,7 @@ class BlockQuoteProcessor(BlockProcessor):
         if line.strip() == ">":
             return ""
         elif m:
-            return m.group(2)
+            return m.group(3)
         else:
             return line
 

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -308,7 +308,7 @@ class BlockQuoteProcessor(BlockProcessor):
     def clean(self, line):
         """ Remove ``>`` from beginning of a line. """
         m = self.RE.match(line)
-        if line.strip() == ">":
+        if line.strip() == ">" or line.strip() == "&gt;":
             return ""
         elif m:
             return m.group(3)


### PR DESCRIPTION
This commit adds the possibility to use “`&gt;`” instead of “>” to introduce a blockquote. This prevents blockquotes from not being rendered when Markdown is escaped.