### PR TITLE
Fix failing cases for Python 3.14

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ and this project adheres to the
 [Python Version Specification](https://packaging.python.org/en/latest/specifications/version-specifiers/).
 See the [Contributing Guide](contributing.md) for details.
 
+## [Unreleased]
+
+### Fixed
+
+* Fix handling of incomplete HTML tags in code spans in Python 3.14.
+
 ## [3.8.2] - 2025-06-19
 
 ### Fixed

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -69,6 +69,20 @@ htmlparser.locatestarttagend_tolerant = re.compile(r"""
    )?
   \s*                                 # trailing whitespace
 """, re.VERBOSE)
+htmlparser.locatetagend = re.compile(r"""
+  [a-zA-Z][^`\t\n\r\f />]*           # tag name
+  [\t\n\r\f /]*                     # optional whitespace before attribute name
+  (?:(?<=['"\t\n\r\f /])[^`\t\n\r\f />][^\t\n\r\f /=>]*  # attribute name
+    (?:=                            # value indicator
+      (?:'[^']*'                    # LITA-enclosed value
+        |"[^"]*"                    # LIT-enclosed value
+        |(?!['"])[^>\t\n\r\f ]*     # bare value
+       )
+     )?
+    [\t\n\r\f /]*                   # possibly followed by a space
+   )*
+   >?
+""", re.VERBOSE)
 
 # Match a blank line at the start of a block of text (two newlines).
 # The newlines may be preceded by additional whitespace.


### PR DESCRIPTION
New change requires us to monkey patch `locatetagend` to prevent capturing incomplete tags in code spans.

Fixes #1547 