### PR TITLE
Add a security policy for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability in Python-Markdown, [open a private vulnerability report](https://github.com/Python-Markdown/markdown/security/advisories/new) and you can create a patch on a private fork or, after reporting the problem, our maintainers will fix it as soon as possible.


### PR DESCRIPTION
Without a security policy defined, if someone finds a security vulnerability in the project and wants to submit a patch, they must make the patch public. This means potential attackers could exploit the vulnerability and compromise projects that are using Python-Markdown.  

In practice, without a security policy, security researchers cannot properly author CVEs through any well-established system, and as a result Python-Markdown is not regularly checked for security vulnerabilities.  

To begin addressing this, I am opening this issue to propose creating a *SECURITY.md* document, which will enable the `Security policy` in the repository’s `Security` tab.  

![image](https://github.com/user-attachments/assets/4d856fe0-fb9b-4250-923e-942304ff0077)  

For private patch submissions through the GitHub system, CVE researchers also need someone with write access to the repository settings to enable `Private vulnerability reporting`. The `Security advisories` tab can also be enabled without forcing reports to be public, since each advisory can later be marked as public or kept private.

**Note:** there is another approach you might want to consider. You can create a single global *SECURITY.md* file that applies to all repositories in your organization by creating a *Python-Markdown/.github* repository and placing the *SECURITY.md* file there.  