### PR TITLE
MANIFEST.in: Include scripts/*.py in the generated source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ include MANIFEST
 include *-requirements.txt
 include mkdocs.yml
 include tox.ini
+include scripts/*.py

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [Contributing Guide](contributing.md) for details.
 
+## [unreleased]
+
+### Fixed
+
+* Include `scripts/*.py` in the generated source tarballs (#1430).
+
 ## [3.5.2] -- 2024-01-10
 
 ### Fixed


### PR DESCRIPTION
These scripts are needed for building the documentation.