### PR TITLE
Correct the declarations of I/O buffers as bytes-based

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [Contributing Guide](contributing.md) for details.
 
+## [unreleased]
+
+### Fixed
+
+* Fix type annotations for `convertFile` - it accepts only bytes-based buffers.
+  Also remove legacy checks from Python 2 (#1400)
+
 ## [3.5.1] -- 2023-10-31
 
 ### Fixed

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -23,7 +23,7 @@ import codecs
 import sys
 import logging
 import importlib
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Mapping, Sequence, TextIO
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, ClassVar, Mapping, Sequence
 from . import util
 from .preprocessors import build_preprocessors
 from .blockprocessors import build_block_parser
@@ -387,8 +387,8 @@ class Markdown:
 
     def convertFile(
         self,
-        input: str | TextIO | None = None,
-        output: str | TextIO | None = None,
+        input: str | BinaryIO | None = None,
+        output: str | BinaryIO | None = None,
         encoding: str | None = None,
     ) -> Markdown:
         """
@@ -424,8 +424,6 @@ class Markdown:
             input_file.close()
         else:
             text = sys.stdin.read()
-            if not isinstance(text, str):  # pragma: no cover
-                text = text.decode(encoding)
 
         text = text.lstrip('\ufeff')  # remove the byte-order mark
 
@@ -448,12 +446,8 @@ class Markdown:
         else:
             # Encode manually and write bytes to stdout.
             html = html.encode(encoding, "xmlcharrefreplace")
-            try:
-                # Write bytes directly to buffer (Python 3).
-                sys.stdout.buffer.write(html)
-            except AttributeError:  # pragma: no cover
-                # Probably Python 2, which works with bytes by default.
-                sys.stdout.write(html)
+            # Write bytes directly to buffer (Python 3).
+            sys.stdout.buffer.write(html)
 
         return self
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -446,7 +446,6 @@ class Markdown:
         else:
             # Encode manually and write bytes to stdout.
             html = html.encode(encoding, "xmlcharrefreplace")
-            # Write bytes directly to buffer (Python 3).
             sys.stdout.buffer.write(html)
 
         return self

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -33,7 +33,7 @@ from markdown.__main__ import parse_options
 from logging import DEBUG, WARNING, CRITICAL
 import yaml
 import tempfile
-from io import BytesIO
+from io import BytesIO, StringIO, TextIOWrapper
 import xml.etree.ElementTree as etree
 from xml.etree.ElementTree import ProcessingInstruction
 
@@ -80,8 +80,8 @@ class TestConvertFile(unittest.TestCase):
 
     def setUp(self):
         self.saved = sys.stdin, sys.stdout
-        sys.stdin = BytesIO(bytes('foo', encoding='utf-8'))
-        sys.stdout = BytesIO()
+        sys.stdin = StringIO('foo')
+        sys.stdout = TextIOWrapper(BytesIO())
 
     def tearDown(self):
         sys.stdin, sys.stdout = self.saved
@@ -111,7 +111,7 @@ class TestConvertFile(unittest.TestCase):
     def testStdinStdout(self):
         markdown.markdownFromFile()
         sys.stdout.seek(0)
-        self.assertEqual(sys.stdout.read().decode('utf-8'), '<p>foo</p>')
+        self.assertEqual(sys.stdout.read(), '<p>foo</p>')
 
 
 class TestBlockParser(unittest.TestCase):


### PR DESCRIPTION
* Correctly declare the parameter annotations as `BinaryIO`, because in fact it works only with byte-based buffers.
   
   Attempt at running code both **before** and after this change:

  ```pycon
  >>> from markdown import Markdown

  >>> from io import StringIO, BytesIO
  
  >>> Markdown().convertFile(BytesIO(b'input'), output=BytesIO())
  <markdown.core.Markdown object at 0x7fe3bba7c710>

  >>> Markdown().convertFile(StringIO('input'), output=BytesIO())
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "markdown/core.py", line 423, in convertFile
      text = input_file.read()
            ^^^^^^^^^^^^^^^^^
    File "<frozen codecs>", line 500, in read
  TypeError: can't concat str to bytes
  
  >>> Markdown().convertFile(BytesIO(b'input'), output=StringIO())
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "markdown/core.py", line 446, in convertFile
      output_file.write(html)
    File "<frozen codecs>", line 378, in write
  TypeError: string argument expected, got 'bytes'
  ```


* `sys.stdin.read()` is always a string, so remove the Python2-specific check.
    * Correct the patch in the test which incorrectly sets `sys.stdin` to a bytes buffer which it never is.

* `sys.stdout.buffer` always exists, so remove the Python2-specific fallback.
    * Correct the patch in the test which incorrectly sets `sys.stdout` to a bytes buffer which it never is. And fix a matching mistake because this necessitated `stdout.read().decode()`.
