### PR TITLE
Fix infinite loop when text contains multiple unclosed comments

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 * Ensure nested elements inside inline comments are properly unescaped (#1571).
 * Make the docs build successfully with mkdocstrings-python 2.0 (#1575).
+* Fix infinite loop when multiple bogus or unclosed HTML comments appear in input (#1578).
 
 ## [3.10.0] - 2025-11-03
 

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1684,3 +1684,17 @@ class TestHTMLBlocks(TestCase):
                 """
             )
         )
+
+    def test_multiple_bogus_comments_no_hang(self):
+        """Test that multiple bogus comments (</` patterns) don't cause infinite loop."""
+        self.assertMarkdownRenders(
+            '`</` and `</`',
+            '<p><code>&lt;/</code> and <code>&lt;/</code></p>'
+        )
+
+    def test_multiple_unclosed_comments_no_hang(self):
+        """Test that multiple unclosed comments don't cause infinite loop."""
+        self.assertMarkdownRenders(
+            '<!-- and <!--',
+            '<p>&lt;!-- and &lt;!--</p>'
+        )


### PR DESCRIPTION
The updatepos() override was resetting the parser position to 0, causing infinite loops when multiple bogus/unclosed comments appeared in the input (e.g., `</` followed by non-standard characters or `<!--` ). Now tracks the position of the triggering `<` and advances past it instead of rewinding to the start of the buffer.

Fixes #1578