### PR TITLE
Fixed links to source code on GitHub from the documentation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [Contributing Guide](contributing.md) for details.
 
+## [unreleased]
+
+### Fixed
+
+* Fixed links to source code on GitHub from the documentation (#1453).
+
 ## [3.6] -- 2024-03-14
 
 ### Changed

--- a/docs/templates/python/nature/attribute.html
+++ b/docs/templates/python/nature/attribute.html
@@ -1,7 +1,7 @@
 {% extends "_base/attribute.html" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ attribute.filepath }}#L{{ attribute.lineno }}{% if attribute.endlineno > attribute.lineno %}-L{{ attribute.endlineno }}{% endif %}" title='View source code on GitHub'>&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ attribute.relative_filepath }}#L{{ attribute.lineno }}{% if attribute.endlineno > attribute.lineno %}-L{{ attribute.endlineno }}{% endif %}" title='View source code on GitHub'>&lsaquo;&rsaquo;</a>
   {% if config.show_symbol_type_heading %}<code class="doc-symbol doc-symbol-heading doc-symbol-attribute"></code>{% endif %}
   {%+ filter highlight(language="python", inline=True) %}
     {{ attribute_name }}{% if attribute.annotation %}: {{ attribute.annotation }}{% endif %}

--- a/docs/templates/python/nature/class.html
+++ b/docs/templates/python/nature/class.html
@@ -1,6 +1,6 @@
 {% extends "_base/class.html" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ class.filepath }}#L{{ class.lineno }}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ class.relative_filepath }}#L{{ class.lineno }}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
   {{ super() }}
 {% endblock heading %}

--- a/docs/templates/python/nature/function.html
+++ b/docs/templates/python/nature/function.html
@@ -1,6 +1,6 @@
 {% extends "_base/function.html" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ function.filepath }}#L{{ function.lineno }}{% if function.endlineno > function.lineno %}-L{{ function.endlineno }}{% endif %}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ function.relative_filepath }}#L{{ function.lineno }}{% if function.endlineno > function.lineno %}-L{{ function.endlineno }}{% endif %}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
   {{ super() }}
 {% endblock heading %}

--- a/docs/templates/python/nature/module.html
+++ b/docs/templates/python/nature/module.html
@@ -1,6 +1,6 @@
 {% extends "_base/module.html" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ module.filepath }}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ module.relative_filepath }}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
   {{ super() }}
 {% endblock heading %}


### PR DESCRIPTION
With the current version, if you open e.g. [this page](https://python-markdown.github.io/reference/markdown/blockprocessors/), the `‹›` links on the right side of the page will point to URLs like `https://github.com/Python-Markdown/markdown/tree/3.6//home/runner/work/markdown/markdown/md/markdown/blockprocessors.py` which are wrong (note the `/home/runner/work/` part).

This commit fixes them by replacing `filepath` with `relative_filepath`. It seems to work locally for me, but needs to be tested on our main documentation website.