### PR TITLE
Speedup line_offset property

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [Contributing Guide](contributing.md) for details.
 
+## [unreleased]
+
+### Fixed
+
+* Fix a performance problem with HTML extraction where large HTML input could trigger quadratic line counting behavior (PR#1392).
+
 ## [3.5] -- 2023-10-06
 
 ### Added

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -85,7 +85,6 @@ class HTMLExtractor(htmlparser.HTMLParser):
 
         self.lineno_start_cache = [0]
 
-
         # This calls self.reset
         super().__init__(*args, **kwargs)
         self.md = md

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -128,15 +128,6 @@ class HTMLExtractor(htmlparser.HTMLParser):
             self.lineno_start_cache.append(lf_pos+1)
 
         return self.lineno_start_cache[self.lineno-1]
-        if self.lineno > 1 and '\n' in self.rawdata:
-            m = re.match(r'([^\n]*\n){{{}}}'.format(self.lineno-1), self.rawdata)
-            if m:
-                return m.end()
-            else:  # pragma: no cover
-                # Value of `self.lineno` must exceed total number of lines.
-                # Find index of beginning of last line.
-                return self.rawdata.rfind('\n')
-        return 0
 
     def at_line_start(self) -> bool:
         """

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -122,7 +122,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
             last_line_start_pos = self.lineno_start_cache[ii]
             lf_pos = self.rawdata.find('\n', last_line_start_pos)
             if lf_pos == -1:
-                # No more newlines found. Use end of rawdata.
+                # No more newlines found. Use end of raw data as start of line beyond end.
                 lf_pos = len(self.rawdata)
             self.lineno_start_cache.append(lf_pos+1)
 


### PR DESCRIPTION
When using `mkdocs`, I noticed huge runtimes and tracked these down to `HTMLExtractor.line_offset` taking all the time.  Before this patch, a run of `mkdocs` could take 500+ seconds, with this patch, it takes ~10 seconds.

Flamegraph before optimization:
![mkdocs2](https://github.com/Python-Markdown/markdown/assets/127622562/bc2f4493-35e5-4035-892c-aa4c4d0a4bb7)

Flamegraph after optimization:
![mkdocs2a](https://github.com/Python-Markdown/markdown/assets/127622562/d3fcfb34-df96-4baa-8c2d-426daf428f38)


Note: It may be the case that the full cache of start-positions of all lines isn't needed, and just a single entry is sufficient; I didn't explore this optimization.