### PR TITLE
Add cjk_friendly_emphasis extension for CJK underscore emphasis

### DIFF
--- a/markdown/extensions/cjk_friendly_emphasis.py
+++ b/markdown/extensions/cjk_friendly_emphasis.py
@@ -1,0 +1,109 @@
+# CJK-Friendly Emphasis Extension for Python-Markdown
+# ===================================================
+
+# This extension enables underscore emphasis (`_em_`, `__strong__`) to work
+# correctly adjacent to CJK (Chinese, Japanese, Korean) characters.
+#
+# By default, Python-Markdown's underscore emphasis uses `\w` word boundaries
+# to prevent intraword emphasis (e.g., `foo_bar_baz`). However, CJK characters
+# are classified as `\w` in Python's regex engine, which means `_`/`__` fails
+# when directly adjacent to CJK text (e.g., `これは__重要__です`).
+#
+# This extension modifies the underscore patterns to allow CJK characters as
+# valid emphasis boundaries while preserving intraword protection for ASCII text.
+#
+# Note: Asterisk emphasis (`*`/`**`) already works with CJK text in
+# Python-Markdown and is not affected by this extension.
+
+# Copyright The Python Markdown Project
+
+# License: [BSD](https://opensource.org/licenses/bsd-license.php)
+
+"""
+An extension to enable CJK-friendly underscore emphasis.
+
+Underscore emphasis (`_em_`, `__strong__`) normally fails adjacent to CJK
+characters because Python's `\\w` matches CJK, triggering intraword protection.
+This extension relaxes the boundary check so CJK characters are treated as
+valid emphasis delimiters.
+
+Usage:
+
+    >>> import markdown
+    >>> md = markdown.Markdown(extensions=['cjk_friendly_emphasis'])
+    >>> md.convert('これは__重要__です')
+    '<p>これは<strong>重要</strong>です</p>'
+
+"""
+
+from __future__ import annotations
+
+from . import Extension
+from ..inlinepatterns import UnderscoreProcessor, EmStrongItem, EM_STRONG2_RE, STRONG_EM2_RE
+import re
+
+# CJK character class covering the major ranges:
+# - CJK Radicals Supplement through CJK Symbols and Punctuation (U+2E80-U+303F)
+# - Hiragana, Katakana (U+3040-U+30FF)
+# - Bopomofo, Hangul Compatibility Jamo, Kanbun, etc. (U+3100-U+31FF)
+# - Enclosed CJK, CJK Compatibility (U+3200-U+33FF)
+# - CJK Unified Ideographs Extension A + main block (U+3400-U+9FFF)
+# - Hangul Syllables (U+AC00-U+D7A3)
+# - CJK Compatibility Ideographs (U+F900-U+FAFF)
+# - CJK Compatibility Forms (U+FE30-U+FE4F)
+# - Fullwidth Forms (U+FF00-U+FFEF)
+_CJK = (
+    r'[\u2E80-\u303F\u3040-\u30FF\u3100-\u31FF\u3200-\u33FF'
+    r'\u3400-\u9FFF\uAC00-\uD7A3\uF900-\uFAFF'
+    r'\uFE30-\uFE4F\uFF00-\uFFEF]'
+)
+
+# CJK-friendly boundary: not preceded by ASCII word char, OR preceded by CJK
+_NOT_WORD_OR_CJK_BEFORE = rf'(?:(?<!\w)|(?<={_CJK}))'
+
+# CJK-friendly boundary: not followed by ASCII word char, OR followed by CJK
+_NOT_WORD_OR_CJK_AFTER = rf'(?:(?!\w)|(?={_CJK}))'
+
+# _emphasis_  (CJK-friendly)
+CJK_SMART_EMPHASIS_RE = (
+    _NOT_WORD_OR_CJK_BEFORE + r'(_)(?!_)(.+?)(?<!_)\1' + _NOT_WORD_OR_CJK_AFTER
+)
+
+# __strong__  (CJK-friendly)
+CJK_SMART_STRONG_RE = (
+    _NOT_WORD_OR_CJK_BEFORE + r'(_{2})(?!_)(.+?)(?<!_)\1' + _NOT_WORD_OR_CJK_AFTER
+)
+
+# __strong _em___  (CJK-friendly)
+CJK_SMART_STRONG_EM_RE = (
+    _NOT_WORD_OR_CJK_BEFORE
+    + r'(\_)\1(?!\1)(.+?)(?<!\w)\1(?!\1)(.+?)\1{3}'
+    + _NOT_WORD_OR_CJK_AFTER
+)
+
+
+class CJKUnderscoreProcessor(UnderscoreProcessor):
+    """Emphasis processor with CJK-friendly underscore boundary handling."""
+
+    PATTERNS = [
+        EmStrongItem(re.compile(EM_STRONG2_RE, re.DOTALL | re.UNICODE), 'double', 'strong,em'),
+        EmStrongItem(re.compile(STRONG_EM2_RE, re.DOTALL | re.UNICODE), 'double', 'em,strong'),
+        EmStrongItem(re.compile(CJK_SMART_STRONG_EM_RE, re.DOTALL | re.UNICODE), 'double2', 'strong,em'),
+        EmStrongItem(re.compile(CJK_SMART_STRONG_RE, re.DOTALL | re.UNICODE), 'single', 'strong'),
+        EmStrongItem(re.compile(CJK_SMART_EMPHASIS_RE, re.DOTALL | re.UNICODE), 'single', 'em'),
+    ]
+
+
+class CJKFriendlyEmphasisExtension(Extension):
+    """Add CJK-friendly emphasis extension to Markdown class."""
+
+    def extendMarkdown(self, md):
+        """Modify inline patterns."""
+        md.inlinePatterns.register(
+            CJKUnderscoreProcessor(r'_'), 'em_strong2', 50
+        )
+
+
+def makeExtension(**kwargs):  # pragma: no cover
+    """Return an instance of the [`CJKFriendlyEmphasisExtension`][]."""
+    return CJKFriendlyEmphasisExtension(**kwargs)

--- a/tests/test_syntax/extensions/test_cjk_friendly_emphasis.py
+++ b/tests/test_syntax/extensions/test_cjk_friendly_emphasis.py
@@ -1,0 +1,135 @@
+"""
+Python Markdown
+
+A Python implementation of John Gruber's Markdown.
+
+Documentation: https://python-markdown.github.io/
+GitHub: https://github.com/Python-Markdown/markdown/
+PyPI: https://pypi.org/project/Markdown/
+
+Started by Manfred Stienstra (http://www.dwerg.net/).
+Maintained for a few years by Yuri Takhteyev (http://www.freewisdom.org).
+Currently maintained by Waylan Limberg (https://github.com/waylan),
+Dmitry Shachnev (https://github.com/mitya57) and Isaac Muse (https://github.com/facelessuser).
+
+Copyright 2007-2023 The Python Markdown Project (v. 1.7 and later)
+Copyright 2004, 2005, 2006 Yuri Takhteyev (v. 0.2-1.6b)
+Copyright 2004 Manfred Stienstra (the original version)
+
+License: BSD (see LICENSE.md for details).
+"""
+
+from markdown.test_tools import TestCase
+
+
+class TestCJKFriendlyEmphasis(TestCase):
+    # -- Japanese: underscore strong --
+
+    def test_underscore_strong_with_cjk(self):
+        self.assertMarkdownRenders(
+            'これは__重要__です',
+            '<p>これは<strong>重要</strong>です</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_underscore_em_with_cjk(self):
+        self.assertMarkdownRenders(
+            'これは_重要_です',
+            '<p>これは<em>重要</em>です</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_underscore_strong_with_cjk_quotes(self):
+        self.assertMarkdownRenders(
+            '彼は__「異常」__と言った',
+            '<p>彼は<strong>「異常」</strong>と言った</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_underscore_strong_with_cjk_parens(self):
+        self.assertMarkdownRenders(
+            '私は__（仮説）__だと思う',
+            '<p>私は<strong>（仮説）</strong>だと思う</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_underscore_strong_with_cjk_period(self):
+        self.assertMarkdownRenders(
+            'これは__重要。__だから',
+            '<p>これは<strong>重要。</strong>だから</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_underscore_strong_at_start(self):
+        self.assertMarkdownRenders(
+            '__「注意」__してください',
+            '<p><strong>「注意」</strong>してください</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    # -- Chinese --
+
+    def test_underscore_strong_chinese(self):
+        self.assertMarkdownRenders(
+            '这是__强调__文本',
+            '<p>这是<strong>强调</strong>文本</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    # -- Korean --
+
+    def test_underscore_strong_korean(self):
+        self.assertMarkdownRenders(
+            '__강조__합니다',
+            '<p><strong>강조</strong>합니다</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    # -- Mixed CJK and Latin --
+
+    def test_underscore_strong_mixed(self):
+        self.assertMarkdownRenders(
+            '日本語__English__混在',
+            '<p>日本語<strong>English</strong>混在</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    # -- ASCII intraword protection preserved --
+
+    def test_ascii_intraword_underscore_protected(self):
+        self.assertMarkdownRenders(
+            'foo_bar_baz',
+            '<p>foo_bar_baz</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_ascii_intraword_double_underscore_protected(self):
+        self.assertMarkdownRenders(
+            'foo__bar__baz',
+            '<p>foo__bar__baz</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    # -- Asterisk emphasis unchanged --
+
+    def test_asterisk_strong_cjk(self):
+        self.assertMarkdownRenders(
+            'これは**「重要」**です',
+            '<p>これは<strong>「重要」</strong>です</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    def test_asterisk_em_cjk(self):
+        self.assertMarkdownRenders(
+            'これは*重要*です',
+            '<p>これは<em>重要</em>です</p>',
+            extensions=['markdown.extensions.cjk_friendly_emphasis']
+        )
+
+    # -- Without extension, underscore CJK should NOT work --
+
+    def test_without_extension_underscore_cjk_fails(self):
+        self.assertMarkdownRenders(
+            'これは__重要__です',
+            '<p>これは__重要__です</p>',
+        )


### PR DESCRIPTION
## Summary

Adds a new `cjk_friendly_emphasis` extension that enables underscore emphasis (`_em_`, `__strong__`) to work correctly adjacent to CJK (Chinese, Japanese, Korean) characters.

## Motivation

Python-Markdown's underscore emphasis patterns use `\w` word boundaries (via `(?<!\w)` and `(?!\w)`) to prevent intraword emphasis in ASCII text like `foo_bar_baz`. However, CJK characters are classified as `\w` in Python 3's regex engine, which means underscore emphasis fails when directly adjacent to CJK text:

```python
>>> markdown.markdown('これは__重要__です')
'<p>これは__重要__です</p>'  # Expected: <p>これは<strong>重要</strong>です</p>
```

Note: Asterisk emphasis (`*`/`**`) already works with CJK text because it has no word-boundary check. This extension only needs to fix underscore behavior.

## Background

This is part of a broader effort to improve CJK emphasis handling across Markdown implementations. The root issue is documented in [commonmark-spec#650](https://github.com/commonmark/commonmark-spec/issues/650). The [markdown-cjk-friendly](https://github.com/tats-u/markdown-cjk-friendly) project provides a formal specification and implementations for CommonMark-based parsers.

While Python-Markdown follows Gruber's original Markdown rather than CommonMark, the CJK underscore emphasis issue is the same fundamental problem: word-boundary assumptions designed for space-separated languages fail for CJK text.

## Changes

**New file: `markdown/extensions/cjk_friendly_emphasis.py`**

- Defines CJK-aware boundary patterns: `(?:(?<!\w)|(?<=CJK_CHAR))` instead of `(?<!\w)`
- Creates `CJKUnderscoreProcessor` that overrides `UnderscoreProcessor` with CJK-friendly regex patterns
- CJK character class covers: CJK Unified Ideographs, Hiragana, Katakana, Hangul Syllables, fullwidth forms, and related blocks
- Follows the same pattern as `legacy_em.py` for extension structure

**New file: `tests/test_syntax/extensions/test_cjk_friendly_emphasis.py`**

14 test cases covering:
- Japanese: `__重要__`, `__「異常」__`, `__重要。__` 
- Chinese: `__强调__`
- Korean: `__강조__`
- Mixed CJK/Latin
- ASCII intraword protection preserved (`foo_bar_baz`, `foo__bar__baz`)
- Asterisk emphasis unchanged
- Without-extension baseline verification

## Usage

```python
import markdown
html = markdown.markdown('これは__重要__です', extensions=['cjk_friendly_emphasis'])
# '<p>これは<strong>重要</strong>です</p>'
```

## Design decisions

1. **Extension, not core change** — opt-in via `extensions=['cjk_friendly_emphasis']`, no change to default behavior
2. **Underscore only** — asterisk emphasis already works with CJK; only `_`/`__` need fixing
3. **ASCII protection preserved** — `foo_bar_baz` remains unaffected because the boundary relaxation only applies to CJK characters
4. **Follows `legacy_em.py` pattern** — minimal code, subclasses `UnderscoreProcessor`, same registration mechanism

## Test plan

- [x] All 14 CJK-specific tests pass
- [x] All 1099 existing tests pass (0 failures, 110 skipped as before)
- [x] ASCII intraword underscore protection unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)