### PR TITLE
Add special case for closing nested quotes; fixes #1514

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ensure `<center>` is treated like a block-level element (#1481).
 * Ensure that `abbr` extension respects `AtomicString` and does not process
   perceived abbreviations in these strings (#1512).
+* The `smarty` extension correctly renders nested closing quotes (#1514).
 
 ## [3.7] -- 2024-08-16
 

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -134,6 +134,8 @@ doubleQuoteStartRe = r'^"(?=%s\B)' % punctClass
 #   <p>He said, "'Quoted' words in a larger quote."</p>
 doubleQuoteSetsRe = r""""'(?=\w)"""
 singleQuoteSetsRe = r"""'"(?=\w)"""
+doubleQuoteSetsRe2 = r'(?<=%s)\'"' % closeClass
+singleQuoteSetsRe2 = r"(?<=%s)\"'" % closeClass
 
 # Special case for decade abbreviations (the '80s):
 decadeAbbrRe = r"(?<!\w)'(?=\d{2}s)"
@@ -143,7 +145,7 @@ openingDoubleQuotesRegex = r'%s"(?=\w)' % openingQuotesBase
 
 # Double closing quotes:
 closingDoubleQuotesRegex = r'"(?=\s)'
-closingDoubleQuotesRegex2 = '(?<=%s)"' % closeClass
+closingDoubleQuotesRegex2 = r'(?<=%s)"' % closeClass
 
 # Get most opening single quotes:
 openingSingleQuotesRegex = r"%s'(?=\w)" % openingQuotesBase
@@ -240,6 +242,8 @@ class SmartyExtension(Extension):
             (doubleQuoteStartRe, (rdquo,)),
             (doubleQuoteSetsRe, (ldquo + lsquo,)),
             (singleQuoteSetsRe, (lsquo + ldquo,)),
+            (doubleQuoteSetsRe2, (rsquo + rdquo,)),
+            (singleQuoteSetsRe2, (rdquo + rsquo,)),
             (decadeAbbrRe, (rsquo,)),
             (openingSingleQuotesRegex, (1, lsquo)),
             (closingSingleQuotesRegex, (rsquo,)),

--- a/tests/test_syntax/extensions/test_smarty.py
+++ b/tests/test_syntax/extensions/test_smarty.py
@@ -45,6 +45,18 @@ class TestSmarty(TestCase):
             '<p>&lsquo;Quoted &ldquo;words&rdquo; in a larger quote.&rsquo;</p>'
         )
         self.assertMarkdownRenders(
+            '"Quoted words at the \'end.\'"',
+            '<p>&ldquo;Quoted words at the &lsquo;end.&rsquo;&rdquo;</p>'
+        )
+        self.assertMarkdownRenders(
+            '\'Quoted words at the "end."\'',
+            '<p>&lsquo;Quoted words at the &ldquo;end.&rdquo;&rsquo;</p>'
+        )
+        self.assertMarkdownRenders(
+            '(He replied, "She said \'Hello.\'")',
+            '<p>(He replied, &ldquo;She said &lsquo;Hello.&rsquo;&rdquo;)</p>'
+        )
+        self.assertMarkdownRenders(
             '"quoted" text and **bold "quoted" text**',
             '<p>&ldquo;quoted&rdquo; text and <strong>bold &ldquo;quoted&rdquo; text</strong></p>'
         )

--- a/tests/test_syntax/extensions/test_smarty.py
+++ b/tests/test_syntax/extensions/test_smarty.py
@@ -57,6 +57,10 @@ class TestSmarty(TestCase):
             '<p>(He replied, &ldquo;She said &lsquo;Hello.&rsquo;&rdquo;)</p>'
         )
         self.assertMarkdownRenders(
+            '<span>He replied, "She said \'Hello.\'"</span>',
+            '<p><span>He replied, &ldquo;She said &lsquo;Hello.&rsquo;&rdquo;</span></p>'
+        )
+        self.assertMarkdownRenders(
             '"quoted" text and **bold "quoted" text**',
             '<p>&ldquo;quoted&rdquo; text and <strong>bold &ldquo;quoted&rdquo; text</strong></p>'
         )


### PR DESCRIPTION
This PR adds two more regular expressions to the smarty extension to handle nested quote marks at the end of a sentence, such as "She said 'Hello.'" Additional unit tests are included.