### PR TITLE
Adjust `md_in_html` "markdown" blocks to process content consistently

### DIFF
--- a/.spell-dict
+++ b/.spell-dict
@@ -178,7 +178,7 @@ plugins
 configs
 pre
 formatters
-
+unflattened
 dedented
 Setext
 unindented

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,10 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Backslash Unescape IDs set via `attr_list` on `toc` (#1493).
-* `md_in_html` should now process content inside "markdown" blocks a similar way
+* `md_in_html` will process content inside "markdown" blocks a similar way
   as they are parsed outside of "markdown" blocks giving a more consistent
   expectation to external extensions (#1503).
-* `md_in_html` should not handle tags within inline code blocks better (#1075).
+* `md_in_html` handle tags within inline code blocks better (#1075).
+* `md_in_html` fix handling of one-liner block HTML handling (#1074)
 
 ## [3.7] -- 2024-08-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Backslash Unescape IDs set via `attr_list` on `toc` (#1493).
+* `md_in_html` should now process content inside "markdown" blocks a similar way
+  as they are parsed outside of "markdown" blocks giving a more consistent
+  expectation to external extensions (#1503).
 
 ## [3.7] -- 2024-08-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `md_in_html` should now process content inside "markdown" blocks a similar way
   as they are parsed outside of "markdown" blocks giving a more consistent
   expectation to external extensions (#1503).
+* `md_in_html` should not handle tags within inline code blocks better (#1075).
 
 ## [3.7] -- 2024-08-16
 

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -179,8 +179,9 @@ class HTMLExtractorExtra(HTMLExtractor):
                             child.tail = None
                             state = child.attrib.get('markdown', 'off')
 
-                            # If the tail is just a new line, omit it.
-                            tail = '' if tail == '\n' else '\n' + tail
+                            # Add a newline to tail if it is not just a trailing newline
+                            if tail != '\n':
+                                tail = '\n' + tail
 
                             # Process the block nested under the span appropriately
                             if state in ('span', 'block'):

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -253,13 +253,12 @@ class HTMLExtractorExtra(HTMLExtractor):
         if self.inraw or not self.mdstack:
             super().handle_empty_tag(data, is_block)
         else:
-            if self.at_line_start() or self.intail:
-                if is_block:
-                    self.handle_data('\n' + self.md.htmlStash.store(data) + '\n\n')
-                else:
-                    self.handle_data(self.md.htmlStash.store(data))
+            if self.at_line_start() and is_block:
+                self.handle_data('\n' + self.md.htmlStash.store(data) + '\n\n')
+            elif self.mdstate and self.mdstate[-1] == "off":
+                self.handle_data(self.md.htmlStash.store(data))
             else:
-                self.treebuilder.data(data)
+                self.handle_data(data)
 
     def parse_pi(self, i: int) -> int:
         if self.at_line_start() or self.intail or self.mdstack:

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -253,10 +253,13 @@ class HTMLExtractorExtra(HTMLExtractor):
         if self.inraw or not self.mdstack:
             super().handle_empty_tag(data, is_block)
         else:
-            if self.at_line_start() and is_block:
-                self.handle_data('\n' + self.md.htmlStash.store(data) + '\n\n')
+            if self.at_line_start() or self.intail:
+                if is_block:
+                    self.handle_data('\n' + self.md.htmlStash.store(data) + '\n\n')
+                else:
+                    self.handle_data(self.md.htmlStash.store(data))
             else:
-                self.handle_data(self.md.htmlStash.store(data))
+                self.treebuilder.data(data)
 
     def parse_pi(self, i: int) -> int:
         if self.at_line_start() or self.intail or self.mdstack:

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -181,11 +181,15 @@ class HTMLExtractorExtra(HTMLExtractor):
 
                             # Add a newline to tail if it is not just a trailing newline
                             if tail != '\n':
-                                tail = '\n' + tail
+                                tail = '\n' + tail.rstrip('\n')
+
+                            # Ensure there is an empty new line between blocks
+                            if not text.endswith('\n\n'):
+                                text = text.rstrip('\n') + '\n\n'
 
                             # Process the block nested under the span appropriately
                             if state in ('span', 'block'):
-                                current.text = f'{text}\n{self.md.htmlStash.store(child)}{tail}'
+                                current.text = f'{text}{self.md.htmlStash.store(child)}{tail}'
                                 last.append(child)
                             else:
                                 # Non-Markdown HTML will not be recursively parsed for Markdown,
@@ -194,7 +198,7 @@ class HTMLExtractorExtra(HTMLExtractor):
                                 # processing.
                                 child.attrib.pop('markdown')
                                 [c.attrib.pop('markdown', None) for c in child.iter()]
-                                current.text = f'{text}\n{self.md.htmlStash.store(child)}{tail}'
+                                current.text = f'{text}{self.md.htmlStash.store(child)}{tail}'
                         # Target the child elements that have been expanded.
                         current = last.pop(0) if last else None
 

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -174,8 +174,8 @@ class HTMLExtractorExtra(HTMLExtractor):
                     while current is not None:
                         for child in list(current):
                             current.remove(child)
-                            text = current.text if current.text is not None else  ''
-                            tail = child.tail if child.tail is not None else  ''
+                            text = current.text if current.text is not None else ''
+                            tail = child.tail if child.tail is not None else ''
                             child.tail = None
                             state = child.attrib.get('markdown', 'off')
 
@@ -183,7 +183,7 @@ class HTMLExtractorExtra(HTMLExtractor):
                             if tail == '\n':
                                 tail = ''
 
-                            # Process the block nested under the spac appropriately
+                            # Process the block nested under the span appropriately
                             if state in ('span', 'block'):
                                 current.text = text + '\n' + self.md.htmlStash.store(child) + '\n' + tail
                                 last.append(child)
@@ -339,7 +339,7 @@ class MarkdownInHtmlProcessor(BlockProcessor):
                     if child is None:
                         element.text = block[start:end]
                     else:
-                        child.tail = (child.tail if child.tail is not None else '')+ block[start:end]
+                        child.tail = (child.tail if child.tail is not None else '') + block[start:end]
                 start = end
 
             # Insert anything left after last element

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -331,28 +331,30 @@ class MarkdownInHtmlProcessor(BlockProcessor):
                     # Replace the placeholder with the element and process it.
                     # Content after the placeholder should be attached to the tail.
                     if child is None:
-                        element.text = block[start:end]
+                        element.text += block[start:end]
                     else:
-                        child.tail = f"{child.tail if child.tail is not None else ''}{block[start:end]}"
+                        child.tail += block[start:end]
                     element.append(el)
                     self.parse_element_content(el)
                     child = el
+                    if child.tail is None:
+                        child.tail = ''
                     self.parser.md.htmlStash.rawHtmlBlocks.pop(index)
                     self.parser.md.htmlStash.rawHtmlBlocks.insert(index, '')
 
                 else:
                     # Not an element object, so insert content back into the element
                     if child is None:
-                        element.text = block[start:end]
+                        element.text += block[start:end]
                     else:
-                        child.tail = f"{child.tail if child.tail is not None else ''}{block[start:end]}"
+                        child.tail += block[start:end]
                 start = end
 
             # Insert anything left after last element
             if child is None:
-                element.text = block[start:]
+                element.text += block[start:]
             else:
-                child.tail = (child.tail if child.tail is not None else '') + block[start:]
+                child.tail += block[start:]
 
         else:
             # Disable inline parsing for everything else

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -265,8 +265,7 @@ class HTMLExtractorExtra(HTMLExtractor):
         if self.inraw or not self.mdstack:
             super().handle_data(data)
         else:
-            for i in range(len(self.mdstarted)):
-                self.mdstarted[i] = False
+            self.mdstarted[-1] = False
             self.treebuilder.data(data)
 
     def handle_empty_tag(self, data, is_block):

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -188,9 +188,14 @@ class HTMLExtractorExtra(HTMLExtractor):
                                 current.text = f'{text}\n{self.md.htmlStash.store(child)}{tail}'
                                 last.append(child)
                             else:
+                                # Non-Markdown HTML will not be recursively parsed for Markdown,
+                                # so we can just remove markers and leave them unflattened.
+                                # Additionally, we don't need to append to our list for further
+                                # processing.
                                 child.attrib.pop('markdown')
                                 [c.attrib.pop('markdown', None) for c in child.iter()]
                                 current.text = f'{text}\n{self.md.htmlStash.store(child)}{tail}'
+                        # Target the child elements that have been expanded.
                         current = last.pop(0) if last else None
 
                     self.cleandoc.append(self.md.htmlStash.store(element))
@@ -322,8 +327,9 @@ class MarkdownInHtmlProcessor(BlockProcessor):
                 el = self.parser.md.htmlStash.rawHtmlBlocks[index]
                 end = m.start()
 
-                # Cut out the placeholder and and insert the processed element back in.
                 if isinstance(el, etree.Element):
+                    # Replace the placeholder with the element and process it.
+                    # Content after the placeholder should be attached to the tail.
                     if child is None:
                         element.text = block[start:end]
                     else:

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -158,7 +158,13 @@ AUTOLINK_RE = r'<((?:[Ff]|[Hh][Tt])[Tt][Pp][Ss]?://[^<>]*)>'
 AUTOMAIL_RE = r'<([^<> !]+@[^@<> ]+)>'
 """ Match an automatic email link (`<me@example.com>`). """
 
-HTML_RE = r'(<(\/?[a-zA-Z][^<>@ ]*( [^<>]*)?|!--(?:(?!<!--|-->).)*--)>)'
+HTML_RE = (
+    r'(<(\/?[a-zA-Z][^<>@ ]*( [^<>]*)?|'           # Tag
+    r'!--(?:(?!<!--|-->).)*--|'                    # Comment
+    r'[?](?:(?!<[?]|[?]>).)*[?]|'                  # Processing instruction
+    r'<!\[CDATA\[(?:(?!<!\[CDATA\[|\]\]).)*\]\]|'  # `CDATA`
+    ')>)'
+)
 """ Match an HTML tag (`<...>`). """
 
 ENTITY_RE = r'(&(?:\#[0-9]+|\#x[0-9a-fA-F]+|[a-zA-Z0-9]+);)'

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -159,10 +159,10 @@ AUTOMAIL_RE = r'<([^<> !]+@[^@<> ]+)>'
 """ Match an automatic email link (`<me@example.com>`). """
 
 HTML_RE = (
-    r'(<(\/?[a-zA-Z][^<>@ ]*( [^<>]*)?|'           # Tag
-    r'!--(?:(?!<!--|-->).)*--|'                    # Comment
-    r'[?](?:(?!<[?]|[?]>).)*[?]|'                  # Processing instruction
-    r'<!\[CDATA\[(?:(?!<!\[CDATA\[|\]\]).)*\]\]|'  # `CDATA`
+    r'(<(\/?[a-zA-Z][^<>@ ]*( [^<>]*)?|'          # Tag
+    r'!--(?:(?!<!--|-->).)*--|'                   # Comment
+    r'[?](?:(?!<[?]|[?]>).)*[?]|'                 # Processing instruction
+    r'!\[CDATA\[(?:(?!<!\[CDATA\[|\]\]>).)*\]\]'  # `CDATA`
     ')>)'
 )
 """ Match an HTML tag (`<...>`). """

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1314,6 +1314,48 @@ class TestMdInHTML(TestCase):
             extensions=['md_in_html']
         )
 
+    def test_md1_oneliner_block_tail(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="a" markdown="block"><div class="b" markdown="block">
+                **foo**
+                </div><div class="c" markdown="block"><div class="d" markdown="block">
+                *bar*
+                </div></div></div>
+                """
+            ),
+            '<div class="a">\n'
+            '<div class="b">\n'
+            '<p><strong>foo</strong></p>\n'
+            '</div>\n'
+            '<div class="c">\n'
+            '<div class="d">\n'
+            '<p><em>bar</em></p>\n'
+            '</div>\n'
+            '</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_oneliner_block_complex_start_tail(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
+        self.assertMarkdownRenders(
+            '<div class="a" markdown><div class="b" markdown>**foo**</div>'
+            '<div class="c" markdown>*bar*</div><div class="d">*not md*</div></div>',
+            '<div class="a">\n'
+            '<div class="b">\n'
+            '<p><strong>foo</strong></p>\n'
+            '</div>\n'
+            '<div class="c">\n'
+            '<p><em>bar</em></p>\n'
+            '</div>\n'
+            '<div class="d">*not md*</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
     def test_md1_oneliner_block_start(self):
         # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1274,6 +1274,107 @@ class TestMdInHTML(TestCase):
             extensions=['md_in_html']
         )
 
+    def test_md1_oneliner_block(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '<div class="outer" markdown="block"><div class="inner" markdown="block">*foo*</div></div>'
+            ),
+            '<div class="outer">\n'
+            '<div class="inner">\n'
+            '<p><em>foo</em></p>\n'
+            '</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_oneliner_block_mixed(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="a" markdown="block"><div class="b" markdown="block">
+
+                <div class="c" markdown="block"><div class="d" markdown="block">
+                *foo*
+                </div></div>
+
+                </div></div>
+                """
+            ),
+            '<div class="a">\n'
+            '<div class="b">\n'
+            '<div class="c">\n'
+            '<div class="d">\n'
+            '<p><em>foo</em></p>\n'
+            '</div>\n'
+            '</div>\n'
+            '</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_oneliner_block_start(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="block"><div class="inner" markdown="block">
+                *foo*
+                </div></div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<div class="inner">\n'
+            '<p><em>foo</em></p>\n'
+            '</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_oneliner_block_span(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                '<div class="outer" markdown="block"><div class="inner" markdown="span">*foo*</div></div>'
+            ),
+            '<div class="outer">\n'
+            '<div class="inner"><em>foo</em></div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_oneliner_block_span_start(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="block"><div class="inner" markdown="span">
+                *foo*
+                </div></div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<div class="inner">\n'
+            '<em>foo</em>\n'
+            '</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_oneliner_span_block_start(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="span"><div class="inner" markdown="block">
+                *foo*
+                </div>
+                *foo*
+                </div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<div class="inner">\n'
+            '<em>foo</em>\n'
+            '</div>\n\n'
+            '<em>foo</em></div>',
+            extensions=['md_in_html']
+        )
 
     def test_md1_code_comment(self):
 

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1214,25 +1214,66 @@ class TestMdInHTML(TestCase):
                 """
                 <div class="outer" markdown="1">
 
-                Code: `<label></input></label>`
+                Code: `<label><input/></label>`
 
                 </div>
 
                 <div class="outer" markdown="1">
 
-                HTML: <label></input></label>
+                HTML: <label><input/></label>
 
                 </div>
                 """
             ),
             '<div class="outer">\n'
-            '<p>Code: <code>&lt;label&gt;&lt;/input&gt;&lt;/label&gt;</code></p>\n'
+            '<p>Code: <code>&lt;label&gt;&lt;input/&gt;&lt;/label&gt;</code></p>\n'
             '</div>\n'
             '<div class="outer">\n'
-            '<p>HTML: <label></input></label></p>\n'
+            '<p>HTML: <label><input/></label></p>\n'
             '</div>',
             extensions=['md_in_html']
         )
+
+    def test_md1_code_void_tag_multiline(self):
+
+        # https://github.com/Python-Markdown/markdown/issues/1075
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="1">
+
+                Code: `
+                <label>
+                <input/>
+                </label>
+                `
+
+                </div>
+
+                <div class="outer" markdown="1">
+
+                HTML:
+                <label>
+                <input/>
+                </label>
+
+                </div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<p>Code: <code>&lt;label&gt;\n'
+            '&lt;input/&gt;\n'
+            '&lt;/label&gt;</code></p>\n'
+            '</div>\n'
+            '<div class="outer">\n'
+            '<p>HTML:\n'
+            '<label>\n'
+            '<input/>\n'
+            '</label></p>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
 
     def test_md1_code_comment(self):
 

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1356,6 +1356,18 @@ class TestMdInHTML(TestCase):
             extensions=['md_in_html']
         )
 
+    def test_md1_oneliner_block_complex_fail(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
+        # Nested will fail because an inline tag is only considered at the beginning if it is not preceded by text.
+        self.assertMarkdownRenders(
+            '<div class="a" markdown>**strong**<div class="b" markdown>**strong**</div></div>',
+            '<div class="a">\n'
+            '<p><strong>strong</strong><div class="b" markdown><strong>strong</strong></p>\n'
+            '</div>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
     def test_md1_oneliner_block_start(self):
         # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1275,6 +1275,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_oneliner_block(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(
             self.dedent(
                 '<div class="outer" markdown="block"><div class="inner" markdown="block">*foo*</div></div>'
@@ -1288,6 +1289,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_oneliner_block_mixed(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1313,6 +1315,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_oneliner_block_start(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1330,6 +1333,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_oneliner_block_span(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(
             self.dedent(
                 '<div class="outer" markdown="block"><div class="inner" markdown="span">*foo*</div></div>'
@@ -1341,6 +1345,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_oneliner_block_span_start(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(
             self.dedent(
                 """
@@ -1358,6 +1363,7 @@ class TestMdInHTML(TestCase):
         )
 
     def test_md1_oneliner_span_block_start(self):
+        # https://github.com/Python-Markdown/markdown/issues/1074
         self.assertMarkdownRenders(
             self.dedent(
                 """

--- a/tests/test_syntax/extensions/test_md_in_html.py
+++ b/tests/test_syntax/extensions/test_md_in_html.py
@@ -1206,6 +1206,115 @@ class TestMdInHTML(TestCase):
             extensions=['md_in_html', 'footnotes']
         )
 
+    def test_md1_code_void_tag(self):
+
+        # https://github.com/Python-Markdown/markdown/issues/1075
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="1">
+
+                Code: `<label></input></label>`
+
+                </div>
+
+                <div class="outer" markdown="1">
+
+                HTML: <label></input></label>
+
+                </div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<p>Code: <code>&lt;label&gt;&lt;/input&gt;&lt;/label&gt;</code></p>\n'
+            '</div>\n'
+            '<div class="outer">\n'
+            '<p>HTML: <label></input></label></p>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_code_comment(self):
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="1">
+
+                Code: `<label><!-- **comment** --></label>`
+
+                </div>
+
+                <div class="outer" markdown="1">
+
+                HTML: <label><!-- **comment** --></label>
+
+                </div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<p>Code: <code>&lt;label&gt;&lt;!-- **comment** --&gt;&lt;/label&gt;</code></p>\n'
+            '</div>\n'
+            '<div class="outer">\n'
+            '<p>HTML: <label><!-- **comment** --></label></p>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_code_pi(self):
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="1">
+
+                Code: `<label><?php # echo '**simple**';?></label>`
+
+                </div>
+
+                <div class="outer" markdown="1">
+
+                HTML: <label><?php # echo '**simple**';?></label>
+
+                </div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<p>Code: <code>&lt;label&gt;&lt;?php # echo \'**simple**\';?&gt;&lt;/label&gt;</code></p>\n'
+            '</div>\n'
+            '<div class="outer">\n'
+            '<p>HTML: <label><?php # echo \'**simple**\';?></label></p>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
+    def test_md1_code_cdata(self):
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                <div class="outer" markdown="1">
+
+                Code: `<label><![CDATA[some stuff]]></label>`
+
+                </div>
+
+                <div class="outer" markdown="1">
+
+                HTML: <label><![CDATA[some stuff]]></label>
+
+                </div>
+                """
+            ),
+            '<div class="outer">\n'
+            '<p>Code: <code>&lt;label&gt;&lt;![CDATA[some stuff]]&gt;&lt;/label&gt;</code></p>\n'
+            '</div>\n'
+            '<div class="outer">\n'
+            '<p>HTML: <label><![CDATA[some stuff]]></label></p>\n'
+            '</div>',
+            extensions=['md_in_html']
+        )
+
 
 def load_tests(loader, tests, pattern):
     """ Ensure `TestHTMLBlocks` doesn't get run twice by excluding it here. """

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ extras = docs
 deps = pyspelling
 commands =
     {envpython} -m mkdocs build --config-file {toxinidir}/mkdocs.yml
-    {envpython} -m pyspelling --config {toxinidir}/.pyspelling.yml
+    {envpython} -m pyspelling -j 4 --config {toxinidir}/.pyspelling.yml
 
 [testenv:checklinks]
 extras = docs


### PR DESCRIPTION
Ensure `md_in_html` processes content inside a "markdown" block the same way content is processed outside of a "markdown" block.

- Flatten the HTML content into placeholders so that the parser will treat the "markdown" block content in the same way it does when `md_in_html` is not enabled. The placeholders are expanded once the parser reaches them in a linear fashion. This allows extensions to deal with HTML content and consume it the same way it deals with them with them when the content is not nested under a "markdown" block.

- Instead of content being processed in dummy tags, content is now processed under the real parent allowing extensions to have better context to make better decisions.

Additionally, fix some issues with tags and inline code.

Also, fix some issues with one-liner block tags, e.g. `<tag><tag>...`

Resolves #1502 
Resolves #1075
Resolves #1074