### PR TITLE
Revert "Allow reference links with backticks"

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,8 +17,6 @@ See the [Contributing Guide](contributing.md) for details.
 * Ensure nested elements inside inline comments are properly unescaped (#1571).
 * Make the docs build successfully with mkdocstrings-python 2.0 (#1575).
 * Fix infinite loop when multiple bogus or unclosed HTML comments appear in input (#1578).
-* Backtick formatting permitted in reference links to match conventional
-  links (#495).
 
 ## [3.10.0] - 2025-11-03
 

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -70,7 +70,7 @@ def build_inlinepatterns(md: Markdown, **kwargs: Any) -> util.Registry[InlinePro
 
     """
     inlinePatterns = util.Registry()
-    inlinePatterns.register(BacktickInlineProcessor(BACKTICK_RE, md), 'backtick', 190)
+    inlinePatterns.register(BacktickInlineProcessor(BACKTICK_RE), 'backtick', 190)
     inlinePatterns.register(EscapeInlineProcessor(ESCAPE_RE, md), 'escape', 180)
     inlinePatterns.register(ReferenceInlineProcessor(REFERENCE_RE, md), 'reference', 170)
     inlinePatterns.register(LinkInlineProcessor(LINK_RE, md), 'link', 160)
@@ -435,13 +435,11 @@ class SubstituteTagInlineProcessor(SimpleTagInlineProcessor):
 
 class BacktickInlineProcessor(InlineProcessor):
     """ Return a `<code>` element containing the escaped matching text. """
-    def __init__(self, pattern: str, md: Markdown):
+    def __init__(self, pattern: str):
         InlineProcessor.__init__(self, pattern)
         self.ESCAPED_BSLASH = '{}{}{}'.format(util.STX, ord('\\'), util.ETX)
         self.tag = 'code'
         """ The tag of the rendered element. """
-
-        self.md = md
 
     def handleMatch(self, m: re.Match[str], data: str) -> tuple[etree.Element | str, int, int]:
         """
@@ -453,8 +451,6 @@ class BacktickInlineProcessor(InlineProcessor):
 
         """
         if m.group(3):
-            if data.lstrip('[').rstrip(']').lower() in self.md.references:  # ignore known references
-                return None, None, None
             el = etree.Element(self.tag)
             el.text = util.AtomicString(util.code_escape(m.group(3).strip()))
             return el, m.start(0), m.end(0)
@@ -883,8 +879,6 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
 
     RE_LINK = re.compile(r'\s?\[([^\]]*)\]', re.DOTALL | re.UNICODE)
 
-    RE_BACKTICK = re.compile(BACKTICK_RE, re.DOTALL | re.UNICODE)
-
     def handleMatch(self, m: re.Match[str], data: str) -> tuple[etree.Element | None, int | None, int | None]:
         """
         Return [`Element`][xml.etree.ElementTree.Element] returned by `makeTag` method or `(None, None, None)`.
@@ -931,19 +925,7 @@ class ReferenceInlineProcessor(LinkInlineProcessor):
         if title:
             el.set('title', title)
 
-        if '`' in text:  # Process possible backtick within text
-            m = self.RE_BACKTICK.search(text)
-            if m and m.group(3):
-                el2 = etree.Element('code')
-                el2.text = util.AtomicString(util.code_escape(m.group(3).strip()))
-                el.append(el2)
-                el.text = text[0:m.start(0)]
-                el2.tail = text[m.end(0):]
-            else:
-                el.text = text
-        else:
-            el.text = text
-
+        el.text = text
         return el
 
 

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -164,24 +164,6 @@ class TestInlineLinks(TestCase):
             '<p><a href="?}]*+|&amp;)">test nonsense</a>.</p>'
         )
 
-    def test_monospaced_title(self):
-        self.assertMarkdownRenders(
-            """[`test`](link)""",
-            """<p><a href="link"><code>test</code></a></p>"""
-        )
-
-    def test_title_containing_monospaced_title(self):
-        self.assertMarkdownRenders(
-            """[some `test`](link)""",
-            """<p><a href="link">some <code>test</code></a></p>"""
-        )
-
-    def test_title_containing_single_backtick(self):
-        self.assertMarkdownRenders(
-            """[some `test](link)""",
-            """<p><a href="link">some `test</a></p>"""
-        )
-
 
 class TestReferenceLinks(TestCase):
 
@@ -451,51 +433,4 @@ class TestReferenceLinks(TestCase):
                 <p><a href="/url(test)" title="title">Text</a>.</p>
                 """
             )
-        )
-
-    def test_ref_link_monospaced_text(self):
-        self.assertMarkdownRenders(
-            self.dedent(
-                """
-                [`Text`]
-
-                [`Text`]: http://example.com
-                """
-            ),
-            """<p><a href="http://example.com"><code>Text</code></a></p>"""
-        )
-
-    def test_ref_link_with_containing_monospaced_text(self):
-        self.assertMarkdownRenders(
-            self.dedent(
-                """
-                [some `Text`]
-
-                [some `Text`]: http://example.com
-                """
-            ),
-            """<p><a href="http://example.com">some <code>Text</code></a></p>"""
-        )
-
-        self.assertMarkdownRenders(
-            self.dedent(
-                """
-                [`Text` after]
-
-                [`Text` after]: http://example.com
-                """
-            ),
-            """<p><a href="http://example.com"><code>Text</code> after</a></p>"""
-        )
-
-    def test_ref_link_with_single_backtick(self):
-        self.assertMarkdownRenders(
-            self.dedent(
-                """
-                [some `Text]
-
-                [some `Text]: http://example.com
-                """
-            ),
-            """<p><a href="http://example.com">some `Text</a></p>"""
         )


### PR DESCRIPTION
This reverts commit 07dfa4eb43f7a2ab3181b4f842a960a03a6c1221.

This does not fully work as advertised.