### PR TITLE
Allow reference links with backticks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,8 @@ See the [Contributing Guide](contributing.md) for details.
 
 * Ensure nested elements inside inline comments are properly unescaped (#1571).
 * Make the docs build successfully with mkdocstrings-python 2.0 (#1575).
+* Backtick formatting permitted in reference links to match conventional
+  links (#495).
 
 ## [3.10.0] - 2025-11-03
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -931,7 +931,7 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
         if title:
             el.set('title', title)
 
-        if '`' in text: # Process possible backtick within text
+        if '`' in text:  # Process possible backtick within text
             m = self.RE_BACKTICK.search(text)
             if m and m.group(3):
                 el2 = etree.Element('code')

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -164,6 +164,23 @@ class TestInlineLinks(TestCase):
             '<p><a href="?}]*+|&amp;)">test nonsense</a>.</p>'
         )
 
+    def test_monospaced_title(self):
+        self.assertMarkdownRenders(
+            """[`test`](link)""",
+            """<p><a href="link"><code>test</code></a></p>"""
+        )
+
+    def test_title_containing_monospaced_title(self):
+        self.assertMarkdownRenders(
+            """[some `test`](link)""",
+            """<p><a href="link">some <code>test</code></a></p>"""
+        )
+
+    def test_title_containing_single_backtick(self):
+        self.assertMarkdownRenders(
+            """[some `test](link)""",
+            """<p><a href="link">some `test</a></p>"""
+        )
 
 class TestReferenceLinks(TestCase):
 
@@ -433,4 +450,52 @@ class TestReferenceLinks(TestCase):
                 <p><a href="/url(test)" title="title">Text</a>.</p>
                 """
             )
+        )
+
+    def test_ref_link_monospaced_text(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [`Text`]
+
+                [`Text`]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com"><code>Text</code></a></p>"""
+        )
+
+    def test_ref_link_with_containing_monospaced_text(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [some `Text`]
+
+                [some `Text`]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com">some <code>Text</code></a></p>"""
+        )
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [`Text` after]
+
+                [`Text` after]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com"><code>Text</code> after</a></p>"""
+        )
+
+
+    def test_ref_link_with_single_backtick(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [some `Text]
+
+                [some `Text]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com">some `Text</a></p>"""
         )

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -182,6 +182,7 @@ class TestInlineLinks(TestCase):
             """<p><a href="link">some `test</a></p>"""
         )
 
+
 class TestReferenceLinks(TestCase):
 
     def test_ref_link(self):
@@ -486,7 +487,6 @@ class TestReferenceLinks(TestCase):
             ),
             """<p><a href="http://example.com"><code>Text</code> after</a></p>"""
         )
-
 
     def test_ref_link_with_single_backtick(self):
         self.assertMarkdownRenders(


### PR DESCRIPTION
Fixes issue #495 

Creates an escape route for backticks which match a know reference link, and then reapplies the backtick `<code>` tag generation after the anchor element is created.

Slight duplication of code for generating the `<code>` tags - but seems unnecessary to extract into its own method. 
