### PR TITLE
Hidden tags with content don't get removed

### DIFF
--- a/docs/change_log/release-3.4.md
+++ b/docs/change_log/release-3.4.md
@@ -111,3 +111,5 @@ The following bug fixes are included in the 3.4 release:
 * Extension entry-points are only loaded if needed (#1216).
 * Added additional checks to the `<pre><code>` handling of
   `PrettifyTreeprocessor` (#1261, #1263).
+* When running in html mode hidden tags with content show
+  up when they have content (#1343)

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -153,7 +153,7 @@ def _serialize_html(write, elem, format):
             write(' xmlns="%s"' % (_escape_attrib(namespace_uri)))
         if format == "xhtml" and tag.lower() in HTML_EMPTY:
             write(" />")
-        else:
+        elif text or len(elem) > 0:
             write(">")
             if text:
                 if tag.lower() in ["script", "style"]:
@@ -162,8 +162,13 @@ def _serialize_html(write, elem, format):
                     write(_escape_cdata(text))
             for e in elem:
                 _serialize_html(write, e, format)
-            if tag.lower() not in HTML_EMPTY:
-                write("</" + tag + ">")
+            write("</" + tag + ">")
+        elif tag.lower() in HTML_EMPTY:
+            if format == "xhtml":
+                write(" /")
+            write(">")
+        else:
+            write("></" + tag + ">")
     if elem.tail:
         write(_escape_cdata(elem.tail))
 

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -164,8 +164,6 @@ def _serialize_html(write, elem, format):
                 _serialize_html(write, e, format)
             write("</" + tag + ">")
         elif tag.lower() in HTML_EMPTY:
-            if format == "xhtml":
-                write(" /")
             write(">")
         else:
             write("></" + tag + ">")

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -506,6 +506,9 @@ class testSerializers(unittest.TestCase):
         p.text = 'foo <&escaped>'
         p.set('hidden', 'hidden')
         etree.SubElement(el, 'hr')
+
+        param = etree.SubElement(el, 'param')
+        param.text = "Param text"
         non_element = etree.SubElement(el, None)
         non_element.text = 'non-element text'
         script = etree.SubElement(non_element, 'script')
@@ -516,6 +519,7 @@ class testSerializers(unittest.TestCase):
             '<div id="foo&lt;&amp;&quot;&gt;">'
             '<p hidden>foo &lt;&amp;escaped&gt;</p>'
             '<hr>'
+            '<param>Param text</param>'
             'non-element text'
             '<script><&"test\nescaping"></script>'
             '</div>tail text'
@@ -529,6 +533,8 @@ class testSerializers(unittest.TestCase):
         p.text = 'foo<&escaped>'
         p.set('hidden', 'hidden')
         etree.SubElement(el, 'hr')
+        param = etree.SubElement(el, 'param')
+        param.text = "Param text"
         non_element = etree.SubElement(el, None)
         non_element.text = 'non-element text'
         script = etree.SubElement(non_element, 'script')
@@ -539,6 +545,7 @@ class testSerializers(unittest.TestCase):
             '<div id="foo&lt;&amp;&quot;&gt;">'
             '<p hidden="hidden">foo&lt;&amp;escaped&gt;</p>'
             '<hr />'
+            '<param />'
             'non-element text'
             '<script><&"test\nescaping"></script>'
             '</div>tail text'


### PR DESCRIPTION
We ran into an issue when doing the following:

```
Hello <param>world</param>
```

Which through markdown produced:

```
Hello <param />
```

This is because by default the output format is set to `xhtml` which is going through serialisation and removing any tag with content that is in the `HTML_EMPTY`, so we set the `ouput_format` to `html` and then the following happens:

```
Hello <param>world
```

So this fix now fixes this issues and produced valid html when `output_format='html`':

```
Hello <param>world</param>
```