### PR TITLE
Ensure nested elements inside inline comments are properly unescaped.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to the
 [Python Version Specification](https://packaging.python.org/en/latest/specifications/version-specifiers/).
 See the [Contributing Guide](contributing.md) for details.
 
-## [unreleased]
+## [Unreleased]
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ and this project adheres to the
 [Python Version Specification](https://packaging.python.org/en/latest/specifications/version-specifiers/).
 See the [Contributing Guide](contributing.md) for details.
 
+## [unreleased]
+
+### Fixed
+
+* Ensure nested elements inside inline comments are properly unescaped (#1571).
+
 ## [3.10.0] - 2025-11-03
 
 ### Changed

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -520,7 +520,8 @@ class HtmlInlineProcessor(InlineProcessor):
             value = stash.get(id)
             if value is not None:
                 try:
-                    return self.md.serializer(value)
+                    # Ensure we don't have a placeholder inside a placeholder
+                    return self.unescape(self.md.serializer(value))
                 except Exception:
                     return r'\%s' % value
 

--- a/tests/test_syntax/inline/test_raw_html.py
+++ b/tests/test_syntax/inline/test_raw_html.py
@@ -34,3 +34,9 @@ class TestRawHtml(TestCase):
 
     def test_noname_tag(self):
         self.assertMarkdownRenders('<span></></span>', '<p><span>&lt;/&gt;</span></p>')
+
+    def test_markdown_nested_in_inline_comment(self):
+        self.assertMarkdownRenders(
+            'Example: <!-- [**Bold link**](http://example.com) -->',
+            '<p>Example: <!-- <a href="http://example.com"><strong>Bold link</strong></a> --></p>'
+        )


### PR DESCRIPTION
When inline Markdwon elements are nested, each nested level contains its own placeholder. Therefore, when unescaping, the regex substitution needs to be run again each nested level. As this is nested inside the match, it ensures only one non-matching regex will be run in each instace.

Closes #1571.