### PR TITLE
Refactor abbr escaping

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Include `scripts/*.py` in the generated source tarballs (#1430).
 * Ensure lines after heading in loose list are properly detabbed (#1443).
 * Give smarty tree processor higher priority than toc (#1440).
-* Explicitly omit carrot (`^`) and backslash (`\`) from abbreviations (#1444).
+* Permit carrot (`^`) and omit backslash (`\`) from abbreviations (#1444).
 
 ## [3.5.2] -- 2024-01-10
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Include `scripts/*.py` in the generated source tarballs (#1430).
 * Ensure lines after heading in loose list are properly detabbed (#1443).
 * Give smarty tree processor higher priority than toc (#1440).
-* Permit carrot (`^`) and omit backslash (`\`) from abbreviations (#1444).
+* Permit carrots (`^`) and square brackets (`]`) but explicitly exclude
+  backslashs (`\`) from abbreviations (#1444).
 
 ## [3.5.2] -- 2024-01-10
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ensure lines after heading in loose list are properly detabbed (#1443).
 * Give smarty tree processor higher priority than toc (#1440).
 * Permit carrots (`^`) and square brackets (`]`) but explicitly exclude
-  backslashs (`\`) from abbreviations (#1444).
+  backslashes (`\`) from abbreviations (#1444).
 
 ## [3.5.2] -- 2024-01-10
 

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -36,9 +36,9 @@ will be rendered as:
 is maintained by the <abbr title="World Wide Web Consortium">W3C</abbr>.</p>
 ```
 
-The backslash (`\`) and left square bracket (`]`) are not permitted in an
-abbreviation. Any abbreviation definitions which include one will not be
-recognized as an abbreviation definition.
+The backslash (`\`) is not permitted in an abbreviation. Any abbreviation
+definitions which include one or more backslashes will not be recognized as an
+abbreviation definition.
 
 Usage
 -----

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -36,13 +36,9 @@ will be rendered as:
 is maintained by the <abbr title="World Wide Web Consortium">W3C</abbr>.</p>
 ```
 
-The following three characters are not permitted in an abbreviation. Any
-abbreviation definitions which include one will not be recognized as an
-abbreviation definition.
-
-1. carrot (`^`)
-2. backslash (`\`)
-3. left square bracket (`]`)
+The backslash (`\`) and left square bracket (`]`) are not permitted in an
+abbreviation. Any abbreviation definitions which include one will not be
+recognized as an abbreviation definition.
 
 Usage
 -----

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -37,8 +37,8 @@ is maintained by the <abbr title="World Wide Web Consortium">W3C</abbr>.</p>
 ```
 
 The backslash (`\`) is not permitted in an abbreviation. Any abbreviation
-definitions which include one or more backslashes will not be recognized as an
-abbreviation definition.
+definitions which include one or more backslashes between the square brackets
+will not be recognized as an abbreviation definition.
 
 Usage
 -----

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -41,7 +41,7 @@ class AbbrExtension(Extension):
 class AbbrPreprocessor(BlockProcessor):
     """ Abbreviation Preprocessor - parse text for abbr references. """
 
-    RE = re.compile(r'^[*]\[(?P<abbr>[^\]\\]*)\][ ]?:[ ]*\n?[ ]*(?P<title>.*)$', re.MULTILINE)
+    RE = re.compile(r'^[*]\[(?P<abbr>[^\\]*?)\][ ]?:[ ]*\n?[ ]*(?P<title>.*)$', re.MULTILINE)
 
     def test(self, parent: etree.Element, block: str) -> bool:
         return True

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -41,7 +41,7 @@ class AbbrExtension(Extension):
 class AbbrPreprocessor(BlockProcessor):
     """ Abbreviation Preprocessor - parse text for abbr references. """
 
-    RE = re.compile(r'^[*]\[(?P<abbr>[^\]\^\\]*)\][ ]?:[ ]*\n?[ ]*(?P<title>.*)$', re.MULTILINE)
+    RE = re.compile(r'^[*]\[(?P<abbr>[^\]\\]*)\][ ]?:[ ]*\n?[ ]*(?P<title>.*)$', re.MULTILINE)
 
     def test(self, parent: etree.Element, block: str) -> bool:
         return True
@@ -72,16 +72,8 @@ class AbbrPreprocessor(BlockProcessor):
         return False
 
     def _generate_pattern(self, text: str) -> str:
-        """
-        Given a string, returns a regex pattern to match that string.
-
-        'HTML' -> r'(?P<abbr>\b[H][T][M][L]\b)'
-
-        Note: we force each char as a literal match via a character set (in brackets)
-        as we don't know what they will be beforehand.
-
-        """
-        return f"(?P<abbr>\\b{ ''.join(f'[{ c }]' for c in text) }\\b)"
+        """ Given a string, returns a regex pattern to match that string. """
+        return f"(?P<abbr>\\b{ re.escape(text) }\\b)"
 
 
 class AbbrInlineProcessor(InlineProcessor):

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -261,25 +261,19 @@ class TestAbbr(TestCase):
             )
         )
 
-    def test_abbr_ignore_special_chars(self):
+    def test_abbr_ignore_backslash(self):
         self.assertMarkdownRenders(
             self.dedent(
                 r"""
-                \\foo bar\]bar baz]baz
+                \\foo
 
                 *[\\foo]: Not an abbreviation
-
-                *[bar\]bar]: Not an abbreviation
-
-                *[baz]baz]: Not an abbreviation
                 """
             ),
             self.dedent(
                 r"""
-                <p>\foo bar]bar baz]baz</p>
+                <p>\foo</p>
                 <p>*[\foo]: Not an abbreviation</p>
-                <p>*[bar]bar]: Not an abbreviation</p>
-                <p>*[baz]baz]: Not an abbreviation</p>
                 """
             )
         )
@@ -312,6 +306,22 @@ class TestAbbr(TestCase):
             self.dedent(
                 """
                 <p><abbr title="Abbreviation">ABBR^abbr</abbr></p>
+                """
+            )
+        )
+
+    def test_abbr_bracket(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                ABBR]abbr
+
+                *[ABBR]abbr]: Abbreviation
+                """
+            ),
+            self.dedent(
+                """
+                <p><abbr title="Abbreviation">ABBR]abbr</abbr></p>
                 """
             )
         )

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -24,6 +24,7 @@ from markdown.test_tools import TestCase
 
 
 class TestAbbr(TestCase):
+    maxDiff = None
 
     default_kwargs = {'extensions': ['abbr']}
 
@@ -264,24 +265,21 @@ class TestAbbr(TestCase):
         self.assertMarkdownRenders(
             self.dedent(
                 r"""
-                [^] [\\] [\]] []]
+                \\foo bar\]bar baz]baz
 
-                *[^]: Not an abbreviation
+                *[\\foo]: Not an abbreviation
 
-                *[\\]: Not an abbreviation
+                *[bar\]bar]: Not an abbreviation
 
-                *[\]]: Not an abbreviation
-
-                *[]]: Not an abbreviation
+                *[baz]baz]: Not an abbreviation
                 """
             ),
             self.dedent(
                 r"""
-                <p>[^] [\] []] []]</p>
-                <p>*[^]: Not an abbreviation</p>
-                <p>*[\]: Not an abbreviation</p>
-                <p>*[]]: Not an abbreviation</p>
-                <p>*[]]: Not an abbreviation</p>
+                <p>\foo bar]bar baz]baz</p>
+                <p>*[\foo]: Not an abbreviation</p>
+                <p>*[bar]bar]: Not an abbreviation</p>
+                <p>*[baz]baz]: Not an abbreviation</p>
                 """
             )
         )
@@ -298,6 +296,22 @@ class TestAbbr(TestCase):
             self.dedent(
                 """
                 <p><abbr title="Abbreviation">ABBR-abbr</abbr></p>
+                """
+            )
+        )
+
+    def test_abbr_carrot(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                ABBR^abbr
+
+                *[ABBR^abbr]: Abbreviation
+                """
+            ),
+            self.dedent(
+                """
+                <p><abbr title="Abbreviation">ABBR^abbr</abbr></p>
                 """
             )
         )


### PR DESCRIPTION
A alternate fix to #1444. This does not omit the use of carrots in abbreviations. It still omits backslashs, however. I played around with backslashes and it just doesn't make sense to support them as they have special meaning in the Markdown, not because of their use in regular expressions.