### PR TITLE
Enable checking against mypy with minimal set of fixes

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [flake8, pep517check, checkspelling]
+        tox-env: [mypy, flake8, pep517check, checkspelling]
 
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -175,7 +175,7 @@ class ListIndentProcessor(BlockProcessor):
         return block.startswith(' '*self.tab_length) and \
             not self.parser.state.isstate('detabbed') and \
             (parent.tag in self.ITEM_TYPES or
-                (len(parent) and parent[-1] is not None and
+                (len(parent) > 0 and parent[-1] is not None and
                     (parent[-1].tag in self.LIST_TYPES)))
 
     def run(self, parent: etree.Element, blocks: list[str]) -> None:

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -453,8 +453,8 @@ class Markdown:
                 # Don't close here. User may want to write more.
         else:
             # Encode manually and write bytes to stdout.
-            html_bytes = html.encode(encoding, "xmlcharrefreplace")
-            sys.stdout.buffer.write(html_bytes)
+            html = html.encode(encoding, "xmlcharrefreplace")
+            sys.stdout.buffer.write(html)  # type: ignore
 
         return self
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -85,7 +85,7 @@ class Markdown:
     callable which accepts an [`Element`][xml.etree.ElementTree.Element] and returns a `str`.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """
         Creates a new Markdown instance.
 
@@ -445,8 +445,8 @@ class Markdown:
                 # Don't close here. User may want to write more.
         else:
             # Encode manually and write bytes to stdout.
-            html = html.encode(encoding, "xmlcharrefreplace")
-            sys.stdout.buffer.write(html)
+            html_bytes = html.encode(encoding, "xmlcharrefreplace")
+            sys.stdout.buffer.write(html_bytes)
 
         return self
 

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -85,7 +85,15 @@ class Markdown:
     callable which accepts an [`Element`][xml.etree.ElementTree.Element] and returns a `str`.
     """
 
-    def __init__(self, **kwargs) -> None:
+    tab_length: int
+    ESCAPED_CHARS: list[str]
+    block_level_elements: list[str]
+    registeredExtensions: list[Extension]
+    stripTopLevelTags: bool
+    references: dict[str, tuple[str, str]]
+    htmlStash: util.HtmlStash
+
+    def __init__(self, **kwargs):
         """
         Creates a new Markdown instance.
 
@@ -106,23 +114,23 @@ class Markdown:
 
         """
 
-        self.tab_length: int = kwargs.get('tab_length', 4)
+        self.tab_length = kwargs.get('tab_length', 4)
 
-        self.ESCAPED_CHARS: list[str] = [
+        self.ESCAPED_CHARS = [
             '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!'
         ]
         """ List of characters which get the backslash escape treatment. """
 
-        self.block_level_elements: list[str] = BLOCK_LEVEL_ELEMENTS.copy()
+        self.block_level_elements = BLOCK_LEVEL_ELEMENTS.copy()
 
-        self.registeredExtensions: list[Extension] = []
+        self.registeredExtensions = []
         self.docType = ""  # TODO: Maybe delete this. It does not appear to be used anymore.
-        self.stripTopLevelTags: bool = True
+        self.stripTopLevelTags = True
 
         self.build_parser()
 
-        self.references: dict[str, tuple[str, str]] = {}
-        self.htmlStash: util.HtmlStash = util.HtmlStash()
+        self.references = {}
+        self.htmlStash = util.HtmlStash()
         self.registerExtensions(extensions=kwargs.get('extensions', []),
                                 configs=kwargs.get('extension_configs', {}))
         self.set_output_format(kwargs.get('output_format', 'xhtml'))

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -94,7 +94,7 @@ class AbbrInlineProcessor(InlineProcessor):
         super().__init__(pattern)
         self.title = title
 
-    def handleMatch(self, m: re.Match[str], data: str) -> tuple[etree.Element, int, int]:
+    def handleMatch(self, m: re.Match[str], data: str) -> tuple[etree.Element, int, int]:  # type: ignore[override]
         abbr = etree.Element('abbr')
         abbr.text = AtomicString(m.group('abbr'))
         abbr.set('title', self.title)

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -59,7 +59,7 @@ class AdmonitionProcessor(BlockProcessor):
         super().__init__(parser)
 
         self.current_sibling: etree.Element | None = None
-        self.content_indention = 0
+        self.content_indent = 0
 
     def parse_content(self, parent: etree.Element, block: str) -> tuple[etree.Element | None, str, str]:
         """Get sibling admonition.

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -56,7 +56,7 @@ def _handle_word(s, t):
     return t, t
 
 
-_scanner = re.Scanner([
+_scanner = re.Scanner([  # type: ignore[attr-defined]
     (r'[^ =]+=".*?"', _handle_double_quote),
     (r"[^ =]+='.*?'", _handle_single_quote),
     (r'[^ =]+=[^ =]+', _handle_key_value),

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -161,7 +161,7 @@ class CodeHilite:
                     lexer = get_lexer_by_name('text', **self.options)
             if not self.lang:
                 # Use the guessed lexer's language instead
-                self.lang = lexer.aliases[0]
+                self.lang = lexer.aliases[0]  # type: ignore[attr-defined]
             lang_str = f'{self.lang_prefix}{self.lang}'
             if isinstance(self.pygments_formatter, str):
                 try:

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -159,7 +159,7 @@ class FencedBlockPreprocessor(Preprocessor):
         """ Return tuple: `(id, [list, of, classes], {configs})` """
         id = ''
         classes = []
-        configs = {}
+        configs: dict[str, Any] = {}
         for k, v in attrs:
             if k == 'id':
                 id = v

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -38,7 +38,7 @@ RE_REF_ID = re.compile(r'(fnref)(\d+)')
 class FootnoteExtension(Extension):
     """ Footnote Extension. """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """ Setup configs. """
 
         self.config = {
@@ -290,7 +290,7 @@ class FootnoteBlockProcessor(BlockProcessor):
                 break
         return fn_blocks
 
-    def detab(self, block: str) -> str:
+    def detab(self, block: str) -> str:  # type: ignore[override]
         """ Remove one level of indent from a block.
 
         Preserve lazily indented blocks by only removing indent from indented lines.

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -38,7 +38,10 @@ RE_REF_ID = re.compile(r'(fnref)(\d+)')
 class FootnoteExtension(Extension):
     """ Footnote Extension. """
 
-    def __init__(self, **kwargs) -> None:
+    found_refs: dict[str, int]
+    used_refs: set[str]
+
+    def __init__(self, **kwargs):
         """ Setup configs. """
 
         self.config = {
@@ -68,8 +71,8 @@ class FootnoteExtension(Extension):
 
         # In multiple invocations, emit links that don't get tangled.
         self.unique_prefix = 0
-        self.found_refs: dict[str, int] = {}
-        self.used_refs: set[str] = set()
+        self.found_refs = {}
+        self.used_refs = set()
 
         self.reset()
 

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -56,7 +56,7 @@ class HTMLExtractorExtra(HTMLExtractor):
         self.block_tags = set(self.block_level_tags) - (self.span_tags | self.raw_tags | self.empty_tags)
         self.span_and_blocks_tags = self.block_tags | self.span_tags
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset this instance.  Loses all unprocessed data."""
         self.mdstack: list[str] = []  # When markdown=1, stack contains a list of tags
         self.treebuilder = etree.TreeBuilder()

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -40,6 +40,10 @@ class HTMLExtractorExtra(HTMLExtractor):
     Markdown.
     """
 
+    mdstack: list[str] = []  # When markdown=1, stack contains a list of tags
+    treebuilder: etree.TreeBuilder
+    mdstate: list[Literal['block', 'span', 'off', None]]
+
     def __init__(self, md: Markdown, *args, **kwargs):
         # All block-level tags.
         self.block_level_tags = set(md.block_level_elements.copy())
@@ -56,11 +60,11 @@ class HTMLExtractorExtra(HTMLExtractor):
         self.block_tags = set(self.block_level_tags) - (self.span_tags | self.raw_tags | self.empty_tags)
         self.span_and_blocks_tags = self.block_tags | self.span_tags
 
-    def reset(self) -> None:
+    def reset(self):
         """Reset this instance.  Loses all unprocessed data."""
-        self.mdstack: list[str] = []  # When markdown=1, stack contains a list of tags
+        self.mdstack = []  # When markdown=1, stack contains a list of tags
         self.treebuilder = etree.TreeBuilder()
-        self.mdstate: list[Literal['block', 'span', 'off', None]] = []
+        self.mdstate = []
         super().reset()
 
     def close(self):

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -78,7 +78,7 @@ class MetaPreprocessor(Preprocessor):
                 else:
                     lines.insert(0, line)
                     break  # no meta data - done
-        self.md.Meta = meta
+        self.md.Meta = meta  # type: ignore[attr-defined]
         return lines
 
 

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -179,7 +179,10 @@ class SubstituteTextPattern(HtmlInlineProcessor):
 
 class SmartyExtension(Extension):
     """ Add Smarty to Markdown. """
-    def __init__(self, **kwargs) -> None:
+
+    substitutions: dict[str, str]
+
+    def __init__(self, **kwargs):
         self.config = {
             'smart_quotes': [True, 'Educate quotes'],
             'smart_angled_quotes': [False, 'Educate angled quotes'],
@@ -189,7 +192,7 @@ class SmartyExtension(Extension):
         }
         """ Default configuration options. """
         super().__init__(**kwargs)
-        self.substitutions: dict[str, str] = dict(substitutions)
+        self.substitutions = dict(substitutions)
         self.substitutions.update(self.getConfig('substitutions', default={}))
 
     def _addPatterns(

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -179,7 +179,7 @@ class SubstituteTextPattern(HtmlInlineProcessor):
 
 class SmartyExtension(Extension):
     """ Add Smarty to Markdown. """
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.config = {
             'smart_quotes': [True, 'Educate quotes'],
             'smart_angled_quotes': [False, 'Educate angled quotes'],
@@ -199,9 +199,8 @@ class SmartyExtension(Extension):
         serie: str,
         priority: int,
     ):
-        for ind, pattern in enumerate(patterns):
-            pattern += (md,)
-            pattern = SubstituteTextPattern(*pattern)
+        for ind, pattern_args in enumerate(patterns):
+            pattern = SubstituteTextPattern(*pattern_args, md)
             name = 'smarty-%s-%d' % (serie, ind)
             self.inlinePatterns.register(pattern, name, priority-ind)
 
@@ -253,7 +252,7 @@ class SmartyExtension(Extension):
         )
         self._addPatterns(md, patterns, 'quotes', 30)
 
-    def extendMarkdown(self, md):
+    def extendMarkdown(self, md: Markdown):
         configs = self.getConfigs()
         self.inlinePatterns: Registry[inlinepatterns.InlineProcessor] = Registry()
         if configs['smart_ellipses']:

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -80,7 +80,7 @@ def stashedHTML2text(text: str, md: Markdown, strip_entities: bool = True) -> st
     def _html_sub(m: re.Match[str]) -> str:
         """ Substitute raw html with plain text. """
         try:
-            raw = md.htmlStash.rawHtmlBlocks[int(m.group(1))]
+            raw: str = md.htmlStash.rawHtmlBlocks[int(m.group(1))]
         except (IndexError, TypeError):  # pragma: no cover
             return m.group(0)
         # Strip out tags and/or entities - leaving text
@@ -335,8 +335,8 @@ class TocTreeprocessor(Treeprocessor):
         toc = self.md.serializer(div)
         for pp in self.md.postprocessors:
             toc = pp.run(toc)
-        self.md.toc_tokens = toc_tokens
-        self.md.toc = toc
+        self.md.toc_tokens = toc_tokens  # type: ignore[attr-defined]
+        self.md.toc = toc  # type: ignore[attr-defined]
 
 
 class TocExtension(Extension):

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -65,6 +65,7 @@ class WikiLinksInlineProcessor(InlineProcessor):
         self.config = config
 
     def handleMatch(self, m: re.Match[str], data: str) -> tuple[etree.Element | str, int, int]:
+        a: etree.Element | str
         if m.group(1).strip():
             base_url, end_url, html_class = self._getMeta()
             label = m.group(1).strip()

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -80,6 +80,9 @@ class HTMLExtractor(htmlparser.HTMLParser):
     is stored in `cleandoc` as a list of strings.
     """
 
+    stack: list[str]
+    cleandoc: list[str]
+
     def __init__(self, md: Markdown, *args, **kwargs):
         if 'convert_charrefs' not in kwargs:
             kwargs['convert_charrefs'] = False
@@ -93,13 +96,13 @@ class HTMLExtractor(htmlparser.HTMLParser):
         super().__init__(*args, **kwargs)
         self.md = md
 
-    def reset(self) -> None:
+    def reset(self):
         """Reset this instance.  Loses all unprocessed data."""
         self.inraw = False
         self.intail = False
-        self.stack: list[str] = []  # When `inraw==True`, stack contains a list of tags
-        self._cache: list[str] = []
-        self.cleandoc: list[str] = []
+        self.stack = []  # When `inraw==True`, stack contains a list of tags
+        self._cache = []
+        self.cleandoc = []
         self.lineno_start_cache = [0]
 
         super().reset()

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import re
 import importlib.util
 import sys
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 if TYPE_CHECKING:  # pragma: no cover
     from markdown import Markdown
@@ -37,7 +37,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # Import a copy of the html.parser lib as `htmlparser` so we can monkeypatch it.
 # Users can still do `from html import parser` and get the default behavior.
 spec = importlib.util.find_spec('html.parser')
-htmlparser = importlib.util.module_from_spec(spec)
+htmlparser: Any = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(htmlparser)
 sys.modules['htmlparser'] = htmlparser
 
@@ -93,7 +93,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
         super().__init__(*args, **kwargs)
         self.md = md
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset this instance.  Loses all unprocessed data."""
         self.inraw = False
         self.intail = False

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -244,7 +244,6 @@ class _BasePattern:
 
     def unescape(self, text: str) -> str:
         """ Return unescaped text given text with an inline placeholder. """
-        assert self.md is not None
         try:
             stash = self.md.treeprocessors['inline'].stashed_nodes  # type: ignore[attr-defined]
         except KeyError:  # pragma: no cover

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -48,7 +48,6 @@ from html import entities
 
 if TYPE_CHECKING:  # pragma: no cover
     from markdown import Markdown
-    from . import treeprocessors
 
 
 def build_inlinepatterns(md: Markdown, **kwargs: Any) -> util.Registry[InlineProcessor]:
@@ -247,8 +246,7 @@ class _BasePattern:
         """ Return unescaped text given text with an inline placeholder. """
         assert self.md is not None
         try:
-            inlineprocessor: treeprocessors.InlineProcessor = self.md.treeprocessors['inline']
-            stash = inlineprocessor.stashed_nodes
+            stash = self.md.treeprocessors['inline'].stashed_nodes  # type: ignore[attr-defined]
         except KeyError:  # pragma: no cover
             return text
 
@@ -516,8 +514,7 @@ class HtmlInlineProcessor(InlineProcessor):
     def unescape(self, text: str) -> str:
         """ Return unescaped text given text with an inline placeholder. """
         try:
-            inline_processor: treeprocessors.InlineProcessor = self.md.treeprocessors['inline']
-            stash = inline_processor.stashed_nodes
+            stash = self.md.treeprocessors['inline'].stashed_nodes  # type: ignore[attr-defined]
         except KeyError:  # pragma: no cover
             return text
 
@@ -535,8 +532,7 @@ class HtmlInlineProcessor(InlineProcessor):
     def backslash_unescape(self, text: str) -> str:
         """ Return text with backslash escapes undone (backslashes are restored). """
         try:
-            unescape_processor: treeprocessors.UnescapeTreeprocessor = self.md.treeprocessors['unescape']
-            RE = unescape_processor.RE
+            RE = self.md.treeprocessors['unescape'].RE  # type: ignore[attr-defined]
         except KeyError:  # pragma: no cover
             return text
 

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -75,8 +75,7 @@ class RawHtmlPostprocessor(Postprocessor):
         """ Iterate over html stash and restore html. """
         replacements = OrderedDict()
         for i in range(self.md.htmlStash.html_counter):
-            raw: str = self.md.htmlStash.rawHtmlBlocks[i]
-            html = self.stash_to_string(raw)
+            html = self.stash_to_string(self.md.htmlStash.rawHtmlBlocks[i])  # type: ignore[arg-type]
             if self.isblocklevel(html):
                 replacements["<p>{}</p>".format(
                     self.md.htmlStash.get_placeholder(i))] = html

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -75,7 +75,8 @@ class RawHtmlPostprocessor(Postprocessor):
         """ Iterate over html stash and restore html. """
         replacements = OrderedDict()
         for i in range(self.md.htmlStash.html_counter):
-            html = self.stash_to_string(self.md.htmlStash.rawHtmlBlocks[i])
+            raw: str = self.md.htmlStash.rawHtmlBlocks[i]
+            html = self.stash_to_string(raw)
             if self.isblocklevel(html):
                 replacements["<p>{}</p>".format(
                     self.md.htmlStash.get_placeholder(i))] = html

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -45,8 +45,8 @@ differences as outlined below:
 
 from __future__ import annotations
 
-from xml.etree.ElementTree import ProcessingInstruction
-from xml.etree.ElementTree import Comment, ElementTree, Element, QName, HTML_EMPTY
+from xml.etree.ElementTree import ProcessingInstruction, Comment, ElementTree, Element, QName
+from xml.etree.ElementTree import HTML_EMPTY  # type: ignore[attr-defined]
 import re
 from typing import Callable, Literal, NoReturn
 

--- a/markdown/test_tools.py
+++ b/markdown/test_tools.py
@@ -29,7 +29,7 @@ from typing import Any
 from . import markdown, Markdown, util
 
 try:
-    import tidylib
+    import tidylib  # type: ignore
 except ImportError:
     tidylib = None
 

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -275,7 +275,7 @@ class InlineProcessor(Treeprocessor):
             new_style = True
             new_pattern = pattern
         else:
-            new_style = False
+            new_style = False  # pragma: no cover
             legacy_pattern = pattern
 
         for exclude in pattern.ANCESTOR_EXCLUDES:

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -271,38 +271,35 @@ class InlineProcessor(Treeprocessor):
             String with placeholders instead of `ElementTree` elements.
 
         """
-        if isinstance(pattern, inlinepatterns.InlineProcessor):
-            new_style = True
-            new_pattern = pattern
-        else:  # pragma: no cover
-            new_style = False
-            legacy_pattern = pattern
+        new_style = isinstance(pattern, inlinepatterns.InlineProcessor)
 
         for exclude in pattern.ANCESTOR_EXCLUDES:
             if exclude.lower() in self.ancestors:
                 return data, False, 0
 
+        start: int | None
+        end: int | None
         if new_style:
             match = None
             # Since `handleMatch` may reject our first match,
             # we iterate over the buffer looking for matches
             # until we can't find any more.
-            for match in new_pattern.getCompiledRegExp().finditer(data, startIndex):
-                node, start, end = new_pattern.handleMatch(match, data)
+            for match in pattern.getCompiledRegExp().finditer(data, startIndex):
+                node, start, end = pattern.handleMatch(match, data)  # type: ignore
                 if start is None or end is None:
                     startIndex += match.end(0)
                     match = None
                     continue
                 break
         else:  # pragma: no cover
-            match = legacy_pattern.getCompiledRegExp().match(data[startIndex:])
+            match = pattern.getCompiledRegExp().match(data[startIndex:])
             leftData = data[:startIndex]
 
         if not match:
             return data, False, 0
 
         if not new_style:  # pragma: no cover
-            node = legacy_pattern.handleMatch(match)
+            node = pattern.handleMatch(match)  # type: ignore
             start = match.start(0)
             end = match.end(0)
 

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -274,8 +274,8 @@ class InlineProcessor(Treeprocessor):
         if isinstance(pattern, inlinepatterns.InlineProcessor):
             new_style = True
             new_pattern = pattern
-        else:
-            new_style = False  # pragma: no cover
+        else:  # pragma: no cover
+            new_style = False
             legacy_pattern = pattern
 
         for exclude in pattern.ANCESTOR_EXCLUDES:

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -218,7 +218,7 @@ class HtmlStash:
     in the beginning and replace with place-holders.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """ Create an `HtmlStash`. """
         self.html_counter = 0  # for counting inline html segments
         self.rawHtmlBlocks: list[str | etree.Element] = []
@@ -309,7 +309,7 @@ class Registry(Generic[_T]):
     an item using that item's assigned "name".
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._data: dict[str, _T] = {}
         self._priority: list[_PriorityItem] = []
         self._is_sorted = False

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -218,12 +218,17 @@ class HtmlStash:
     in the beginning and replace with place-holders.
     """
 
-    def __init__(self) -> None:
+    html_counter: int
+    rawHtmlBlocks: list[str | etree.Element]
+    tag_counter: int
+    tag_data: list[TagData]
+
+    def __init__(self):
         """ Create an `HtmlStash`. """
         self.html_counter = 0  # for counting inline html segments
-        self.rawHtmlBlocks: list[str | etree.Element] = []
+        self.rawHtmlBlocks = []
         self.tag_counter = 0
-        self.tag_data: list[TagData] = []  # list of dictionaries in the order tags appear
+        self.tag_data = []  # list of dictionaries in the order tags appear
 
     def store(self, html: str | etree.Element) -> str:
         """
@@ -309,9 +314,9 @@ class Registry(Generic[_T]):
     an item using that item's assigned "name".
     """
 
-    def __init__(self) -> None:
-        self._data: dict[str, _T] = {}
-        self._priority: list[_PriorityItem] = []
+    def __init__(self):
+        self._data = {}
+        self._priority = []
         self._is_sorted = False
 
     def __contains__(self, item: str | _T) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,13 @@ legacy_em = 'markdown.extensions.legacy_em:LegacyEmExtension'
 [tool.setuptools]
 packages = ['markdown', 'markdown.extensions']
 
+[tool.setuptools.package-data]
+"markdown" = ["py.typed"]
+
 [tool.setuptools.dynamic]
 version = {attr = 'markdown.__meta__.__version__'}
+
+[tool.mypy]
+strict_optional = false
+warn_no_return = false
+disable_error_code = 'assignment, var-annotated'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,6 @@ legacy_em = 'markdown.extensions.legacy_em:LegacyEmExtension'
 [tool.setuptools]
 packages = ['markdown', 'markdown.extensions']
 
-[tool.setuptools.package-data]
-"markdown" = ["py.typed"]
-
 [tool.setuptools.dynamic]
 version = {attr = 'markdown.__meta__.__version__'}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38, 39, 310, 311, 312}, pypy{38, 39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{38, 39, 310, 311, 312}, pypy{38, 39, 310}, pygments, mypy, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]
@@ -18,6 +18,15 @@ setenv =
 deps =
     pytidylib
     pygments=={env:PYGMENTS_VERSION}
+
+[testenv:mypy]
+deps =
+    mypy
+    types-PyYAML
+    types-Pygments
+allowlist_externals = mypy
+commands = mypy {toxinidir}/markdown
+skip_install = true
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
4 significant checks are disabled:
* `strict_optional` - check that an object might be `None` on access
* `warn_no_return` - requiring a `return`
* `assignment` - any assignment of a variable of a wrong type
* `var-annotated` - a type annotation is missing
