### PR TITLE
WikiLinks extension: Allow literal dot in wikilink pattern

### DIFF
--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -51,7 +51,7 @@ class WikiLinkExtension(Extension):
         self.md = md
 
         # append to end of inline patterns
-        WIKILINK_RE = r'\[\[([\w0-9_ -]+)\]\]'
+        WIKILINK_RE = r'\[\[([\w0-9_ -\.]+)\]\]'
         wikilinkPattern = WikiLinksInlineProcessor(WIKILINK_RE, self.getConfigs())
         wikilinkPattern.md = md
         md.inlinePatterns.register(wikilinkPattern, 'wikilink', 75)


### PR DESCRIPTION
Having a literal dot in a wikilink is arguably a common use case, and allowing this library to recognize such patters would broaden its utility.

For context: I'm trying to use Python-Markdown to generate online documentation for a software package, and as part of that I'm transcoding roff man pages to html for publishing on the website. A roff man page typically has names such as `ad.1` or `afp.conf.5` and I would like to be able to create wikilinks to them.