### PR TITLE
Add `set_css_classes` configuration option to the table extension

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,10 @@ will cause the links to be inserted at the start of the header, before any other
 header content. The default behavior for `permalink` is to append permanent
 links to the header, placing them after all other header content.
 
+#### Add `set_css_classes` configuration option to the table extension 
+
+A new boolean option `set_css_classes` adds css classes to the table generation. These classes include row and columns counts and parity and will allow for more granular table styling.
+
 ### Changed
 
 * Add support for cPython version 3.12 (and PyPy 3.10) and drop support for

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -72,14 +72,16 @@ The following options are provided to change the default behavior:
     Default: `'False'`
 
 CSS classes added: 
-* **`tr`**
-    `row-#`
-    `row-even`
-    `row-odd`
-* **`td`**
-    `col-#`
-    `col-even`
-    `col-odd`
+* **`tr`** : `row-#`, `row-even`, `row-odd`
+* **`td`** : `col-#`, `col-even`, `col-odd`
+
+This will allow some CSS stying, for example: 
+```css
+.col-1 {
+    background-color:blue;
+    color:white;
+}
+```
 
 
 A trivial example:

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -73,13 +73,13 @@ The following options are provided to change the default behavior:
 
 CSS classes added: 
 * tr
--- row-#
--- row-even
--- row-odd
+- row-#
+- row-even
+- row-odd
 * td
--- col-#
--- col-even
--- col-odd
+- col-#
+- col-even
+- col-odd
 
 
 A trivial example:

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -67,6 +67,20 @@ The following options are provided to change the default behavior:
 
     Default: `'False'`
 
+* **`set_css_classes`**: Set to `True` to inject css classes for tr and td tags. 
+
+    Default: `'False'`
+
+CSS classes added: 
+* tr
+-- row-#
+-- row-even
+-- row-odd
+* td
+-- col-#
+-- col-even
+-- col-odd
+
 
 A trivial example:
 
@@ -85,3 +99,8 @@ attribute.
 ...                 extensions=[TableExtension(use_align_attribute=True)]
 ... )
 ```
+
+
+
+
+

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -72,14 +72,14 @@ The following options are provided to change the default behavior:
     Default: `'False'`
 
 CSS classes added: 
-* tr
-- row-#
-- row-even
-- row-odd
-* td
-- col-#
-- col-even
-- col-odd
+* **`tr`**
+    `row-#`
+    `row-even`
+    `row-odd`
+* **`td`**
+    `col-#`
+    `col-even`
+    `col-odd`
 
 
 A trivial example:

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -75,7 +75,7 @@ CSS classes added:
 * **`tr`** : `row-#`, `row-even`, `row-odd`
 * **`td`** : `col-#`, `col-even`, `col-odd`
 
-This will allow some CSS stying, for example: 
+This will allow some CSS styling, for example: 
 ```css
 .col-1 {
     background-color:blue;

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -108,17 +108,19 @@ class TableProcessor(BlockProcessor):
         """Build an empty row."""
         tr = etree.SubElement(parent, 'tr')
         if self.config['set_css_classes']:
-            tr.set('class', 'row-1')
+            tr.set('class', 'row-1 row-odd')
         count = len(align)
-        while count:
-            etree.SubElement(tr, 'td')
-            count -= 1
+        for i in range(count):
+            td = etree.SubElement(tr, 'td')
+            if self.config['set_css_classes']:
+                col_parity = 'col-even' if ((i+1) % 2) == 0 else 'col-odd'
+                td.set('class', f'col-{i+1} {col_parity}')
 
     def _build_row(self, row, parent, align, rownumber):
         """ Given a row of text, build table cells. """
         tr = etree.SubElement(parent, 'tr')
         if self.config['set_css_classes'] and rownumber:
-            row_parity = 'row-odd' if (rownumber % 2) == 0 else 'row-even'
+            row_parity = 'row-even' if (rownumber % 2) == 0 else 'row-odd'
             tr.set('class', f'row-{rownumber} {row_parity}')
 
         tag = 'td'
@@ -139,7 +141,7 @@ class TableProcessor(BlockProcessor):
                 else:
                     c.set('style', f'text-align: {a};')
             if self.config['set_css_classes'] and tag == 'td':
-                col_parity = 'col-odd' if ((i+1) % 2) == 0 else 'col-even'
+                col_parity = 'col-even' if ((i+1) % 2) == 0 else 'col-odd'
                 c.set('class', f'col-{i+1} {col_parity}')
 
     def _split_row(self, row):


### PR DESCRIPTION
A new boolean option `set_css_classes` adds css classes to the table generation. These classes include row and columns counts and parity and will allow for more granular table styling.