### PR TITLE
fix: prevent mixed =/- chars in Setext-style headings (fixes #1604)

### DIFF
--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -494,7 +494,7 @@ class SetextHeaderProcessor(BlockProcessor):
     """ Process Setext-style Headers. """
 
     # Detect Setext-style header. Must be first 2 lines of block.
-    RE = re.compile(r'^.*?\n[=-]+[ ]*(\n|$)', re.MULTILINE)
+    RE = re.compile(r'^.*?\n(?:[=]+|[-]+)[ ]*(\n|$)', re.MULTILINE)
 
     def test(self, parent: etree.Element, block: str) -> bool:
         return bool(self.RE.match(block))


### PR DESCRIPTION
## Description
The regex `[=-]+` incorrectly matches mixed runs like `=-=-` or `-=-=` as Setext-style headings, even though only all-`=` (H1) or all-`-` (H2) are valid.

## Fix
Changed regex from `[=-]+` to `(?:[=]+|[-]+)`.

## Test
- Mixed =/- → NOT headings ✓
- All = → H1 ✓
- All - → H2 ✓

Fixes #1604