### PR TITLE
Update pypa/gh-action-pypi-publish to v1.12.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           python -m build
       - name: Publish to PyPI
         if: success()
-        uses: pypa/gh-action-pypi-publish@v1.1.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This is the first tag with support for metadata format 2.4 (including PEP 639), see pypa/gh-action-pypi-publish@10df67dae045599d4687ac5a225e5a0bf311f033.

This should fix the deploy action, which currently [fails](https://github.com/Python-Markdown/markdown/actions/runs/14363519015/job/40270725898) with the following error:
> Make sure the distribution includes the files where those fields are specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.

Although I have no good way to test that.