### PR TITLE
Fix edge-case crash in codehilite

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove legacy import needed only in Python 2 (#1403)
 * Fix typo that left the attribute `AdmonitionProcessor.content_indent` unset
   (#1404)
+* Fix edge-case crash in `codehilite` with an empty `code` tag (#1405).
 * Improve and expand type annotations in the code base (#1401).
 
 ## [3.5.1] -- 2023-10-31

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -270,8 +270,11 @@ class HiliteTreeprocessor(Treeprocessor):
         for block in blocks:
             if len(block) == 1 and block[0].tag == 'code':
                 local_config = self.config.copy()
+                text = block[0].text
+                if text is None:
+                    continue
                 code = CodeHilite(
-                    self.code_unescape(block[0].text),
+                    self.code_unescape(text),
                     tab_length=self.md.tab_length,
                     style=local_config.pop('pygments_style', 'default'),
                     **local_config


### PR DESCRIPTION
If there is an empty `<pre><code></code></pre>` inserted by another extension, there can be an exception. The added test case was crashing before this change:

```
  File "markdown/core.py", line 361, in convert
    newRoot = treeprocessor.run(root)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "markdown/extensions/codehilite.py", line 274, in run
    self.code_unescape(block[0].text),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "markdown/extensions/codehilite.py", line 260, in code_unescape
    text = text.replace("&lt;", "<")
           ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```