### PR TITLE
Mkdocstrings doc updates

### DIFF
--- a/docs/templates/python/nature/attribute.html
+++ b/docs/templates/python/nature/attribute.html
@@ -2,6 +2,7 @@
 
 {% block heading scoped %}
   <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ attribute.filepath }}#L{{ attribute.lineno }}{% if attribute.endlineno > attribute.lineno %}-L{{ attribute.endlineno }}{% endif %}" title='View source code on GitHub'>&lsaquo;&rsaquo;</a>
+  {% if config.show_symbol_type_heading %}<code class="doc-symbol doc-symbol-heading doc-symbol-attribute"></code>{% endif %}
   {%+ filter highlight(language="python", inline=True) %}
     {{ attribute_name }}{% if attribute.annotation %}: {{ attribute.annotation }}{% endif %}
   {% endfilter %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,7 @@ plugins:
           show_signature_annotations: true
           show_source: false
           show_symbol_type_heading: true
-          show_symbol_type_toc: true
+          show_symbol_type_toc: false
           signature_crossrefs: false
           summary: true
           source:


### PR DESCRIPTION
* Restore Attribute symbol type in mkdocstrings template
* Disable mkdocstrings `show_symbol_type_toc` option to work around searching issue in #1432.