### PR TITLE
+ PY314 - PY39

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,10 +20,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py39, py310, py311, py312, py313, py314, pypy39, pypy310, pygments]
+        tox-env: [py310, py311, py312, py313, py314, pypy310, pypy311, pygments]
         include:
-          - tox-env: py39
-            python-version: '3.9'
           - tox-env: py310
             python-version: '3.10'
           - tox-env: py311
@@ -34,10 +32,10 @@ jobs:
             python-version: '3.13'
           - tox-env: py314
             python-version: '3.14'
-          - tox-env: pypy39
-            python-version: pypy-3.9
           - tox-env: pypy310
             python-version: pypy-3.10
+          - tox-env: pypy311
+            python-version: pypy-3.11
           - tox-env: pygments
             python-version: '3.11'
     env:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 ### Changed
 
-* Oficially support Python 3.14 and PyPy 3.11 and drop support for Python 3.9
+* Officially support Python 3.14 and PyPy 3.11 and drop support for Python 3.9
   and PyPy 3.9.
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,8 +14,8 @@ See the [Contributing Guide](contributing.md) for details.
 
 ### Changed
 
-* Oficially support Python 3.14 and pypy 3.11 and drop support for Python 3.9
-  and pypy 3.9.
+* Oficially support Python 3.14 and PyPy 3.11 and drop support for Python 3.9
+  and PyPy 3.9.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ See the [Contributing Guide](contributing.md) for details.
 
 ## [Unreleased]
 
+### Changed
+
+* Oficially support Python 3.14 and pypy 3.11 and drop support for Python 3.9
+  and pypy 3.9.
+
 ### Fixed
 
 * Fix an HTML comment parsing case in some Python versions that can cause an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,21 +19,18 @@ maintainers = [
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE.md"]
-requires-python = '>=3.9'
-dependencies = [
-    "importlib-metadata>=4.4;python_version<'3.10'"
-]
+requires-python = '>=3.10'
 keywords = ['markdown', 'markdown-parser', 'python-markdown', 'markdown-to-html']
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39, 310, 311, 312, 313, py314}, pypy{39, 310}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{310, 311, 312, 313, 314}, pypy{310, 311}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python officially released 3.14 on 2025-10-07 and ended support for 3.9 on 2025-10-31.