### PR TITLE
Fix edge-case crash in InlineProcessor

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove legacy import needed only in Python 2 (#1403)
 * Fix typo that left the attribute `AdmonitionProcessor.content_indent` unset
   (#1404)
+* Fix edge-case crash in `InlineProcessor` with `AtomicString` (#1406).
 * Improve and expand type annotations in the code base (#1401).
 
 ## [3.5.1] -- 2023-10-31

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -218,7 +218,7 @@ class InlineProcessor(Treeprocessor):
                         text = data[strartIndex:index]
                         linkText(text)
 
-                    if not isString(node):  # it's Element
+                    if not isinstance(node, str):  # it's Element
                         for child in [node] + list(node):
                             if child.tail:
                                 if child.tail.strip():
@@ -304,7 +304,7 @@ class InlineProcessor(Treeprocessor):
         if node is None:
             return data, True, end
 
-        if not isString(node):
+        if not isinstance(node, str):
             if not isinstance(node.text, util.AtomicString):
                 # We need to process current node too
                 for child in [node] + list(node):


### PR DESCRIPTION
If an inlineprocessor returns an AtomicString (even though that is pointless, a plain string is atomic in that context), there can be an exception in 2 separate places. The added test case was crashing before this change.

```
  File "tests/test_apis.py", line 722, in testInlineProcessorDoesntCrashWithAtomicString
    new = self.inlineprocessor.run(tree)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "markdown/treeprocessors.py", line 384, in run
    lst = self.__processPlaceholders(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "markdown/treeprocessors.py", line 223, in __processPlaceholders
    if child.tail:
       ^^^^^^^^^^
AttributeError: 'AtomicString' object has no attribute 'tail'
```

```
  File "tests/test_apis.py", line 722, in testInlineProcessorDoesntCrashWithAtomicString
    new = self.inlineprocessor.run(tree)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "markdown/treeprocessors.py", line 387, in run
    self.__handleInline(text), child
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "markdown/treeprocessors.py", line 136, in __handleInline
    data, matched, startIndex = self.__applyPattern(
                                ^^^^^^^^^^^^^^^^^^^^
  File "markdown/treeprocessors.py", line 310, in __applyPattern
    if not isinstance(node.text, util.AtomicString):
                      ^^^^^^^^^
AttributeError: 'AtomicString' object has no attribute 'text'
```