### PR TITLE
Make the docs build successfully with mkdocstrings-python 2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ See the [Contributing Guide](contributing.md) for details.
 ### Fixed
 
 * Ensure nested elements inside inline comments are properly unescaped (#1571).
+* Make the docs build successfully with mkdocstrings-python 2.0 (#1575).
 
 ## [3.10.0] - 2025-11-03
 

--- a/docs/templates/python/nature/attribute.html.jinja
+++ b/docs/templates/python/nature/attribute.html.jinja
@@ -1,7 +1,7 @@
 {% extends "_base/attribute.html.jinja" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ attribute.relative_filepath }}#L{{ attribute.lineno }}{% if attribute.endlineno > attribute.lineno %}-L{{ attribute.endlineno }}{% endif %}" title='View source code on GitHub'>&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.extra.source.repo }}/tree/{{ config.extra.source.tag }}/{{ attribute.relative_filepath }}#L{{ attribute.lineno }}{% if attribute.endlineno > attribute.lineno %}-L{{ attribute.endlineno }}{% endif %}" title='View source code on GitHub'>&lsaquo;&rsaquo;</a>
   {% if config.show_symbol_type_heading %}<code class="doc-symbol doc-symbol-heading doc-symbol-attribute"></code>{% endif %}
   {%+ filter highlight(language="python", inline=True) %}
     {{ attribute_name }}{% if attribute.annotation %}: {{ attribute.annotation }}{% endif %}

--- a/docs/templates/python/nature/class.html.jinja
+++ b/docs/templates/python/nature/class.html.jinja
@@ -1,6 +1,6 @@
 {% extends "_base/class.html.jinja" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ class.relative_filepath }}#L{{ class.lineno }}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.extra.source.repo }}/tree/{{ config.extra.source.tag }}/{{ class.relative_filepath }}#L{{ class.lineno }}" title="{{ config.extra.source.title }}">&lsaquo;&rsaquo;</a>
   {{ super() }}
 {% endblock heading %}

--- a/docs/templates/python/nature/function.html.jinja
+++ b/docs/templates/python/nature/function.html.jinja
@@ -1,6 +1,6 @@
 {% extends "_base/function.html.jinja" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ function.relative_filepath }}#L{{ function.lineno }}{% if function.endlineno > function.lineno %}-L{{ function.endlineno }}{% endif %}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.extra.source.repo }}/tree/{{ config.extra.source.tag }}/{{ function.relative_filepath }}#L{{ function.lineno }}{% if function.endlineno > function.lineno %}-L{{ function.endlineno }}{% endif %}" title="{{ config.extra.source.title }}">&lsaquo;&rsaquo;</a>
   {{ super() }}
 {% endblock heading %}

--- a/docs/templates/python/nature/module.html.jinja
+++ b/docs/templates/python/nature/module.html.jinja
@@ -1,6 +1,6 @@
 {% extends "_base/module.html.jinja" %}
 
 {% block heading scoped %}
-  <a class="doc-source-link" href="{{ config.source.repo }}/tree/{{ config.source.tag }}/{{ module.relative_filepath }}" title="{{ config.source.title }}">&lsaquo;&rsaquo;</a>
+  <a class="doc-source-link" href="{{ config.extra.source.repo }}/tree/{{ config.extra.source.tag }}/{{ module.relative_filepath }}" title="{{ config.extra.source.title }}">&lsaquo;&rsaquo;</a>
   {{ super() }}
 {% endblock heading %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ plugins:
     custom_templates: docs/templates
     handlers:
       python:
-        import:
+        inventories:
         - https://docs.python.org/3/objects.inv
         options:
           annotations_path: brief
@@ -113,7 +113,8 @@ plugins:
           show_symbol_type_toc: false
           signature_crossrefs: false
           summary: true
-          source:
-            repo: https://github.com/Python-Markdown/markdown
-            tag: !!python/name:markdown.__version__
-            title: "View source code on GitHub."
+          extra:
+            source:
+              repo: https://github.com/Python-Markdown/markdown
+              tag: !!python/name:markdown.__version__
+              title: "View source code on GitHub."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
     'mkdocs>=1.6',
     'mkdocs-nature>=0.6',
     'mdx_gh_links>=0.2',
-    "mkdocstrings[python]",
+    "mkdocstrings[python]>=0.28.3",
     "mkdocs-gen-files",
     "mkdocs-section-index",
     "mkdocs-literate-nav",


### PR DESCRIPTION
This fixes CI failure which can be seen [here](https://github.com/Python-Markdown/markdown/actions/runs/20112704275/job/57714086708).

In mkdocstrings/python@5ebeda6fce1b1bc7cb3f5e27a5a90ac394a3de0c (1.14 release), two changes happened:
- `import` was renamed to `inventories`;
- passing extra options directly under `options` was deprecated, and they should be now passed in `options.extra`.

The old config kept working in 1.x releases, but since mkdocstrings/python@c10afdb98d590a23c8840c7c0cdd6c358094dc2c (2.0 release), it no longer works.

I bumped mkdocstrings dependency to 0.28.3, because it in turn depends on mkdocstrings-python new enough to contain the first commit (see mkdocstrings/mkdocstrings@ba9003e96c8e5e01900743d5c464cbd228d732f4).

---

While working on this, I noticed that links to code are broken in the current release, because the tag name is `3.10.0` but `_get_version()` returns just `3.10`. We should make this consistent, but that’s a separate issue.