### PR TITLE
Bump version to 3.5

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,7 +31,7 @@ jobs:
           - tox-env: py311
             python-version: '3.11'
           - tox-env: py312
-            python-version: '3.12.0-rc.1'
+            python-version: '3.12'
           - tox-env: pypy38
             python-version: pypy-3.8
           - tox-env: pypy39

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [Contributing Guide](contributing.md) for details.
 
-## [Unreleased]
+## [3.5] -- 2023-10-06
 
 ### Added
 

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 
 
-__version_info__ = (3, 4, 4, 'final', 0)
+__version_info__ = (3, 5, 0, 'final', 0)
 
 
 def _get_version(version_info):


### PR DESCRIPTION
As Python 3.12 was released on Monday (2023-10-02), we should get this out now to provide support (see #1357).