### PR TITLE
Allow reference links with backticks (again)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,8 @@ See the [Contributing Guide](contributing.md) for details.
 * Ensure nested elements inside inline comments are properly unescaped (#1571).
 * Make the docs build successfully with mkdocstrings-python 2.0 (#1575).
 * Fix infinite loop when multiple bogus or unclosed HTML comments appear in input (#1578).
+* Backtick formatting permitted in reference links to match conventional
+  links (#495).
 
 ## [3.10.0] - 2025-11-03
 

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -164,6 +164,29 @@ class TestInlineLinks(TestCase):
             '<p><a href="?}]*+|&amp;)">test nonsense</a>.</p>'
         )
 
+    def test_monospaced_title(self):
+        self.assertMarkdownRenders(
+            """[`test`](link)""",
+            """<p><a href="link"><code>test</code></a></p>"""
+        )
+
+    def test_title_containing_monospaced_title(self):
+        self.assertMarkdownRenders(
+            """[some `test`](link)""",
+            """<p><a href="link">some <code>test</code></a></p>"""
+        )
+
+        self.assertMarkdownRenders(
+            """before [`test` and `test`](link) after""",
+            """<p>before <a href="link"><code>test</code> and <code>test</code></a> after</p>"""
+        )
+
+    def test_title_containing_single_backtick(self):
+        self.assertMarkdownRenders(
+            """[some `test](link)""",
+            """<p><a href="link">some `test</a></p>"""
+        )
+
 
 class TestReferenceLinks(TestCase):
 
@@ -433,4 +456,75 @@ class TestReferenceLinks(TestCase):
                 <p><a href="/url(test)" title="title">Text</a>.</p>
                 """
             )
+        )
+
+    def test_ref_link_monospaced_text(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [`Text`]
+
+                [`Text`]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com"><code>Text</code></a></p>"""
+        )
+
+    def test_ref_link_with_containing_monospaced_text(self):
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                text before [`Text` internal `Text`] text after
+
+                [`Text` internal `Text`]: http://example.com
+                """
+            ),
+            """<p>text before <a href="http://example.com"><code>Text</code> internal <code>Text</code></a> text after</p>"""
+        )
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [some `Text`]
+
+                [some `Text`]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com">some <code>Text</code></a></p>"""
+        )
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [`Text` after]
+
+                [`Text` after]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com"><code>Text</code> after</a></p>"""
+        )
+
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                text before [`Text` internal] text after
+
+                [`Text` internal]: http://example.com
+                """
+            ),
+            """<p>text before <a href="http://example.com"><code>Text</code> internal</a> text after</p>"""
+        )
+
+
+    def test_ref_link_with_single_backtick(self):
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                [some `Text]
+
+                [some `Text]: http://example.com
+                """
+            ),
+            """<p><a href="http://example.com">some `Text</a></p>"""
         )


### PR DESCRIPTION
@facelessuser

Thoughts appreciated - I did have this working on a previous version, but seem to have dropped the test and broke it in the re-write. Thought it was a bit too simple.

Previously I was expanding the backtick within reference, then comparing against the stashed nodes.

So find reference and expand to [some <code>content</code>] then storing that as the references list.

Then in the inline reference processor, all of the stashed_nodes were expanded and then the reference comparison happens.

