### PR TITLE
Add PY3.12 & PYPY3.10 and drop 3.7

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -9,6 +9,8 @@ jobs:
   require_changelog:
 
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v2
     - uses: mskelton/changelog-reminder-action@v1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,10 +20,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py37, py38, py39, py310, py311, pypy37, pypy38, pypy39, pygments]
+        tox-env: [py38, py39, py310, py311, py312, pypy38, pypy39, pypy310, pygments]
         include:
-          - tox-env: py37
-            python-version: '3.7'
           - tox-env: py38
             python-version: '3.8'
           - tox-env: py39
@@ -32,14 +30,16 @@ jobs:
             python-version: '3.10'
           - tox-env: py311
             python-version: '3.11'
-          - tox-env: pypy37
-            python-version: pypy-3.7
+          - tox-env: py312
+            python-version: '3.12'
           - tox-env: pypy38
             python-version: pypy-3.8
           - tox-env: pypy39
             python-version: pypy-3.9
+          - tox-env: pypy310
+            python-version: pypy-3.10
           - tox-env: pygments
-            python-version: '3.7'
+            python-version: '3.11'
 
     env:
       TOXENV: ${{ matrix.tox-env }}
@@ -81,7 +81,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,7 +31,7 @@ jobs:
           - tox-env: py311
             python-version: '3.11'
           - tox-env: py312
-            python-version: '3.12'
+            python-version: '3.12.0-rc.1'
           - tox-env: pypy38
             python-version: pypy-3.8
           - tox-env: pypy39

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,25 @@
+name: version_check
+
+on:
+  pull_request:
+    branches:
+    - '**'
+    paths:
+    # Only run when these files have been edited.
+    - 'markdown/__meta__.py'
+
+jobs:
+  check_version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12.0-rc.1'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip packaging
+    - name: Run tests
+      run: |
+        python -m unittest tests.test_meta.TestVersion.test__version__IsValid

--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.12.0-rc.1'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip packaging

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -423,8 +423,9 @@ Python-Markdown follows [Semantic Versioning] and uses the
 of the `master` branch should always be identified in the `__version_info__`
 tuple defined in [`markdown/__meta__.py`][markdown/__meta__.py]. The contents of
 that tuple will automatically be converted into a normalized version which
-conforms to [PEP 440]. An invalid `__version_info__` tuple will raise an error,
-preventing the library from running and the package from building.
+conforms to [PEP 440]. Each time the version is changed, the continuous
+integration server will run a test to ensure that the current version is in a
+valid normalized format.
 
 ### Version Status
 

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -24,7 +24,7 @@ License: BSD (see LICENSE.md for details).
 #     (1, 1, 2, 'dev', 0) => "1.1.2.dev0"
 #     (1, 1, 2, 'alpha', 1) => "1.1.2a1"
 #     (1, 2, 0, 'beta', 2) => "1.2b2"
-#     (1, 2, 0, 'rc', 4) => "1.2rc4"
+#     (1, 2, 0, 'rc', 3) => "1.2rc3"
 #     (1, 2, 0, 'final', 0) => "1.2"
 __version_info__ = (3, 4, 4, 'final', 0)
 

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -24,7 +24,7 @@ License: BSD (see LICENSE.md for details).
 #     (1, 1, 2, 'dev', 0) => "1.1.2.dev0"
 #     (1, 1, 2, 'alpha', 1) => "1.1.2a1"
 #     (1, 2, 0, 'beta', 2) => "1.2b2"
-#     (1, 2, 0, 'rc', 3) => "1.2rc3"
+#     (1, 2, 0, 'rc', 4) => "1.2rc4"
 #     (1, 2, 0, 'final', 0) => "1.2"
 __version_info__ = (3, 4, 4, 'final', 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,7 @@ classifiers = [
 [project.optional-dependencies]
 testing = [
     'coverage',
-    'pyyaml',
-    'packaging'
+    'pyyaml'
 ]
 docs = [
     'mkdocs>=1.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
     {name = 'Isaac Muse'}
 ]
 license = {file = 'LICENSE.md'}
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 dependencies = [
     "importlib-metadata>=4.4;python_version<'3.10'"
 ]
@@ -29,11 +29,11 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
@@ -51,6 +51,7 @@ classifiers = [
 testing = [
     'coverage',
     'pyyaml',
+    'packaging'
 ]
 docs = [
     'mkdocs>=1.0',

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -18,7 +18,7 @@ class TestVersion(unittest.TestCase):
 
         try:
             import packaging.version
-        except:
+        except ImportError:
             self.skipTest('packaging does not appear to be installed')
 
         self.assertEqual(__version__, str(packaging.version.Version(__version__)))

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -16,9 +16,6 @@ class TestVersion(unittest.TestCase):
     def test__version__IsValid(self):
         """Test that __version__ is valid and normalized."""
 
-        try:
-            import packaging.version
-        except ImportError:
-            from pkg_resources.extern import packaging
+        import packaging.version
 
         self.assertEqual(__version__, str(packaging.version.Version(__version__)))

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -16,6 +16,9 @@ class TestVersion(unittest.TestCase):
     def test__version__IsValid(self):
         """Test that __version__ is valid and normalized."""
 
-        import packaging.version
+        try:
+            import packaging.version
+        except:
+            self.skipTest('packaging does not appear to be installed')
 
         self.assertEqual(__version__, str(packaging.version.Version(__version__)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37, 38, 39, 310, 311}, pypy{37, 38, 39}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{38, 39, 310, 311, 312}, pypy{38, 39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Also update default version for non-version specific tests (linters, etc) to PY-3.11 (previously used 3.7). Fixes #1357.