### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=61.2", "wheel"]
+requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Apparently, the wheel dependency is redundant as setuptools will always ensure wheel is installed. In fact, the documentation has been updated to reflect that in pypa/setuptools@f7d30a9.