### PR TITLE
Add test case for large markdown table, add useful debug prints

### DIFF
--- a/markdown/core.py
+++ b/markdown/core.py
@@ -233,7 +233,7 @@ class Markdown:
         5. The output is written to a string.
 
         """
-
+        logger.debug("Converting markdown file to serialzed XHTML or HTML")
         # Fix up the source text
         if not source.strip():
             return ''  # a blank Unicode string
@@ -246,20 +246,23 @@ class Markdown:
             raise
 
         # Split into lines and run the line preprocessors.
+        logger.debug("Split document into lines")
         self.lines = source.split("\n")
         for prep in self.preprocessors:
+            logger.debug(f"Running preprocessor prep for {prep.__module__.__str__()}")
             self.lines = prep.run(self.lines)
 
-        # Parse the high-level elements.
+        logger.debug("Parse the high-level elements of the file")
         root = self.parser.parseDocument(self.lines).getroot()
 
-        # Run the tree-processors
+        logger.debug("Run the tree-processors")
         for treeprocessor in self.treeprocessors:
+            logger.debug(f"Running treeprocessor for {treeprocessor.__module__.__str__()}:{treeprocessor.__class__.__name__}")
             newRoot = treeprocessor.run(root)
             if newRoot is not None:
                 root = newRoot
 
-        # Serialize _properly_.  Strip top-level tags.
+        logger.debug("Serialize _properly_.  Strip top-level tags.")
         output = self.serializer(root)
         if self.stripTopLevelTags:
             try:
@@ -269,14 +272,14 @@ class Markdown:
                 output = output[start:end].strip()
             except ValueError as e:  # pragma: no cover
                 if output.strip().endswith('<%s />' % self.doc_tag):
-                    # We have an empty document
+                    logger.debug("Document is empty")
                     output = ''
                 else:
                     # We have a serious problem
                     raise ValueError('Markdown failed to strip top-level '
                                      'tags. Document=%r' % output.strip()) from e
 
-        # Run the text post-processors
+        logger.debug("Run the text post-processors")
         for pp in self.postprocessors:
             output = pp.run(output)
 

--- a/tests/test_syntax/extensions/test_tables.py
+++ b/tests/test_syntax/extensions/test_tables.py
@@ -920,3 +920,50 @@ Content Cell  |  
             ),
             extensions=[TableExtension(use_align_attribute=True)]
         )
+
+    def test_large_table(self):
+        num_rows = 20000
+        lots_of_rows_raw = "|test1|test2|test3|\n" * num_rows
+        lots_of_rows_html = (
+            self.dedent(
+                """
+                <tr>
+                <td>test1</td>
+                <td>test2</td>
+                <td>test3</td>
+                </tr>
+                """
+            ) + "\n"
+        ) * num_rows
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <a name="some_link">Some link</a>
+
+                |foo|bar|baz|
+                |---|---|---|
+                """
+            ) + "\n" + lots_of_rows_raw,
+            '<p><a name="some_link">Some link</a></p>\n' + 
+            self.dedent(
+                """
+                <table>
+                <thead>
+                <tr>
+                <th>foo</th>
+                <th>bar</th>
+                <th>baz</th>
+                </tr>
+                </thead>
+                <tbody>
+                """
+            ) + "\n" +
+            lots_of_rows_html + 
+            self.dedent(
+                """
+                </tbody>
+                </table>
+                """
+            ),
+            extensions=[TableExtension()]
+        )


### PR DESCRIPTION
- Adds a test case for a large markdown table with an HTML link before it
- Adds useful debug prints

By removing the blank space in the test between the HTML link and the markdown table, the test fails to complete without a very helpful warning / error.

I'd be up for improving the error that is reported if you are, just let me know if this is interesting for the project or not.

Relates to #1374 