### PR TITLE
Add Python 3.13 and drop Python 3.8

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,8 +22,6 @@ jobs:
       matrix:
         tox-env: [py39, py310, py311, py312, py313, pypy38, pypy39, pypy310, pygments]
         include:
-          - tox-env: py38
-            python-version: '3.8'
           - tox-env: py39
             python-version: '3.9'
           - tox-env: py310

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,7 @@ jobs:
             python-version: '3.11'
           - tox-env: py312
             python-version: '3.12'
-            - tox-env: py313
+          - tox-env: py313
             python-version: '3.13'
           - tox-env: pypy38
             python-version: pypy-3.8

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py39, py310, py311, py312, py313, pypy38, pypy39, pypy310, pygments]
+        tox-env: [py39, py310, py311, py312, py313, pypy39, pypy310, pygments]
         include:
           - tox-env: py39
             python-version: '3.9'
@@ -32,8 +32,6 @@ jobs:
             python-version: '3.12'
           - tox-env: py313
             python-version: '3.13'
-          - tox-env: pypy38
-            python-version: pypy-3.8
           - tox-env: pypy39
             python-version: pypy-3.9
           - tox-env: pypy310

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py38, py39, py310, py311, py312, pypy38, pypy39, pypy310, pygments]
+        tox-env: [py39, py310, py311, py312, py313, pypy38, pypy39, pypy310, pygments]
         include:
           - tox-env: py38
             python-version: '3.8'
@@ -32,6 +32,8 @@ jobs:
             python-version: '3.11'
           - tox-env: py312
             python-version: '3.12'
+            - tox-env: py313
+            python-version: '3.13'
           - tox-env: pypy38
             python-version: pypy-3.8
           - tox-env: pypy39

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -48,6 +48,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         sudo apt-get install libtidy-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
     {name = 'Isaac Muse'}
 ]
 license = {file = 'LICENSE.md'}
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     "importlib-metadata>=4.4;python_version<'3.10'"
 ]
@@ -29,11 +29,11 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39, 310, 311, 312, 313}, pypy{38, 39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{39, 310, 311, 312, 313}, pypy{39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38, 39, 310, 311, 312}, pypy{38, 39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{39, 310, 311, 312, 313}, pypy{38, 39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Yesterday (2024-10-07), Python 3.13 was released and 3.8 reached end-of-life. This adjusts Python-Markdown's meta-data and tests to match.

However, I don't expect to immediately merge this. We can wait until we know we are working on our next major release. That is, unless there are some failing tests in 3.13.