### PR TITLE
Add GitHub Releases action to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,19 +14,25 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel build
       - name: Build
         run: |
           python -m build
-      - name: Publish
+      - name: Publish to PyPI
         if: success()
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}
+      - name: Release to GitHub
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        uses: fnkr/github-action-ghr@v1
+        env:
+          GHR_PATH: dist/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ghpages:
     runs-on: ubuntu-latest
@@ -35,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
@@ -43,7 +49,7 @@ jobs:
       - name: Build
         run: |
           python -m mkdocs build --clean --verbose
-      - name: Publish
+      - name: Publish to GitHub Pages
         if: success()
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
While we don't really need to upload release files to GitHub (as they are uploaded to PyPI), creating releases does provide a mechanism to notify users that a new release is available. As GitHub will automaticaly create files from the repo when none are provided, we upload the official distribution files instead. Fixes #1365.