### PR TITLE
Added support for alternative link text for wikilinks extension.

### DIFF
--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -43,7 +43,7 @@ class WikiLinkExtension(Extension):
         self.md = md
 
         # append to end of inline patterns
-        WIKILINK_RE = r'\[\[([\w0-9_ -]+)\]\]'
+        WIKILINK_RE = r'\[\[([\w0-9_ -]+)\|?([^\]]*)\]\]'
         wikilinkPattern = WikiLinksInlineProcessor(WIKILINK_RE, self.getConfigs())
         wikilinkPattern.md = md
         md.inlinePatterns.register(wikilinkPattern, 'wikilink', 75)
@@ -58,7 +58,12 @@ class WikiLinksInlineProcessor(InlineProcessor):
         if m.group(1).strip():
             base_url, end_url, html_class = self._getMeta()
             label = m.group(1).strip()
-            url = self.config['build_url'](label, base_url, end_url)
+            alt_label = m.group(2).strip()
+            if alt_label == '':
+                url = self.config['build_url'](label, base_url, end_url)
+            else:
+                url = self.config['build_url'](label, base_url, end_url)
+                label = alt_label
             a = etree.Element('a')
             a.text = label
             a.set('href', url)

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -59,13 +59,12 @@ class WikiLinksInlineProcessor(InlineProcessor):
             base_url, end_url, html_class = self._getMeta()
             label = m.group(1).strip()
             alt_label = m.group(2).strip()
-            if alt_label == '':
-                url = self.config['build_url'](label, base_url, end_url)
-            else:
-                url = self.config['build_url'](label, base_url, end_url)
-                label = alt_label
+            url = self.config['build_url'](label, base_url, end_url)
             a = etree.Element('a')
-            a.text = label
+            if alt_label:
+                a.text = alt_label
+            else:
+                a.text = label
             a.set('href', url)
             if html_class:
                 a.set('class', html_class)


### PR DESCRIPTION
This is a really simple change to the `wikilinks` extension that adds support for the alternative link text: \
<https://community.telligent.com/community/10/w/user-documentation/62141/how-do-i-use-wiki-link-syntax#Using_alternative_link_text>

The Finnish language uses inflection heavily, so most links need to have an alternative name:
```markdown
Lue täältä lisää [[ meidän koiramme | meidän koristamme! ]]
```

(If a thing like this looks suitable for a merge, I can add test cases and the documentation.)