### PR TITLE
Fix incorrect TOC list structure in docs

### DIFF
--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -49,10 +49,12 @@ would generate the following output:
 ```html
 <div class="toc">
   <ul>
-    <li><a href="#header-1">Header 1</a></li>
+    <li>
+      <a href="#header-1">Header 1</a>
       <ul>
         <li><a href="#header-2">Header 2</a></li>
       </ul>
+    </li>
   </ul>
 </div>
 <h1 id="header-1">Header 1</h1>
@@ -121,10 +123,12 @@ would generate the following output:
 ```html
 <div class="toc">
   <ul>
-    <li><a href="#functions">Functions</a></li>
+    <li>
+      <a href="#functions">Functions</a>
       <ul>
         <li><a href="#markdown">markdown.markdown</a></li>
       </ul>
+    </li>
   </ul>
 </div>
 <h1 id="functions">Functions</h1>


### PR DESCRIPTION
I initially thought the list hierarchy was implemented incorrectly and was ready to skip using this module. After testing, I realized that the issue was in the documentation, which had been incorrect for 16 years.