### PR TITLE
Bump version to 3.8.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to the
 [Python Version Specification]: https://packaging.python.org/en/latest/specifications/version-specifiers/.
 See the [Contributing Guide](contributing.md) for details.
 
-## [Unreleased]
+## [3.8.2] - 2025-06-19
 
 ### Fixed
 

--- a/markdown/__meta__.py
+++ b/markdown/__meta__.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 
 
-__version_info__ = (3, 8, 1, 'final', 0)
+__version_info__ = (3, 8, 2, 'final', 0)
 
 
 def _get_version(version_info):


### PR DESCRIPTION
I think we should go ahead and release this ahead of the backports being released to Python 3.9-2.13