### PR TITLE
Video extension

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -55,6 +55,7 @@ Extension                          | Entry Point    | Dot Notation
 [SmartyPants]                      | `smarty`       | `markdown.extensions.smarty`
 [Table of Contents]                | `toc`          | `markdown.extensions.toc`
 [WikiLinks]                        | `wikilinks`    | `markdown.extensions.wikilinks`
+[Video]                            | `video`        | `markdown.extensions.video`
 
 [Extra]: extra.md
 [Abbreviations]: abbreviations.md

--- a/docs/extensions/video.md
+++ b/docs/extensions/video.md
@@ -1,0 +1,114 @@
+title: Video Extension
+
+# Video Extension
+
+**Convert Markdown images pointing to video files into `<video>` HTML elements.**
+
+---
+
+## Installation
+
+The `video` extension is a single Python file.
+Enable it like any other Markdown extension:
+
+```python
+import markdown
+
+md = markdown.Markdown(extensions=['video'])
+```
+
+Or configure it with custom video extensions:
+
+```python
+from video import VideoImageExtension
+
+md = markdown.Markdown(
+    extensions=[VideoImageExtension(video_extensions=['avi', 'mkv'])]
+)
+```
+
+---
+
+## Usage
+
+Markdown images with recognized video extensions will be rendered as `<video>` elements:
+
+```markdown
+![Intro Video](intro.mp4)
+```
+
+Outputs:
+
+```html
+<video src="intro.mp4" controls title="Intro Video"></video>
+```
+
+* Default attributes: `controls` and `title` (from alt text)
+* File extensions recognized by default: `mp4`, `webm`, `ogg`, `mov`
+
+---
+
+## Grav-Style Query Parameters
+
+You can add query parameters in the URL to customize `<video>` attributes:
+
+```markdown
+![Looped Video](video.mov?loop=1&autoplay=1&muted=1&controls=0)
+```
+
+Outputs:
+
+```html
+<video src="video.mov" loop="loop" autoplay="autoplay" muted="muted"></video>
+```
+
+| Parameter  | Description                       |
+| ---------- | --------------------------------- |
+| `autoplay` | Automatically play the video      |
+| `loop`     | Loop the video continuously       |
+| `muted`    | Mute the video by default         |
+| `controls` | Show or hide browser controls     |
+| other      | Passed as attributes to `<video>` |
+
+---
+
+## Custom Video Extensions
+
+You can define which file extensions are treated as videos:
+
+```python
+md = markdown.Markdown(
+    extensions=[VideoImageExtension(video_extensions=['avi', 'mkv'])]
+)
+```
+
+* Only files with these extensions will be converted to `<video>` elements.
+* Other image files will remain `<img>`.
+
+---
+
+## Examples
+
+Markdown:
+
+```markdown
+![My Video](demo.webm?autoplay=1&loop=1&muted=1&poster=thumb.png)
+```
+
+HTML:
+
+```html
+<video src="demo.webm" autoplay="autoplay" loop="loop" muted="muted" poster="thumb.png" controls></video>
+```
+
+Markdown image that is not a video:
+
+```markdown
+![Image](photo.png)
+```
+
+HTML:
+
+```html
+<img src="photo.png" alt="Image">
+```

--- a/markdown/extensions/video.py
+++ b/markdown/extensions/video.py
@@ -1,0 +1,97 @@
+"""
+Video Markdown Extension
+
+Transforms Markdown images pointing to video files into <video> elements,
+supporting query parameters for HTML5 attributes.
+
+Usage:
+    import markdown
+    md = markdown.Markdown(extensions=[
+        'video',
+        # optional config:
+        # ('video', {'video_extensions': ['mp4', 'webm']})
+    ])
+    html = md.convert('![sample](video.mov?loop=1&controls=0&autoplay=1&muted)')
+"""
+
+import os
+from urllib.parse import urlparse, parse_qs
+import xml.etree.ElementTree as etree
+from markdown.inlinepatterns import ImageInlineProcessor
+from markdown.extensions import Extension
+
+
+class VideoImageProcessor(ImageInlineProcessor):
+    """Transform images pointing to videos into <video> elements."""
+
+    def __init__(self, pattern, md, video_ext=None):
+        super().__init__(pattern, md)
+        # allow user-defined extensions; default list
+        self.video_ext = tuple(ext.lower().lstrip(".") for ext in (video_ext or ["mp4", "webm", "ogg", "mov"]))
+
+    def handleMatch(self, m, data):
+        el, start, end = super().handleMatch(m, data)
+        if el is None:
+            return None, None, None
+
+        src = el.get("src", "")
+        parsed = urlparse(src)
+        path, query = parsed.path, parsed.query
+        _, ext = os.path.splitext(path.lower())
+
+        if ext.lstrip(".") not in self.video_ext:
+            # Not a video; fallback to <img>
+            return el, start, end
+
+        # Build <video> element
+        video = etree.Element("video")
+        video.set("src", src)
+
+        # Parse Grav-style query parameters
+        query_params = parse_qs(query, keep_blank_values=True)
+        for key, values in query_params.items():
+            val = values[0] if values else ""
+            # Boolean attributes
+            if key.lower() in ("controls", "autoplay", "loop", "muted"):
+                if val == "0":
+                    continue
+                video.set(key, key)
+            else:
+                # Any other attribute
+                video.set(key, val or key)
+
+        # Default controls if not explicitly disabled
+        if "controls" not in video.attrib and query_params.get("controls", ["1"])[0] != "0":
+            video.set("controls", "controls")
+
+        # Preserve alt text as title
+        if el.get("alt"):
+            video.set("title", el.get("alt"))
+
+        return video, start, end
+
+
+class VideoImageExtension(Extension):
+    """Markdown extension for video images."""
+
+    def __init__(self, **kwargs):
+        self.config = {
+            "video_extensions": [
+                ["mp4", "webm", "ogg", "mov"],
+                "List of allowed video file extensions",
+            ],
+        }
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md):
+        pattern = r"\!\["
+        md.inlinePatterns.register(
+            VideoImageProcessor(pattern, md, self.getConfig("video_extensions")),
+            "video_image",
+            151,
+        )
+
+
+def makeExtension(**kwargs):
+    """Return extension instance."""
+    return VideoImageExtension(**kwargs)

--- a/markdown/extensions/video.py
+++ b/markdown/extensions/video.py
@@ -11,7 +11,7 @@ Usage:
         # optional config:
         # ('video', {'video_extensions': ['mp4', 'webm']})
     ])
-    html = md.convert('![sample](video.mov?loop=1&controls=0&autoplay=1&muted)')
+    html = md.convert('![sample](video.mov?loop=1&controls=0&autoplay=1&muted&poster=thumb.png)')
 """
 
 import os
@@ -45,15 +45,15 @@ class VideoImageProcessor(ImageInlineProcessor):
 
         # Build <video> element
         video = etree.Element("video")
-        video.set("src", src)
+        video.set("src", path)  # src without query parameters
 
-        # Parse Grav-style query parameters
+        # Parse query parameters
         query_params = parse_qs(query, keep_blank_values=True)
         for key, values in query_params.items():
             val = values[0] if values else ""
             # Boolean attributes
             if key.lower() in ("controls", "autoplay", "loop", "muted"):
-                if val == "0":
+                if val in ("0", "false"):
                     continue
                 video.set(key, key)
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ toc = 'markdown.extensions.toc:TocExtension'
 wikilinks = 'markdown.extensions.wikilinks:WikiLinkExtension'
 legacy_attrs = 'markdown.extensions.legacy_attrs:LegacyAttrExtension'
 legacy_em = 'markdown.extensions.legacy_em:LegacyEmExtension'
+video = 'markdown.extensions.video:VideoImageExtension'
 
 [tool.setuptools]
 packages = ['markdown', 'markdown.extensions']

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,55 @@
+import unittest
+import markdown
+from video import VideoImageExtension
+
+class TestVideoExtension(unittest.TestCase):
+    def make_md(self, **kwargs):
+        """Helper to create a Markdown instance with video extension."""
+        return markdown.Markdown(extensions=[VideoImageExtension(**kwargs)])
+
+    def test_basic_video(self):
+        md = self.make_md()
+        src = 'video.mp4'
+        html = md.convert(f'![Alt text]({src})')
+        self.assertIn('<video', html)
+        self.assertIn('src="video.mp4"', html)
+        self.assertIn('controls', html)
+        self.assertIn('title="Alt text"', html)
+
+    def test_grav_params(self):
+        md = self.make_md()
+        src = 'video.webm?autoplay=1&loop=1&muted=1&controls=0'
+        html = md.convert(f'![test]({src})')
+        self.assertIn('<video', html)
+        self.assertIn('autoplay="autoplay"', html)
+        self.assertIn('loop="loop"', html)
+        self.assertIn('muted="muted"', html)
+        # Controls explicitly disabled
+        self.assertNotIn('controls="controls"', html)
+
+    def test_non_video_image(self):
+        md = self.make_md()
+        html = md.convert('![img](image.png)')
+        # Should remain an <img> element
+        self.assertIn('<img', html)
+        self.assertNotIn('<video', html)
+
+    def test_custom_extensions(self):
+        md = self.make_md(video_extensions=['avi'])
+        # avi should convert to video
+        html = md.convert('![clip](movie.avi)')
+        self.assertIn('<video', html)
+        # mp4 should NOT convert because it's not in custom list
+        html2 = md.convert('![clip](movie.mp4)')
+        self.assertIn('<img', html2)
+
+    def test_other_attributes(self):
+        md = self.make_md()
+        src = 'video.mp4?poster=thumb.png&preload=auto'
+        html = md.convert(f'![v]({src})')
+        self.assertIn('poster="thumb.png"', html)
+        self.assertIn('preload="auto"', html)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,6 +1,6 @@
 import unittest
 import markdown
-from video import VideoImageExtension
+from markdown.extensions.video import VideoImageExtension
 
 class TestVideoExtension(unittest.TestCase):
     def make_md(self, **kwargs):


### PR DESCRIPTION
Add `video` Markdown extension

This PR introduces a new Markdown extension, `video`, that automatically transforms image links pointing to video files into HTML5 `<video>` elements.

Features:

* Supports common video formats (`mp4`, `webm`, `ogg`, `mov`) with configurable extensions.
* Parses query parameters in Markdown links to set HTML5 attributes (`autoplay`, `controls`, `loop`, `muted`).
* Supports the `poster` attribute for video thumbnails.
* Preserves `alt` text as the video `title`.
* Works as a standard Markdown extension:

  ```python
  import markdown
  md = markdown.Markdown(extensions=['video'])
  html = md.convert('![Demo](video.mp4?poster=thumb.png&autoplay=1&controls=1)')
  ```

This keeps the extension consistent with the existing project structure and allows users to easily add videos in Markdown without custom HTML.
