### PR TITLE
Update docs deploy scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,16 @@ jobs:
   ghpages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Source Repo
+        uses: actions/checkout@v4
+        with:
+          path: md
+      - name: Checkout Target Repo
+        uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.PAGES_DEPLOY_KEY  }}
+          repository: Python-Markdown/Python-Markdown.github.io
+          path: target
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -60,15 +69,11 @@ jobs:
           python -m pip install .[docs]
       - name: Build
         run: |
+          cd md
           python -m mkdocs build --clean --verbose
       - name: Publish
         if: success()
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          SSH_DEPLOY_KEY: ${{ secrets.PAGES_DEPLOY_KEY }}
-        with:
-          source-directory: 'site'
-          destination-github-username: 'Python-Markdown'
-          destination-repository-name: 'Python-Markdown.github.io'
-          user-name: ${{ github.actor }}
-          target-branch: master
+        run: |
+          cd target
+          git config user.email waylan.limberg@icloud.com
+          python -m ghp-import --push --no-jekyll --branch=master ../md/site

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -1,14 +1,30 @@
 name: manual deploy
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout and build.'
+        type: string
+        required: true
+        default: master
 
 jobs:
 
   ghpages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Source Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: md
+      - name: Checkout Target Repo
+        uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.PAGES_DEPLOY_KEY  }}
+          repository: Python-Markdown/Python-Markdown.github.io
+          path: target
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -19,15 +35,11 @@ jobs:
           python -m pip install .[docs]
       - name: Build
         run: |
+          cd md
           python -m mkdocs build --clean --verbose
       - name: Publish
         if: success()
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          SSH_DEPLOY_KEY: ${{ secrets.PAGES_DEPLOY_KEY }}
-        with:
-          source-directory: 'site'
-          destination-github-username: 'Python-Markdown'
-          destination-repository-name: 'Python-Markdown.github.io'
-          user-name: ${{ github.actor }}
-          target-branch: master
+        run: |
+          cd target
+          git config user.email waylan.limberg@icloud.com
+          python -m ghp-import --push --no-jekyll --branch=master ../md/site


### PR DESCRIPTION
The update in #1398 didn't provide for a `.nojekyll` file, which we want to avoid Jekyll messing with our statically generated documentation.

I've also added a user input to the manual deploy script which allows deploying from any past reference (tag or commit).