### PR TITLE
Fix typo in attribute name

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix type annotations for `convertFile` - it accepts only bytes-based buffers.
   Also remove legacy checks from Python 2 (#1400)
 * Remove legacy import needed only in Python 2 (#1403)
+* Fix typo that left the attribute `AdmonitionProcessor.content_indent` unset
+  (#1404)
 * Improve and expand type annotations in the code base (#1401).
 
 ## [3.5.1] -- 2023-10-31

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -59,7 +59,7 @@ class AdmonitionProcessor(BlockProcessor):
         super().__init__(parser)
 
         self.current_sibling: etree.Element | None = None
-        self.content_indention = 0
+        self.content_indent = 0
 
     def parse_content(self, parent: etree.Element, block: str) -> tuple[etree.Element | None, str, str]:
         """Get sibling admonition.


### PR DESCRIPTION
There are no other references to `content_indention`, and it seems that there were no problems with this only because the other line `self.content_indent = indent` kicks in in all relevant situations.
