### PR TITLE
Update changelog validation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # - name: Ensure Changelog Entry Made
-    #   uses: dangoslen/changelog-enforcer@v3
-    #   with:
-    #     changeLogPath: 'docs/changelog.md'
-    #     missingUpdateErrorMessage: |
-    #       @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
-    #       changelog describing the changes you have made. Doing so will help to ensure your contribution is accepted.
+    - name: Ensure Changelog Entry Made
+      uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: 'docs/changelog.md'
+        missingUpdateErrorMessage: |
+          @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
+          changelog describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
-    #       Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
+          Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
     - name: Validate Changelog
-      # if: success()
+      if: success()
       id: changelog_reader
       uses: mindsers/changelog-reader-action@v2
       with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,15 +16,15 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - name: Ensure Changelog Entry Made
-      uses: dangoslen/changelog-enforcer@v3
-      with:
-        changeLogPath: 'docs/changelog.md'
-        missingUpdateErrorMessage: |
-          @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
-          changelog describing the changes you have made. Doing so will help to ensure your contribution is accepted.
+    # - name: Ensure Changelog Entry Made
+    #   uses: dangoslen/changelog-enforcer@v3
+    #   with:
+    #     changeLogPath: 'docs/changelog.md'
+    #     missingUpdateErrorMessage: |
+    #       @${{ github.actor }}, thank you for your contribution. It appears that you have not added a comment to the
+    #       changelog describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
-          Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
+    #       Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
     - name: Validate Changelog
       # if: success()
       id: changelog_reader

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
 
           Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
     - name: Validate Changelog
-      if: success()
+      # if: success()
       id: changelog_reader
       uses: mindsers/changelog-reader-action@v2
       with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     # - name: Ensure Changelog Entry Made
     #   uses: dangoslen/changelog-enforcer@v3
     #   with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,4 +31,4 @@ jobs:
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: error
-        path: ./docs/changelog.md
+        path: docs/changelog.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,9 +26,9 @@ jobs:
 
           Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
     - name: Validate Changelog
-        if: success()
-        id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          validation_level: error
-          path: ./docs/changelog.md
+      if: success()
+      id: changelog_reader
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_level: error
+        path: ./docs/changelog.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,8 +16,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    # - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v3
+    - name: Ensure Changelog Entry Made
+      uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'docs/changelog.md'
         missingUpdateErrorMessage: |
@@ -25,3 +25,10 @@ jobs:
           changelog describing the changes you have made. Doing so will help to ensure your contribution is accepted.
 
           Please see the [Contributing Guide](https://python-markdown.github.io/contributing/#changelog) for details.
+    - name: Validate Changelog
+        if: success()
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_level: error
+          path: ./docs/changelog.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,8 +5,9 @@ on:
     branches:
     - '**'
     path:
-    # Only run if changes were made in markdown/
+    # Only run if changes were made in markdown/ or the changelog
     - 'markdown/**'
+    - 'docs/changelog.md'
 
 # permissions:
 #   pull-requests: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
         with:
-          validation_level: warn
           version: ${{ github.ref_name }}
           path: ./docs/changelog.md
       - name: Release to GitHub

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -187,10 +187,6 @@ valid parameter and will raise an error if provided.
 
 ## [3.3.5] -- 2021-11-16
 
-### Added
-
-* Support Python 3.10 (#1124).
-
 ### Fixed
 
 * Make the `slugify_unicode` function not remove diacritical marks (#1118).
@@ -199,6 +195,7 @@ valid parameter and will raise an error if provided.
 * Don't process shebangs in fenced code blocks when using CodeHilite (#1156).
 * Improve email address validation for Automatic Links (#1165).
 * Ensure `<summary>` tags are parsed correctly (#1079).
+* Support Python 3.10 (#1124).
 
 ## [3.3.4] -- 2021-02-24
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,20 +51,15 @@ links to the header, placing them after all other header content.
 
 ## [3.4.2] -- 2023-03-22
 
-### Added
-
-* Officially support Python 3.11.
-
 ### Fixed
-
+* Officially support Python 3.11.
 * Improve standalone * and _ parsing (#1300).
 * Consider `<html>` HTML tag a block-level element (#1309).
-
-### Infrastructure
-
 * Switch from `setup.py` to `pyproject.toml`.
 
 ## [3.4.1] -- 2022-07-15
+
+### Fixed
 
 * Fix an import issue with `importlib.util` (#1274).
 

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 
 
-__version_info__ = (3, 5, 0, 'rc', 0)
+__version_info__ = (3, 5, 0, 'final', 0)
 
 
 def _get_version(version_info):

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 
 
-__version_info__ = (3, 5, 0, 'final', 0)
+__version_info__ = (3, 5, 0, 'rc', 0)
 
 
 def _get_version(version_info):


### PR DESCRIPTION
My first attempt to release version 3.5 [failed](https://github.com/Python-Markdown/markdown/actions/runs/6435539821/job/17477010868) due to an invalid changelog file. We need to validate its format every time we confirm an edit is needed to ensure edits don't break the format and prevent a release.