### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![BSD License][bsdlicense-button]][bsdlicense]
 [![Code of Conduct][codeofconduct-button]][Code of Conduct]
 
-[build-button]: https://github.com/Python-Markdown/markdown/workflows/CI/badge.svg?event=push
-[build]: https://github.com/Python-Markdown/markdown/actions?query=workflow%3ACI+event%3Apush
+[build-button]: https://github.com/Python-Markdown/markdown/actions/workflows/tox.yml/badge.svg
+[build]: https://github.com/Python-Markdown/markdown/actions/workflows/tox.yml
 [codecov-button]: https://codecov.io/gh/Python-Markdown/markdown/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/Python-Markdown/markdown
 [mdversion-button]: https://img.shields.io/pypi/v/Markdown.svg


### PR DESCRIPTION
The syntax/API for GHA badges (their workflow identification) changed over time, with the current CI status in repo readme shown as unknown.

This updates the URL syntax to show a green badge that the build is A-OK again…

_Preview: [janbrasna`@6b9b97#readme`](https://github.com/janbrasna/markdown/tree/6b9b978eb5bf1bca2f7d81f31dad8bce324d738a?tab=readme-ov-file#readme)_