### PR TITLE
Ensure incomplete markup declaration in raw HTML doesn't crash parser.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 ### Fixed
 
+* Ensure incomplete markup declaration in raw HTML doesn't crash parser (#1534).
 * Fixed dropped content in `md_in_html` (#1526).
 * Fixed HTML handling corner case that prevented some content from not being rendered (#1528).
 

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -281,7 +281,7 @@ class HTMLExtractorExtra(HTMLExtractor):
     def parse_html_declaration(self, i: int) -> int:
         if self.at_line_start() or self.intail or self.mdstack:
             if self.rawdata[i:i+3] == '<![' and not self.rawdata[i:i+9] == '<![CDATA[':
-                # We have encountered the bug in #1534 (Python bug gh-77057).
+                # We have encountered the bug in #1534 (Python bug `gh-77057`).
                 # Provide an override until we drop support for Python < 3.13.
                 return self.parse_bogus_comment(i)
             # The same override exists in `HTMLExtractor` without the check

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -280,6 +280,10 @@ class HTMLExtractorExtra(HTMLExtractor):
 
     def parse_html_declaration(self, i: int) -> int:
         if self.at_line_start() or self.intail or self.mdstack:
+            if self.rawdata[i:i+3] == '<![' and not self.rawdata[i:i+9] == '<![CDATA[':
+                # We have encountered the bug in #1534 (Python bug gh-77057).
+                # Provide an override until we drop support for Python < 3.13.
+                return self.parse_bogus_comment(i)
             # The same override exists in `HTMLExtractor` without the check
             # for `mdstack`. Therefore, use parent of `HTMLExtractor` instead.
             return super(HTMLExtractor, self).parse_html_declaration(i)

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -276,7 +276,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
     def parse_html_declaration(self, i: int) -> int:
         if self.at_line_start() or self.intail:
             if self.rawdata[i:i+3] == '<![' and not self.rawdata[i:i+9] == '<![CDATA[':
-                # We have encountered the bug in #1534 (Python bug gh-77057).
+                # We have encountered the bug in #1534 (Python bug `gh-77057`).
                 # Provide an override until we drop support for Python < 3.13.
                 return self.parse_bogus_comment(i)
             return super().parse_html_declaration(i)

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -275,6 +275,10 @@ class HTMLExtractor(htmlparser.HTMLParser):
 
     def parse_html_declaration(self, i: int) -> int:
         if self.at_line_start() or self.intail:
+            if self.rawdata[i:i+3] == '<![' and not self.rawdata[i:i+9] == '<![CDATA[':
+                # We have encountered the bug in #1534 (Python bug gh-77057).
+                # Provide an override until we drop support for Python < 3.13.
+                return self.parse_bogus_comment(i)
             return super().parse_html_declaration(i)
         # This is not the beginning of a raw block so treat as plain data
         # and avoid consuming any tags which may follow (see #1066).

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1275,6 +1275,13 @@ class TestHTMLBlocks(TestCase):
             )
         )
 
+    def test_not_actually_cdata(self):
+        # Ensure bug reported in #1534 is avoided.
+        self.assertMarkdownRenders(
+            '<![',
+            '<p>&lt;![</p>'
+        )
+
     def test_raw_cdata_code_span(self):
         self.assertMarkdownRenders(
             self.dedent(


### PR DESCRIPTION
See Python bug report at [gh-77057](https://github.com/python/cpython/issues/77057) for details. Until we drop support for Python < 3.13 (where this was fixed upstream), we need to avoid the unwanted error by checking for it explicitly. Fixes #1534.

As a reminder, the `html_in_md` tests inherit the standard HTML parser tests. Therefore, the one new test is run twice, once for each HTML parser. In other words, with the one test added and no changes to the code, we would get 2 failures.