### PR TITLE
Abbr Extension: Definition Sorting and Glossary storage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,12 +33,8 @@ abbreviation, which may be useful for documents that uses two terms with
 identical abbreviations.
 
 Added an optional `glossary` configuration option to the abbreviations extension.
-This provides a simple and efficient way to apply abbreviations to every page.
-
-Added an optional `use_last_abbr` configuration option to the abbreviations
-extension. Default (`True`) maintains the existing behavior. `False` causes
-the extension to only use the first instance of an abbreviation, rather than
-the last. 
+This provides a simple and efficient way to apply a dictionary of abbreviations
+to every page.
 
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,10 @@ better reflects what it is. `AbbrPreprocessor` has been deprecated.
 
 A call to `Markdown.reset()` now clears all previously defined abbreviations.
 
+Abbreviations are now sorted by length before executing `AbbrTreeprocessor`
+to ensure that multi-word abbreviations are implemented even if an abbreviation
+exists for one of those component words.
+
 ### Fixed
 
 * Fixed links to source code on GitHub from the documentation (#1453).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,16 +27,18 @@ Abbreviations are now sorted by length before executing `AbbrTreeprocessor`
 to ensure that multi-word abbreviations are implemented even if an abbreviation
 exists for one of those component words. (#1465)
 
-Added an optional `use_last_abbr` configuration option to the abbreviations
-extension. Default (`True`) maintains the existing behavior. `False` causes
-the extension to only use the first instance of an abbreviation, rather than
-the last.
-
 Empty abbreviations are now skipped by `AbbrTreeprocessor`. This avoids applying
 abbr tags to text without a title value. This also allows disabling an
 abbreviation, which may be useful for documents that uses two terms with
 identical abbreviations.
 
+Added an optional `glossary` configuration option to the abbreviations extension.
+This provides a simple and efficient way to apply abbreviations to every page.
+
+Added an optional `use_last_abbr` configuration option to the abbreviations
+extension. Default (`True`) maintains the existing behavior. `False` causes
+the extension to only use the first instance of an abbreviation, rather than
+the last. 
 
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,7 +25,19 @@ A call to `Markdown.reset()` now clears all previously defined abbreviations.
 
 Abbreviations are now sorted by length before executing `AbbrTreeprocessor`
 to ensure that multi-word abbreviations are implemented even if an abbreviation
-exists for one of those component words.
+exists for one of those component words. (#1465)
+
+Added an optional `use_last_abbr` configuration option to the abbreviations
+extension. Default (`True`) maintains the existing behavior. `False` causes
+the extension to only use the first instance of an abbreviation, rather than
+the last.
+
+Empty abbreviations are now skipped by `AbbrTreeprocessor`. This avoids applying
+abbr tags to text without a title value. This also allows disabling an
+abbreviation, which may be useful for documents that uses two terms with
+identical abbreviations.
+
+
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,14 +27,15 @@ Abbreviations are now sorted by length before executing `AbbrTreeprocessor`
 to ensure that multi-word abbreviations are implemented even if an abbreviation
 exists for one of those component words. (#1465)
 
-Empty abbreviations are now skipped by `AbbrTreeprocessor`. This avoids applying
-abbr tags to text without a title value. This also allows disabling an
-abbreviation, which may be useful for documents that uses two terms with
-identical abbreviations.
+Abbreviations without a definition are now ignored. This avoids applying
+abbr tags to text without a title value.
 
 Added an optional `glossary` configuration option to the abbreviations extension.
 This provides a simple and efficient way to apply a dictionary of abbreviations
 to every page.
+
+Abbreviations can now be disabled by setting their definition to `""` or `''`.
+This can be useful when using the `glossary` option.
 
 
 ### Fixed

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -51,7 +51,20 @@ Usage
 See [Extensions](index.md) for general extension usage. Use `abbr` as the name
 of the extension.
 
-This extension does not accept any special configuration options.
+The following options are provided to configure the output:
+
+* **`use_last_abbr`**:
+    `True` to use the last instance of an abbreviation, rather than the first instance.
+
+    This is useful when auto-appending glossary files to pages while still wanting the page's
+    abbreviations to take precedence. Not recommended for use with the `glossary` option.
+
+* **`glossary`**:
+    Path to a Markdown file containing abbreviations to be applied to every page.
+
+    The abbreviations from this file will be the default abbreviations applied to every page with
+    abbreviations defined on the page taking precedence (unless also using `use_last_abbr`). The
+    glossary syntax should use the same Markdown syntax described on this page.
 
 A trivial example:
 

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -1,10 +1,5 @@
 title: Abbreviations Extension
 
-ABBR
-
-*[ABBR]: Abbreviation
-*[ABBR]: Override Ignored
-
 Abbreviations
 =============
 
@@ -60,4 +55,16 @@ A trivial example:
 
 ```python
 markdown.markdown(some_text, extensions=['abbr'])
+```
+
+Disabling Abbreviations
+-----------------------
+
+When using the `glossary` option, there may be times when you need to turn off
+a specific abbreviation. To do this, set the abbreviation to `''` or `""`.
+
+```md
+The HTML abbreviation is disabled on this page.
+
+*[HTML]: ''
 ```

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -1,5 +1,10 @@
 title: Abbreviations Extension
 
+ABBR
+
+*[ABBR]: Abbreviation
+*[ABBR]: Override Ignored
+
 Abbreviations
 =============
 

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -53,18 +53,8 @@ of the extension.
 
 The following options are provided to configure the output:
 
-* **`use_last_abbr`**:
-    `True` to use the last instance of an abbreviation, rather than the first instance.
-
-    This is useful when auto-appending glossary files to pages while still wanting the page's
-    abbreviations to take precedence. Not recommended for use with the `glossary` option.
-
 * **`glossary`**:
-    Path to a Markdown file containing abbreviations to be applied to every page.
-
-    The abbreviations from this file will be the default abbreviations applied to every page with
-    abbreviations defined on the page taking precedence (unless also using `use_last_abbr`). The
-    glossary syntax should use the same Markdown syntax described on this page.
+    A dictionary where the `key` is the abbreviation and the `value` is the definition.
 
 A trivial example:
 

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -146,14 +146,18 @@ class AbbrBlockprocessor(BlockProcessor):
         if m:
             abbr = m.group('abbr').strip()
             title = m.group('title').strip()
-            self.abbrs[abbr] = title
-            if block[m.end():].strip():
-                # Add any content after match back to blocks as separate block
-                blocks.insert(0, block[m.end():].lstrip('\n'))
-            if block[:m.start()].strip():
-                # Add any content before match back to blocks as separate block
-                blocks.insert(0, block[:m.start()].rstrip('\n'))
-            return True
+            if title and abbr:
+                if title == "''" or title == '""':
+                    self.abbrs.pop(abbr)
+                else:
+                    self.abbrs[abbr] = title
+                if block[m.end():].strip():
+                    # Add any content after match back to blocks as separate block
+                    blocks.insert(0, block[m.end():].lstrip('\n'))
+                if block[:m.start()].strip():
+                    # Add any content before match back to blocks as separate block
+                    blocks.insert(0, block[:m.start()].rstrip('\n'))
+                return True
         # No match. Restore block.
         blocks.insert(0, block)
         return False

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -23,7 +23,6 @@ for details.
 from __future__ import annotations
 
 from . import Extension
-from ..util import parseBoolValue
 from ..blockprocessors import BlockProcessor
 from ..inlinepatterns import InlineProcessor
 from ..treeprocessors import Treeprocessor
@@ -64,7 +63,7 @@ class AbbrExtension(Extension):
         """ Clear all abbreviations from the glossary. """
         self.glossary.clear()
 
-    def load_glossary(self, dictionary : dict[str, str]):
+    def load_glossary(self, dictionary: dict[str, str]):
         """Adds `dictionary` to our glossary. Any abbreviations that already exist will be overwritten."""
         if dictionary:
             self.glossary = {**dictionary, **self.glossary}
@@ -76,7 +75,7 @@ class AbbrExtension(Extension):
         self.abbrs.update(self.glossary)
         md.registerExtension(self)
         md.treeprocessors.register(AbbrTreeprocessor(md, self.abbrs), 'abbr', 7)
-        md.parser.blockprocessors.register(AbbrBlockprocessor(md.parser, self.abbrs, self.getConfigs()), 'abbr', 16)
+        md.parser.blockprocessors.register(AbbrBlockprocessor(md.parser, self.abbrs), 'abbr', 16)
 
 
 class AbbrTreeprocessor(Treeprocessor):
@@ -129,7 +128,7 @@ class AbbrBlockprocessor(BlockProcessor):
 
     RE = re.compile(r'^[*]\[(?P<abbr>[^\\]*?)\][ ]?:[ ]*\n?[ ]*(?P<title>.*)$', re.MULTILINE)
 
-    def __init__(self, parser: BlockParser, abbrs: dict, config: dict):
+    def __init__(self, parser: BlockParser, abbrs: dict):
         self.abbrs: dict = abbrs
         super().__init__(parser)
 

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -92,7 +92,9 @@ class AbbrTreeprocessor(Treeprocessor):
             # No abbreviations defined. Skip running processor.
             return
         # Build and compile regex
-        self.RE = re.compile(f"\\b(?:{ '|'.join(re.escape(key) for key in self.abbrs) })\\b")
+        abbr_list = list(self.abbrs.keys())
+        abbr_list.sort(key=len, reverse=True)
+        self.RE = re.compile(f"\\b(?:{ '|'.join(re.escape(key) for key in abbr_list) })\\b")
         # Step through tree and modify on matches
         self.iter_element(root)
 

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -20,7 +20,6 @@ Copyright 2004 Manfred Stienstra (the original version)
 License: BSD (see LICENSE.md for details).
 """
 
-import os
 from markdown.test_tools import TestCase
 from markdown import Markdown
 from markdown.extensions.abbr import AbbrExtension
@@ -120,13 +119,30 @@ class TestAbbr(TestCase):
             )
         )
 
+    def test_abbr_override(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                ABBR
+
+                *[ABBR]: Ignored
+                *[ABBR]: The override
+                """
+            ),
+            self.dedent(
+                """
+                <p><abbr title="The override">ABBR</abbr></p>
+                """
+            )
+        )
+
     def test_abbr_glossary(self):
 
         glossary = {
-            "ABBR" : "Abbreviation",
-            "abbr" : "Abbreviation",
-            "HTML" : "Hyper Text Markup Language",
-            "W3C" : "World Wide Web Consortium"
+            "ABBR": "Abbreviation",
+            "abbr": "Abbreviation",
+            "HTML": "Hyper Text Markup Language",
+            "W3C": "World Wide Web Consortium"
         }
 
         self.assertMarkdownRenders(
@@ -153,14 +169,14 @@ class TestAbbr(TestCase):
     def test_abbr_glossary_2(self):
 
         glossary = {
-            "ABBR" : "Abbreviation",
-            "abbr" : "Abbreviation",
-            "HTML" : "Hyper Text Markup Language",
-            "W3C" : "World Wide Web Consortium"
+            "ABBR": "Abbreviation",
+            "abbr": "Abbreviation",
+            "HTML": "Hyper Text Markup Language",
+            "W3C": "World Wide Web Consortium"
         }
 
         glossary_2 = {
-            "ABBR" : "New Abbreviation"
+            "ABBR": "New Abbreviation"
         }
 
         abbr_ext = AbbrExtension(glossary=glossary)
@@ -169,15 +185,15 @@ class TestAbbr(TestCase):
         self.assertMarkdownRenders(
             self.dedent(
                 """
-                ABBR abbr
-                
-                HTML W3C
+                ABBR abbr HTML W3C
                 """
             ),
             self.dedent(
                 """
-                <p><abbr title="New Abbreviation">ABBR</abbr> <abbr title="Abbreviation">abbr</abbr></p>
-                <p><abbr title="Hyper Text Markup Language">HTML</abbr> <abbr title="World Wide Web Consortium">W3C</abbr></p>
+                <p><abbr title="New Abbreviation">ABBR</abbr> """
+                + """<abbr title="Abbreviation">abbr</abbr> """
+                + """<abbr title="Hyper Text Markup Language">HTML</abbr> """
+                + """<abbr title="World Wide Web Consortium">W3C</abbr></p>
                 """
             ),
             extensions=[abbr_ext]
@@ -482,7 +498,3 @@ class TestAbbr(TestCase):
         self.assertEqual(ext.abbrs, {})
         md.convert('*[foo]: Foo Definition')
         self.assertEqual(ext.abbrs, {'foo': 'Foo Definition'})
-
-import unittest
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -471,18 +471,47 @@ class TestAbbr(TestCase):
         self.assertMarkdownRenders(
             self.dedent(
                 """
-                *[abbr]: Abbreviation Definition
+                *[abbr]:
+                Abbreviation Definition
 
                 abbr
 
+                *[]: Empty
+
                 *[abbr]:
+
+                *[ABBR]:
 
                 Testing document text.
                 """
             ),
             self.dedent(
                 """
-                <p>abbr</p>\n<p>Testing document text.</p>
+                <p><abbr title="Abbreviation Definition">abbr</abbr></p>\n"""
+                + """<p>*[]: Empty</p>\n"""
+                + """<p>*[<abbr title="Abbreviation Definition">abbr</abbr>]:</p>\n"""
+                + """<p>*[ABBR]:</p>\n"""
+                + """<p>Testing document text.</p>
+                """
+            )
+        )
+
+    def test_abbr_clear(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                *[abbr]: Abbreviation Definition
+                *[ABBR]: Abbreviation Definition
+
+                abbr ABBR
+
+                *[abbr]: ""
+                *[ABBR]: ''
+                """
+            ),
+            self.dedent(
+                """
+                <p>abbr ABBR</p>
                 """
             )
         )

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -478,6 +478,8 @@ class TestAbbr(TestCase):
 
                 *[]: Empty
 
+                *[ ]: Empty
+
                 *[abbr]:
 
                 *[ABBR]:
@@ -489,6 +491,7 @@ class TestAbbr(TestCase):
                 """
                 <p><abbr title="Abbreviation Definition">abbr</abbr></p>\n"""
                 + """<p>*[]: Empty</p>\n"""
+                + """<p>*[ ]: Empty</p>\n"""
                 + """<p>*[<abbr title="Abbreviation Definition">abbr</abbr>]:</p>\n"""
                 + """<p>*[ABBR]:</p>\n"""
                 + """<p>Testing document text.</p>

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -133,7 +133,26 @@ class TestAbbr(TestCase):
                 """
                 <p><abbr title="The override">ABBR</abbr></p>
                 """
-            )
+            ),
+            extensions=[AbbrExtension(use_last_abbr=True)]
+        )
+
+    def test_abbr_override_Ignored(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                ABBR
+
+                *[ABBR]: Abbreviation
+                *[ABBR]: Override Ignored
+                """
+            ),
+            self.dedent(
+                """
+                <p><abbr title="Abbreviation">ABBR</abbr></p>
+                """
+            ),
+            extensions=[AbbrExtension(use_last_abbr=False)]
         )
 
     def test_abbr_nested(self):
@@ -397,6 +416,26 @@ class TestAbbr(TestCase):
             self.dedent(
                 """
                 <p><abbr title="Abbreviation Definition">abbr</abbr>, <abbr title="Superset Definition">SS</abbr>, and <abbr title="Abbreviation Superset Definition">abbr-SS</abbr> should have different definitions.</p>
+                """
+            )
+        )
+
+    def test_abbr_empty(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                *[abbr]: Abbreviation Definition
+
+                abbr
+
+                *[abbr]:
+
+                Testing document text.
+                """
+            ),
+            self.dedent(
+                """
+                <p>abbr</p>\n<p>Testing document text.</p>
                 """
             )
         )

--- a/tests/test_syntax/extensions/test_abbr.py
+++ b/tests/test_syntax/extensions/test_abbr.py
@@ -383,6 +383,24 @@ class TestAbbr(TestCase):
             extensions=['abbr', 'attr_list']
         )
 
+    def test_abbr_superset_vs_subset(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                abbr, SS, and abbr-SS should have different definitions.
+                
+                *[abbr]: Abbreviation Definition
+                *[abbr-SS]: Abbreviation Superset Definition
+                *[SS]: Superset Definition
+                """
+            ),
+            self.dedent(
+                """
+                <p><abbr title="Abbreviation Definition">abbr</abbr>, <abbr title="Superset Definition">SS</abbr>, and <abbr title="Abbreviation Superset Definition">abbr-SS</abbr> should have different definitions.</p>
+                """
+            )
+        )
+
     def test_abbr_reset(self):
         ext = AbbrExtension()
         md = Markdown(extensions=[ext])


### PR DESCRIPTION
Several changes/features here.  All input welcome on each.  

* **Sorting**: A simple sort by length to process longer abbreviations first solves all instances of smaller abbreviations preventing longer ones from being used.
* `glossary`: An option to include a Markdown file with abbreviations to apply to every page.
* `use_last_abbr`: An option to only keep the first instance of an abbreviation (useful when using other methods to append glossaries to pages).

The glossary ended up being the more complex of the three and involved replicating some of the code/process from **core.py**.