### PR TITLE
Document all extensions are in maintenance mode

### DIFF
--- a/.spell-dict
+++ b/.spell-dict
@@ -94,6 +94,7 @@ prepended
 preprocessor
 preprocessors
 Pygments
+PyMdown
 PyPI
 PyPy
 PYTHONPATH

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ See the [Contributing Guide](contributing.md) for details.
 ### Fixed
 
 * Fix `SetextHeaderProcessor` regex to prevent mixed `=` and `-` chars in setext-style headers (#1606).
+* Officially document all included extensions as being in maintenance mode.
 
 ## [3.10.2] - 2026-02-09
 

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -13,7 +13,7 @@ The Abbreviations extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/abbreviations.md
+++ b/docs/extensions/abbreviations.md
@@ -11,6 +11,19 @@ Specifically, any defined abbreviation is wrapped in  an `<abbr>` tag.
 
 The Abbreviations extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Syntax
 ------
 

--- a/docs/extensions/admonition.md
+++ b/docs/extensions/admonition.md
@@ -14,7 +14,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/admonition.md
+++ b/docs/extensions/admonition.md
@@ -12,6 +12,22 @@ This extension is included in the standard Markdown library.
 
 [rST]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#specific-admonitions
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+    We recommend [PyMdown Admonition] as an actively developed alternative. 
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+[PyMdown Admonition]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/admonition/
+
 Syntax
 ------
 

--- a/docs/extensions/attr_list.md
+++ b/docs/extensions/attr_list.md
@@ -9,6 +9,19 @@ HTML elements in markdown's output.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 ## Syntax
 
 The basic syntax was inspired by Maruku's Attribute Lists feature (see [web archive][Maruku]).

--- a/docs/extensions/attr_list.md
+++ b/docs/extensions/attr_list.md
@@ -11,7 +11,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/code_hilite.md
+++ b/docs/extensions/code_hilite.md
@@ -13,7 +13,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/code_hilite.md
+++ b/docs/extensions/code_hilite.md
@@ -11,6 +11,22 @@ Python-Markdown code blocks using [Pygments][].
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+    We recommend [Highlight] as an actively developed alternative. 
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+[Highlight]: https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
+
 ## Setup
 
 ### Step 1: Download and Install Pygments

--- a/docs/extensions/definition_lists.md
+++ b/docs/extensions/definition_lists.md
@@ -13,7 +13,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/definition_lists.md
+++ b/docs/extensions/definition_lists.md
@@ -11,6 +11,22 @@ Markdown documents.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+    We recommend [PyMdown Definition] as an actively developed alternative. 
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+[PyMdown Definition]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/definition/
+
 Syntax
 ------
 

--- a/docs/extensions/extra.md
+++ b/docs/extensions/extra.md
@@ -22,7 +22,7 @@ supported extensions are included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/extra.md
+++ b/docs/extensions/extra.md
@@ -20,6 +20,19 @@ The supported extensions include:
 See each individual extension for syntax documentation. Extra and all its
 supported extensions are included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 ## Usage
 
 From the Python interpreter:

--- a/docs/extensions/fenced_code_blocks.md
+++ b/docs/extensions/fenced_code_blocks.md
@@ -9,6 +9,21 @@ indented code blocks.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+    We recommend [SuperFences] as an actively developed alternative.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 ## Syntax
 
 Fenced Code Blocks are defined using the syntax originally established in [PHP Markdown Extra][php] and popularized by

--- a/docs/extensions/fenced_code_blocks.md
+++ b/docs/extensions/fenced_code_blocks.md
@@ -11,7 +11,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/footnotes.md
+++ b/docs/extensions/footnotes.md
@@ -13,7 +13,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/footnotes.md
+++ b/docs/extensions/footnotes.md
@@ -11,6 +11,19 @@ documents.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Syntax
 ------
 

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -26,12 +26,12 @@ See the [Command Line docs](../cli.md) or use the `--help` option for more detai
     If you would like to write your own extensions, see the
     [Extension API](api.md) for details.
 
-Officially Supported Extensions
--------------------------------
+Included Extensions
+-------------------
 
 The extensions listed below are included with (at least) the most recent release
 and are officially supported by Python-Markdown. Any documentation is
-maintained here and all bug reports should be made to the project. If you
+maintained here and all bug reports should be made to this project. If you
 have a typical install of Python-Markdown, these extensions are already
 available to you using the "Entry Point" name listed in the second column below.
 
@@ -75,7 +75,23 @@ Extension                          | Entry Point    | Dot Notation
 [Table of Contents]: toc.md
 [WikiLinks]: wikilinks.md
 
-Third Party Extensions
+!!! Note
+
+    All of the included extensions are in __maintenance mode__. We will
+    continue to fix bugs and keep them up-to-date with the core parser, but
+    no new features or changes in behavior will be made. Additionally, no new
+    extensions will be added to the project. All future extension development
+    should happen in third-party extensions. If you need a feature that seems
+    like it would be a good addition to one of the included extensions, then
+    you have three options (1) find an existing [third-party extension] which
+    meets your needs, (2) [build your own extension], or (3) fork the
+    relevant included extension (pursuant to its licensing requirements) and
+    maintain it as a third-party extension.
+
+[third-party extension]: #third-party-extensions
+[build your own extension]: api.md
+
+Third-Party Extensions
 ----------------------
 
 Various individuals and/or organizations have developed extensions which they

--- a/docs/extensions/legacy_attrs.md
+++ b/docs/extensions/legacy_attrs.md
@@ -11,6 +11,19 @@ users have never made use of the syntax and it has been deprecated in favor of
 [Attribute Lists](attr_list.md). This extension restores the legacy behavior for
 users who have existing documents which use the syntax.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 ## Syntax
 
 Attributes are defined by including the following within the element you wish to

--- a/docs/extensions/legacy_attrs.md
+++ b/docs/extensions/legacy_attrs.md
@@ -13,7 +13,7 @@ users who have existing documents which use the syntax.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/legacy_em.md
+++ b/docs/extensions/legacy_em.md
@@ -17,6 +17,19 @@ of the reference implementation. Therefore, this extension can be used to better
 match the reference implementation. With the extension enabled, the above input
 would result in this output: `<em>connected</em>words_`.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 ## Usage
 
 See [Extensions](index.md) for general extension usage. Use `legacy_em` as the

--- a/docs/extensions/legacy_em.md
+++ b/docs/extensions/legacy_em.md
@@ -19,7 +19,7 @@ would result in this output: `<em>connected</em>words_`.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/md_in_html.md
+++ b/docs/extensions/md_in_html.md
@@ -6,6 +6,22 @@ title: Markdown in HTML Extension
 
 An extension that parses Markdown inside of HTML tags.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+    We recommend [PyMdown HTML] as an alternative solution. 
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+[PyMdown HTML]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/html/
+
 ## Syntax
 
 By default, Markdown ignores any content within a raw HTML block-level element. With the `md-in-html` extension

--- a/docs/extensions/md_in_html.md
+++ b/docs/extensions/md_in_html.md
@@ -8,7 +8,7 @@ An extension that parses Markdown inside of HTML tags.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/meta_data.md
+++ b/docs/extensions/meta_data.md
@@ -18,7 +18,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/meta_data.md
+++ b/docs/extensions/meta_data.md
@@ -16,6 +16,19 @@ This extension is included in the standard Markdown library.
 
 [MultiMarkdown]: https://fletcherpenney.net/multimarkdown/#metadata
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Syntax
 ------
 

--- a/docs/extensions/nl2br.md
+++ b/docs/extensions/nl2br.md
@@ -11,6 +11,19 @@ hard breaks; like StackOverflow and [GitHub][] flavored Markdown do.
 
 [Github]: https://github.github.com/github-flavored-markdown/
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Example
 -------
 

--- a/docs/extensions/nl2br.md
+++ b/docs/extensions/nl2br.md
@@ -13,7 +13,7 @@ hard breaks; like StackOverflow and [GitHub][] flavored Markdown do.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/sane_lists.md
+++ b/docs/extensions/sane_lists.md
@@ -13,7 +13,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/sane_lists.md
+++ b/docs/extensions/sane_lists.md
@@ -11,6 +11,19 @@ to be less surprising.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Syntax
 ------
 

--- a/docs/extensions/smarty.md
+++ b/docs/extensions/smarty.md
@@ -52,7 +52,7 @@ extension_configs = {
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/smarty.md
+++ b/docs/extensions/smarty.md
@@ -50,6 +50,19 @@ extension_configs = {
 [SmartyPants]: https://pythonhosted.org/smartypants/
 [CodeHilite]: code_hilite.md
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Usage
 -----
 

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -10,6 +10,19 @@ The Tables extension adds the ability to create tables in Markdown documents.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Syntax
 ------
 

--- a/docs/extensions/tables.md
+++ b/docs/extensions/tables.md
@@ -12,7 +12,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -13,7 +13,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/toc.md
+++ b/docs/extensions/toc.md
@@ -11,6 +11,19 @@ document and adds it into the resulting HTML document.
 
 This extension is included in the standard Markdown library.
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 Syntax
 ------
 

--- a/docs/extensions/wikilinks.md
+++ b/docs/extensions/wikilinks.md
@@ -13,7 +13,7 @@ This extension is included in the standard Markdown library.
 
 !!! Note
 
-    This extension is in __maintanence mode__.  We will continue to fix bugs
+    This extension is in __maintenance mode__.  We will continue to fix bugs
     and keep it up-to-date with the core parser, but no new features or
     changes in behavior will be made. If you need a feature that this
     extension does not offer, then you have three options (1) find an

--- a/docs/extensions/wikilinks.md
+++ b/docs/extensions/wikilinks.md
@@ -11,6 +11,19 @@ This extension is included in the standard Markdown library.
 
 [WikiLinks]: https://en.wikipedia.org/wiki/Wikilink
 
+!!! Note
+
+    This extension is in __maintanence mode__.  We will continue to fix bugs
+    and keep it up-to-date with the core parser, but no new features or
+    changes in behavior will be made. If you need a feature that this
+    extension does not offer, then you have three options (1) find an
+    existing [third-party extension] which meets your needs, (2) [build your
+    own extension], or (3) fork this extension (pursuant to its licensing
+    requirements) and maintain it as a third-party extension.
+
+[third-party extension]: index.md#third-party-extensions
+[build your own extension]: api.md
+
 ## Syntax
 
 A ``[[bracketed]]`` word is any combination of  upper or lower case letters,


### PR DESCRIPTION
This has been the de facto policy for some time. We are now officially documenting it. Relates to #1612.

Some recommendations for alternative extensions have been included. If anyone would like to include other recommendations, I am open to suggestions.

#### AI Assistance Disclosure
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://python-markdown.github.io/contributing/).
- [ ] N/A The code follows the [Code Style Guide](https://python-markdown.github.io/contributing/#code-style-guide).
- [x] The commit message follows the [Commit Message Style Guide](https://python-markdown.github.io/contributing/#commit-message-style-guide).
- [x] I have added or updated relevant docs, including release notes if applicable which follow the [Documentation Style Guide](Documentation Style Guide).
- [ ] N/A I have added or updated relevant tests.
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
