### PR TITLE
fix(htmlparser): handle zipimporter without exec_module for embedded Python

### DIFF
--- a/markdown/htmlparser.py
+++ b/markdown/htmlparser.py
@@ -40,7 +40,11 @@ commentclose = re.compile(r'--!?>')
 # Users can still do `from html import parser` and get the default behavior.
 spec = importlib.util.find_spec('html.parser')
 htmlparser = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(htmlparser)
+if hasattr(spec.loader, 'exec_module'):
+    spec.loader.exec_module(htmlparser)
+else:
+    import importlib
+    htmlparser.__dict__.update(importlib.import_module('html.parser').__dict__)
 sys.modules['htmlparser'] = htmlparser
 
 # This is a hack. We are sneaking in `</>` so we can capture it without the HTML parser


### PR DESCRIPTION
When Python is installed as an embeddable package (e.g. Windows embeddable zip), html.parser is loaded via zipimporter which does not have an exec_module method. This causes an AttributeError on import. The fix adds a hasattr check before calling exec_module(), falling back to importlib.import_module() for loaders that do not support it. Fixes #1132