### PR TITLE
Give smarty treeprocessor higher priority than toc

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Include `scripts/*.py` in the generated source tarballs (#1430).
 * Ensure lines after heading in loose list are properly detabbed (#1443).
+* Give smarty tree processor higher priority than toc (#1440).
 
 ## [3.5.2] -- 2024-01-10
 

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -269,7 +269,7 @@ class SmartyExtension(Extension):
             self.educateDashes(md)
         inlineProcessor = InlineProcessor(md)
         inlineProcessor.inlinePatterns = self.inlinePatterns
-        md.treeprocessors.register(inlineProcessor, 'smarty', 2)
+        md.treeprocessors.register(inlineProcessor, 'smarty', 6)
         md.ESCAPED_CHARS.extend(['"', "'"])
 
 

--- a/tests/test_syntax/extensions/test_smarty.py
+++ b/tests/test_syntax/extensions/test_smarty.py
@@ -198,3 +198,26 @@ class TestSmartyCustomSubstitutions(TestCase):
             'Must not be confused with &sbquo;ndash&lsquo;  (\u2013) \u2026 ]</p>'
         )
         self.assertMarkdownRenders(text, html)
+
+
+class TestSmartyAndToc(TestCase):
+
+    default_kwargs = {
+        'extensions': ['smarty', 'toc'],
+    }
+
+    def test_smarty_and_toc(self):
+        self.assertMarkdownRenders(
+            '# *Foo* --- `bar`',
+            '<h1 id="foo-bar"><em>Foo</em> &mdash; <code>bar</code></h1>',
+            expected_attrs={
+                'toc_tokens': [
+                    {
+                        'level': 1,
+                        'id': 'foo-bar',
+                        'name': 'Foo &mdash; bar',
+                        'children': [],
+                    },
+                ],
+            },
+        )


### PR DESCRIPTION
And add a test for using smarty in ToC headers.

Fixes #1438.