### PR TITLE
fix: prevent mixed =/- chars in Setext-style headings (+tests)

### DIFF
--- a/.spell-dict
+++ b/.spell-dict
@@ -203,3 +203,4 @@ Serafim
 overridable
 unescaped
 APIs
+setext

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ and this project adheres to the
 [Python Version Specification](https://packaging.python.org/en/latest/specifications/version-specifiers/).
 See the [Contributing Guide](contributing.md) for details.
 
+## [Unreleased]
+
+### Fixed
+
+* Fix `SetextHeaderProcessor` regex to prevent mixed `=` and `-` chars in setext-style headers (#1606).
+
 ## [3.10.2] - 2026-02-09
 
 ### Fixed

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -494,7 +494,7 @@ class SetextHeaderProcessor(BlockProcessor):
     """ Process Setext-style Headers. """
 
     # Detect Setext-style header. Must be first 2 lines of block.
-    RE = re.compile(r'^.*?\n[=-]+[ ]*(\n|$)', re.MULTILINE)
+    RE = re.compile(r'^.*?\n(?:=+|-+)[ ]*(\n|$)', re.MULTILINE)
 
     def test(self, parent: etree.Element, block: str) -> bool:
         return bool(self.RE.match(block))

--- a/tests/test_syntax/blocks/test_headers.py
+++ b/tests/test_syntax/blocks/test_headers.py
@@ -109,6 +109,58 @@ class TestSetextHeaders(TestCase):
 
     # TODO: fix this
     # see https://johnmacfarlane.net/babelmark2/?normalize=1&text=Paragraph%0AAn+H1%0A%3D%3D%3D%3D%3D
+
+    def test_setext_mixed_chars_not_h1(self):
+        """Mixed = and - chars should not form a valid H1."""
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                This is not an H1
+                =-
+                """
+            ),
+            self.dedent(
+                """
+                <p>This is not an H1
+                =-</p>
+                """
+            )
+        )
+
+    def test_setext_mixed_chars_not_h2(self):
+        """Mixed - and = chars should not form a valid H2."""
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                This is not an H2
+                -=
+                """
+            ),
+            self.dedent(
+                """
+                <p>This is not an H2
+                -=</p>
+                """
+            )
+        )
+
+    def test_setext_mixed_multiple_chars(self):
+        """Multiple mixed = and - chars should not form a valid H1/H2."""
+        self.assertMarkdownRenders(
+            self.dedent(
+                """
+                Not a Header
+                =-=-
+                """
+            ),
+            self.dedent(
+                """
+                <p>Not a Header
+                =-=-</p>
+                """
+            )
+        )
+
     @unittest.skip('This is broken in Python-Markdown')
     def test_p_followed_by_setext_h1(self):
         self.assertMarkdownRenders(


### PR DESCRIPTION
## Summary
This PR fixes issue #1604 - mixed =/- characters in Setext-style headers were incorrectly matched.

## Changes
- **markdown/blockprocessors.py**: Changed regex from `[=-]+` to `(?:[=]+|[-]+)` to match only homogeneous runs
- **tests/test_syntax/blocks/test_headers.py**: Added 3 test cases for mixed-char rejection

## Tests Added
- `test_setext_mixed_chars_not_h1`: `=-` should not form an H1
- `test_setext_mixed_chars_not_h2`: `-=` should not form an H2  
- `test_setext_mixed_multiple_chars`: Mixed runs are not valid headers

Closes #1604