### PR TITLE
Fixes for Python 3.14 and fixes for deprecations

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py39, py310, py311, py312, py313, pypy39, pypy310, pygments]
+        tox-env: [py39, py310, py311, py312, py313, py314, pypy39, pypy310, pygments]
         include:
           - tox-env: py39
             python-version: '3.9'
@@ -32,13 +32,14 @@ jobs:
             python-version: '3.12'
           - tox-env: py313
             python-version: '3.13'
+          - tox-env: pygments
+            python-version: '3.14'
           - tox-env: pypy39
             python-version: pypy-3.9
           - tox-env: pypy310
             python-version: pypy-3.10
           - tox-env: pygments
             python-version: '3.11'
-
     env:
       TOXENV: ${{ matrix.tox-env }}
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,7 @@ jobs:
             python-version: '3.12'
           - tox-env: py313
             python-version: '3.13'
-          - tox-env: pygments
+          - tox-env: py314
             python-version: '3.14'
           - tox-env: pypy39
             python-version: pypy-3.9

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 * Fix `codecs` deprecation.
 * Fix issue with unclosed comment parsing in Python 3.14.
-* Fix issue with unclosed declerations in Python 3.14.
+* Fix issue with unclosed declarations in Python 3.14.
 * Fix issue with unclosed HTML tag `<foo` and Python 3.14.
 
 ## [3.8.1] - 2025-06-18

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to the
 [Python Version Specification]: https://packaging.python.org/en/latest/specifications/version-specifiers/.
 See the [Contributing Guide](contributing.md) for details.
 
-## [unreleased]
+## [Unreleased]
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 ### Fixed
 
-* Fix `codecs` deprecation.
+* Fix `codecs` deprecation in Python 3.14.
 * Fix issue with unclosed comment parsing in Python 3.14.
 * Fix issue with unclosed declarations in Python 3.14.
 * Fix issue with unclosed HTML tag `<foo` and Python 3.14.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,8 @@ See the [Contributing Guide](contributing.md) for details.
 ### Fixed
 
 * Fix `codecs` deprecation.
-* Fix issue with unclosed `<![` in Python 3.14.
+* Fix issue with unclosed comment parsing in Python 3.14.
+* Fix issue with unclosed declerations in Python 3.14.
 * Fix issue with unclosed HTML tag `<foo` and Python 3.14.
 
 ## [3.8.1] - 2025-06-18

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ See the [Contributing Guide](contributing.md) for details.
 
 ## [unreleased]
 
+### Fixed
+
+* Fix `codecs` deprecation.
+* Fix issue with unclosed `<![` in Python 3.14.
+* Fix issue with unclosed HTML tag `<foo` and Python 3.14.
+
 ## [3.8.1] - 2025-06-18
 
 ### Fixed

--- a/markdown/__main__.py
+++ b/markdown/__main__.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import sys
 import optparse
-import codecs
 import warnings
 import markdown
 try:
@@ -100,7 +99,7 @@ def parse_options(args=None, values=None):
 
     extension_configs = {}
     if options.configfile:
-        with codecs.open(
+        with open(
             options.configfile, mode="r", encoding=options.encoding
         ) as fp:
             try:

--- a/markdown/core.py
+++ b/markdown/core.py
@@ -417,7 +417,7 @@ class Markdown:
         # Read the source
         if input:
             if isinstance(input, str):
-                input_file = codecs.open(input, mode="r", encoding=encoding)
+                input_file = open(input, mode="r", encoding=encoding)
             else:
                 input_file = codecs.getreader(encoding)(input)
             text = input_file.read()

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -283,7 +283,10 @@ class HTMLExtractorExtra(HTMLExtractor):
             if self.rawdata[i:i+3] == '<![' and not self.rawdata[i:i+9] == '<![CDATA[':
                 # We have encountered the bug in #1534 (Python bug `gh-77057`).
                 # Provide an override until we drop support for Python < 3.13.
-                return self.parse_bogus_comment(i)
+                result = self.parse_bogus_comment(i)
+                if result == -1:
+                    self.handle_data(self.rawdata[i:i + 1])
+                    return i + 1
             # The same override exists in `HTMLExtractor` without the check
             # for `mdstack`. Therefore, use parent of `HTMLExtractor` instead.
             return super(HTMLExtractor, self).parse_html_declaration(i)

--- a/markdown/extensions/md_in_html.py
+++ b/markdown/extensions/md_in_html.py
@@ -287,6 +287,7 @@ class HTMLExtractorExtra(HTMLExtractor):
                 if result == -1:
                     self.handle_data(self.rawdata[i:i + 1])
                     return i + 1
+                return result
             # The same override exists in `HTMLExtractor` without the check
             # for `mdstack`. Therefore, use parent of `HTMLExtractor` instead.
             return super(HTMLExtractor, self).parse_html_declaration(i)

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -256,10 +256,9 @@ class HTMLExtractor(htmlparser.HTMLParser):
 
     def handle_comment(self, data: str):
         # Check if the comment is unclosed, if so, we need to override position
-        # update
         i = self.line_offset + self.offset + len(data) + 4
         if self.rawdata[i:i + 3] != '-->':
-            self.handle_data('<!--')
+            self.handle_data('<')
             self.override_comment_update = True
             return
         self.handle_empty_tag('<!--{}-->'.format(data), is_block=True)
@@ -268,7 +267,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
         if self.override_comment_update:
             self.override_comment_update = False
             i = 0
-            j = 4
+            j = 1
         return super().updatepos(i, j)
 
     def handle_decl(self, data: str):

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -278,7 +278,11 @@ class HTMLExtractor(htmlparser.HTMLParser):
             if self.rawdata[i:i+3] == '<![' and not self.rawdata[i:i+9] == '<![CDATA[':
                 # We have encountered the bug in #1534 (Python bug `gh-77057`).
                 # Provide an override until we drop support for Python < 3.13.
-                return self.parse_bogus_comment(i)
+                result = self.parse_bogus_comment(i)
+                if result == -1:
+                    self.handle_data(self.rawdata[i:i + 1])
+                    return i + 1
+                return result
             return super().parse_html_declaration(i)
         # This is not the beginning of a raw block so treat as plain data
         # and avoid consuming any tags which may follow (see #1066).
@@ -313,7 +317,8 @@ class HTMLExtractor(htmlparser.HTMLParser):
         self.__starttag_text = None
         endpos = self.check_for_whole_start_tag(i)
         if endpos < 0:
-            return endpos
+            self.handle_data(self.rawdata[i:i + 1])
+            return i + 1
         rawdata = self.rawdata
         self.__starttag_text = rawdata[i:endpos]
 

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -93,6 +93,8 @@ class HTMLExtractor(htmlparser.HTMLParser):
 
         self.lineno_start_cache = [0]
 
+        self.override_comment_update = False
+
         # This calls self.reset
         super().__init__(*args, **kwargs)
         self.md = md
@@ -253,7 +255,21 @@ class HTMLExtractor(htmlparser.HTMLParser):
         self.handle_empty_tag('&{};'.format(name), is_block=False)
 
     def handle_comment(self, data: str):
+        # Check if the comment is unclosed, if so, we need to override position
+        # update
+        i = self.line_offset + self.offset + len(data) + 4
+        if self.rawdata[i:i + 3] != '-->':
+            self.handle_data('<!--')
+            self.override_comment_update = True
+            return
         self.handle_empty_tag('<!--{}-->'.format(data), is_block=True)
+
+    def updatepos(self, i: int, j: int) -> int:
+        if self.override_comment_update:
+            self.override_comment_update = False
+            i = 0
+            j = 4
+        return super().updatepos(i, j)
 
     def handle_decl(self, data: str):
         self.handle_empty_tag('<!{}>'.format(data), is_block=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39, 310, 311, 312, 313}, pypy{39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{39, 310, 311, 312, 313, py314}, pypy{39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
- Fix codecs deprecation
- Fix issue with unclosed `<![`
- Fix issue with unclosed HTML tag `<foo`

Fixes #1537