### PR TITLE
Fix admonition corner case with indented code blocks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,12 +28,10 @@ links to the header, placing them after all other header content.
 * Update the list of empty HTML tags (#1353).
 * Add customizable TOC title class to TOC extension (#1293).
 
-## [3.4.5] -- ????-??-??
-
 ### Fixed
 
 * Fix a corner case in admonitions where if an indented code block was provided
-  as the first block, the output would be malformed.
+  as the first block, the output would be malformed (#1329).
 
 ## [3.4.4] -- 2023-07-25
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,13 @@ links to the header, placing them after all other header content.
 * Update the list of empty HTML tags (#1353).
 * Add customizable TOC title class to TOC extension (#1293).
 
+## [3.4.5] -- ????-??-??
+
+### Fixed
+
+* Fix a corner case in admonitions where if an indented code block was provided
+  as the first block, the output would be malformed.
+
 ## [3.4.4] -- 2023-07-25
 
 ### Fixed

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -69,7 +69,7 @@ class AdmonitionProcessor(BlockProcessor):
 
         sibling = self.lastChild(parent)
 
-        if sibling is None or sibling.get('class', '').find(self.CLASSNAME) == -1:
+        if sibling is None or sibling.tag != 'div' or sibling.get('class', '').find(self.CLASSNAME) == -1:
             sibling = None
         else:
             # If the last child is a list and the content is sufficiently indented

--- a/tests/test_syntax/extensions/test_admonition.py
+++ b/tests/test_syntax/extensions/test_admonition.py
@@ -243,3 +243,23 @@ class TestAdmonition(TestCase):
             ),
             extensions=['admonition']
         )
+
+    def test_admonition_first_indented(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '''
+                !!! danger "This is not"
+                        one long admonition title
+                '''
+            ),
+            self.dedent(
+                '''
+                <div class="admonition danger">
+                <p class="admonition-title">This is not</p>
+                <pre><code>one long admonition title
+                </code></pre>
+                </div>
+                '''
+            ),
+            extensions=['admonition']
+        )


### PR DESCRIPTION
Fix a corner case in admonitions where if an indented code block was provided as the first block, the output would be malformed.

Fixes #1329