### PR TITLE
More HTML fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ See the [Contributing Guide](contributing.md) for details.
 * Ensure nested elements inside inline comments are properly unescaped (#1571).
 * Make the docs build successfully with mkdocstrings-python 2.0 (#1575).
 * Fix infinite loop when multiple bogus or unclosed HTML comments appear in input (#1578).
+* Fix another infinite loop when handling bad comments (#1586).
 
 ## [3.10.0] - 2025-11-03
 

--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -126,6 +126,7 @@ class HTMLExtractor(htmlparser.HTMLParser):
         self.cleandoc: list[str] = []
         self.lineno_start_cache = [0]
         self.override_comment_start = 0
+        self.override_comment_update = False
 
         super().reset()
 
@@ -275,11 +276,11 @@ class HTMLExtractor(htmlparser.HTMLParser):
 
     def handle_comment(self, data: str):
         # Check if the comment is unclosed, if so, we need to override position
-        i = self.line_offset + self.offset + len(data) + 4
-        if self.rawdata[i:i + 3] != '-->':
+        j = len(self.rawdata) - len(data)
+        i = j - 2
+        if self.rawdata[i:j] == '</':
             self.handle_data('<')
-            pos = self.line_offset + self.offset
-            self.override_comment_start = pos - 1 if self.rawdata[pos - 1:pos] == '<' else pos
+            self.override_comment_start = i
             self.override_comment_update = True
             return
         self.handle_empty_tag('<!--{}-->'.format(data), is_block=True)
@@ -309,21 +310,19 @@ class HTMLExtractor(htmlparser.HTMLParser):
         self.handle_data('<?')
         return i + 2
 
-    if not hasattr(htmlparser, 'commentabruptclose'):
-        # Internal -- parse comment, return length or -1 if not terminated
-        # see https://html.spec.whatwg.org/multipage/parsing.html#comment-start-state
-        def parse_comment(self, i, report=True):
-            rawdata = self.rawdata
-            assert rawdata.startswith('<!--', i), 'unexpected call to parse_comment()'
-            match = commentclose.search(rawdata, i+4)
-            if not match:
-                match = commentabruptclose.match(rawdata, i+4)
-                if not match:
-                    return -1
-            if report:
-                j = match.start()
-                self.handle_comment(rawdata[i+4: j])
-            return match.end()
+    # Internal -- parse comment, return length or -1 if not terminated
+    # see https://html.spec.whatwg.org/multipage/parsing.html#comment-start-state
+    def parse_comment(self, i, report=True):
+        rawdata = self.rawdata
+        assert rawdata.startswith('<!--', i), 'unexpected call to parse_comment()'
+        match = commentclose.search(rawdata, i+4)
+        if not match:
+            self.handle_data('<')
+            return i + 1
+        if report:
+            j = match.start()
+            self.handle_comment(rawdata[i+4: j])
+        return match.end()
 
     def parse_html_declaration(self, i: int) -> int:
         if self.at_line_start() or self.intail:

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1700,7 +1700,7 @@ class TestHTMLBlocks(TestCase):
         )
 
     def test_no_hang_issue_1586(self):
-        """Test no hange condition for issue #1586."""
+        """Test no hang condition for issue #1586."""
 
         self.assertMarkdownRenders(
             'Test `<!--[if mso]>` and `<!--[if !mso]>`',

--- a/tests/test_syntax/blocks/test_html_blocks.py
+++ b/tests/test_syntax/blocks/test_html_blocks.py
@@ -1698,3 +1698,11 @@ class TestHTMLBlocks(TestCase):
             '<!-- and <!--',
             '<p>&lt;!-- and &lt;!--</p>'
         )
+
+    def test_no_hang_issue_1586(self):
+        """Test no hange condition for issue #1586."""
+
+        self.assertMarkdownRenders(
+            'Test `<!--[if mso]>` and `<!--[if !mso]>`',
+            '<p>Test <code>&lt;!--[if mso]&gt;</code> and <code>&lt;!--[if !mso]&gt;</code></p>'
+        )


### PR DESCRIPTION
- Have `parse_comment` handle bad `<!--` cases.
- `handle_comment` only needs to handle the `</` case for comments. Provide a more reliable way to calculate the index to check for this case.
- Ensure `override_comment_update` is reset, just in case.

Resolves #1586