### PR TITLE
smarty: Add a special case for 's at the beginning of the token

### DIFF
--- a/docs/change_log/index.md
+++ b/docs/change_log/index.md
@@ -3,6 +3,10 @@ title: Change Log
 Python-Markdown Change Log
 =========================
 
+*under development*: version 3.4.4 (a bug-fix release).
+
+* Add a special case for initial 's to smarty extension (#1305).
+
 March 23, 2023: version 3.4.3 (a bug-fix release).
 
 * Restore console script (#1327).

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -139,7 +139,7 @@ openingSingleQuotesRegex = r"%s'(?=\w)" % openingQuotesBase
 
 # Single closing quotes:
 closingSingleQuotesRegex = r"(?<=%s)'(?!\s|s\b|\d)" % closeClass
-closingSingleQuotesRegex2 = r"(?<=%s)'(\s|s\b)" % closeClass
+closingSingleQuotesRegex2 = r"'(\s|s\b)"
 
 # All remaining quotes should be opening ones
 remainingSingleQuotesRegex = r"'"

--- a/tests/test_syntax/extensions/test_smarty.py
+++ b/tests/test_syntax/extensions/test_smarty.py
@@ -64,6 +64,10 @@ class TestSmarty(TestCase):
             '"Ellipsis within quotes..."',
             '<p>&ldquo;Ellipsis within quotes&hellip;&rdquo;</p>'
         )
+        self.assertMarkdownRenders(
+            "*Custer*'s Last Stand",
+            "<p><em>Custer</em>&rsquo;s Last Stand</p>"
+        )
 
     def test_years(self):
         self.assertMarkdownRenders("1440--80's", '<p>1440&ndash;80&rsquo;s</p>')


### PR DESCRIPTION
When `'s` is not preceded by anything, it probably means that it comes after some HTML tag, so it should be converted to a closing quote.

The reference Perl implementation makes the close_class optional and adds a lookahead check for `(\s|s\b)` when close_class was not matched:

```perl
# Single closing quotes:
s {
    ($close_class)?
    '
    (?(1)|          # If $1 captured, then do nothing;
      (?=\s | s\b)  # otherwise, positive lookahead for a whitespace
    )               # char or an 's' at a word ending position. This
                    # is a special case to handle something like:
                    # "<i>Custer</i>'s Last Stand."
} {$1&#8217;}xgi;
```

Let's copy that behavior by removing closeClass lookbehind check from closingSingleQuotesRegex2.

Fixes #1305.