### PR TITLE
Backslash Unescape IDs set via `attr_list` on `toc`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * DRY fix in `abbr` extension by introducing method `create_element` (#1483).
 
+### Fixed
+
+* Backslash Unescape IDs set via `attr_list` on `toc` (#1493).
+
 ## [3.7] -- 2024-08-16
 
 ### Changed

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -391,7 +391,7 @@ class TocTreeprocessor(Treeprocessor):
                 if int(el.tag[-1]) >= self.toc_top and int(el.tag[-1]) <= self.toc_bottom:
                     toc_tokens.append({
                         'level': int(el.tag[-1]),
-                        'id': el.attrib["id"],
+                        'id': unescape(el.attrib["id"]),
                         'name': name,
                         'html': innerhtml,
                         'data-toc-label': data_toc_label

--- a/tests/test_syntax/extensions/test_attr_list.py
+++ b/tests/test_syntax/extensions/test_attr_list.py
@@ -72,6 +72,13 @@ class TestAttrList(TestCase):
             '<h1 foo="&quot;bar">Heading</h1>'
         )
 
+    def test_backslash_escape_value(self):
+        self.assertMarkdownRenders(
+            '# `*Foo*` { id="\\*Foo\\*" }',
+            '<h1 id="*Foo*"><code>*Foo*</code></h1>'
+        )
+
+
     def test_table_td(self):
         self.assertMarkdownRenders(
             self.dedent(

--- a/tests/test_syntax/extensions/test_attr_list.py
+++ b/tests/test_syntax/extensions/test_attr_list.py
@@ -78,7 +78,6 @@ class TestAttrList(TestCase):
             '<h1 id="*Foo*"><code>*Foo*</code></h1>'
         )
 
-
     def test_table_td(self):
         self.assertMarkdownRenders(
             self.dedent(

--- a/tests/test_syntax/extensions/test_toc.py
+++ b/tests/test_syntax/extensions/test_toc.py
@@ -974,6 +974,32 @@ class TestTOC(TestCase):
             extensions=['toc']
         )
 
+    def test_escaped_char_in_attr_list(self):
+        self.assertMarkdownRenders(
+            r'# `*Foo*` { id="\*Foo\*" }',
+            '<h1 id="*Foo*"><code>*Foo*</code></h1>',
+            expected_attrs={
+                'toc': (
+                    '<div class="toc">\n'
+                      '<ul>\n'                                                           # noqa
+                        '<li><a href="#*Foo*">*Foo*</a></li>\n'                          # noqa
+                      '</ul>\n'                                                          # noqa
+                    '</div>\n'                                                           # noqa
+                ),
+                'toc_tokens': [
+                    {
+                        'level': 1,
+                        'id': '*Foo*',
+                        'name': '*Foo*',
+                        'html': '<code>*Foo*</code>',
+                        'data-toc-label': '',
+                        'children': []
+                    }
+                ]
+            },
+            extensions=['toc', 'attr_list']
+        )
+
     def testAutoLinkEmail(self):
         self.assertMarkdownRenders(
             '## <foo@example.org>',


### PR DESCRIPTION
Fixes #1493.