### PR TITLE
Yaml can be indented only two spaces, so we need to account for that

### DIFF
--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -21,17 +21,18 @@ for details.
 
 from __future__ import annotations
 
-from . import Extension
-from ..preprocessors import Preprocessor
-import re
 import logging
+import re
 from typing import Any
+
+from ..preprocessors import Preprocessor
+from . import Extension
 
 log = logging.getLogger('MARKDOWN')
 
 # Global Vars
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
-META_MORE_RE = re.compile(r'^[ ]{4,}(?P<value>.*)')
+META_MORE_RE = re.compile(r'^[ ]{2,}(?P<value>.*)')
 BEGIN_RE = re.compile(r'^-{3}(\s.*)?')
 END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -26,6 +26,7 @@ continue to work as advertised. This used to be accomplished by `doctests`.
 """
 
 import unittest
+
 import markdown
 
 
@@ -79,6 +80,23 @@ class TestMetaData(unittest.TestCase):
 
     def setUp(self):
         self.md = markdown.Markdown(extensions=['meta'])
+
+    def test_yaml_indented_two_spaces(self):
+        """Yaml but a list indented two spaces"""
+
+        text = '''---
+Author: John Doe
+Tags:
+  - hello
+  - world
+---
+Paragraph'''
+        text = self.md.convert(text)
+        self.assertEqual(text, "<p>Paragraph</p>")
+        self.assertEqual(self.md.Meta, {
+            'author': ['John Doe'],
+            'tags': ['', '- hello', '- world']
+        })
 
     def testBasicMetaData(self):
         """ Test basic metadata. """


### PR DESCRIPTION
When you're using yaml for the metadata part and you've got something like a list that is only indented two spaces (which also is valid yaml). In a case like this, that extra data is omitted in the final metadata. So this PR aims to fix that particular issue. 