### PR TITLE
Use correct import path in `abbr.py`

### DIFF
--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -33,7 +33,7 @@ import xml.etree.ElementTree as etree
 
 if TYPE_CHECKING:  # pragma: no cover
     from .. import Markdown
-    from ..blockparsers import BlockParser
+    from ..blockparser import BlockParser
 
 
 class AbbrExtension(Extension):


### PR DESCRIPTION
This is the module: https://github.com/Python-Markdown/markdown/blob/master/markdown/blockparser.py