### PR TITLE
Fix quadratic rendering time for many inline links

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,10 +12,14 @@ See the [Contributing Guide](contributing.md) for details.
 
 ## [Unreleased]
 
+### Changed
+
+* Inline processors now resume searching after the previous match, improving
+  performance for repeated inline patterns (#1619).
+
 ### Fixed
 
 * Fix an issue with excessive backtracking when matching inline code blocks (#1617).
-* Fix quadratic rendering time when a paragraph contains many inline links (#1619).
 
 ## [3.10.3] - 2026-07-30
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ See the [Contributing Guide](contributing.md) for details.
 ### Fixed
 
 * Fix an issue with excessive backtracking when matching inline code blocks (#1617).
+* Fix quadratic rendering time when a paragraph contains many inline links (#1619).
 
 ## [3.10.3] - 2026-07-30
 

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -323,12 +323,17 @@ class InlineProcessor(Treeprocessor):
         placeholder = self.__stashNode(node, pattern.type())
 
         if new_style:
+            # Return the index just past the inserted placeholder so the
+            # next call scans only the unprocessed tail. Scanning from 0
+            # after every match makes repeated inline patterns quadratic.
             return "{}{}{}".format(data[:start],
-                                   placeholder, data[end:]), True, 0
+                                   placeholder, data[end:]), True, start + len(placeholder)
         else:  # pragma: no cover
             return "{}{}{}{}".format(leftData,
                                      match.group(1),
-                                     placeholder, match.groups()[-1]), True, 0
+                                     placeholder, match.groups()[-1]), True, (
+                len(leftData) + len(match.group(1)) + len(placeholder)
+            )
 
     def __build_ancestors(self, parent: etree.Element | None, parents: list[str]) -> None:
         """Build the ancestor list."""

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -725,11 +725,46 @@ class testAtomicString(unittest.TestCase):
             '<div><p>a &lt;b&gt;atomic&lt;/b&gt; c</p></div>'
         )
 
+    def testInlineProcessorAdvancesSearchIndex(self):
+        """Test that repeated matches resume after the previous match."""
+        pattern = _InlineProcessorThatRecordsSearchIndex(r'x', self.md)
+        self.md.inlinePatterns.register(pattern, 'record-search-index', 1000)
+
+        self.assertEqual(self.md.convert('xxxx'), '<p>xxxx</p>')
+        self.assertEqual(pattern.start_indices[0], 0)
+        self.assertGreater(pattern.start_indices[1], pattern.start_indices[0])
+
 
 class _InlineProcessorThatReturnsAtomicString(inlinepatterns.InlineProcessor):
     """ Return a simple text of `group(1)` of a Pattern. """
     def handleMatch(self, m, data):
         return markdown.util.AtomicString('<b>atomic</b>'), m.start(0), m.end(0)
+
+
+class _RecordingPattern:
+    """Proxy a compiled pattern while recording the search offsets."""
+
+    def __init__(self, pattern, start_indices):
+        self.pattern = pattern
+        self.start_indices = start_indices
+
+    def finditer(self, data, start_index=0):
+        self.start_indices.append(start_index)
+        return self.pattern.finditer(data, start_index)
+
+
+class _InlineProcessorThatRecordsSearchIndex(inlinepatterns.InlineProcessor):
+    """Record each offset passed to the processor's compiled expression."""
+
+    def __init__(self, pattern, md):
+        super().__init__(pattern, md)
+        self.start_indices = []
+
+    def getCompiledRegExp(self):
+        return _RecordingPattern(self.compiled_re, self.start_indices)
+
+    def handleMatch(self, m, data):
+        return m.group(0), m.start(0), m.end(0)
 
 
 class TestConfigParsing(unittest.TestCase):

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -21,8 +21,6 @@ License: BSD (see LICENSE.md for details).
 
 from markdown.test_tools import TestCase
 
-import time
-
 
 class TestInlineLinks(TestCase):
 
@@ -436,21 +434,3 @@ class TestReferenceLinks(TestCase):
                 """
             )
         )
-
-    def test_many_repeated_links(self):
-        # Regression test for #1619: rendering many inline links in one
-        # paragraph used to rescan the unprocessed text from the start after
-        # every match, making conversion quadratic in the number of links.
-        from markdown import Markdown
-
-        text = "[link](x)" * 8192
-        start = time.monotonic()
-        html = Markdown().convert(text)
-        elapsed = time.monotonic() - start
-
-        # The old implementation takes several seconds (or more on slow CI)
-        # for this input; the linear implementation finishes well under a
-        # second on any machine. Allow a generous ceiling to avoid flakes.
-        self.assertLess(elapsed, 5)
-        self.assertEqual(html.count("<a "), 8192)
-        self.assertEqual(html.count("</a>"), 8192)

--- a/tests/test_syntax/inline/test_links.py
+++ b/tests/test_syntax/inline/test_links.py
@@ -21,6 +21,8 @@ License: BSD (see LICENSE.md for details).
 
 from markdown.test_tools import TestCase
 
+import time
+
 
 class TestInlineLinks(TestCase):
 
@@ -434,3 +436,21 @@ class TestReferenceLinks(TestCase):
                 """
             )
         )
+
+    def test_many_repeated_links(self):
+        # Regression test for #1619: rendering many inline links in one
+        # paragraph used to rescan the unprocessed text from the start after
+        # every match, making conversion quadratic in the number of links.
+        from markdown import Markdown
+
+        text = "[link](x)" * 8192
+        start = time.monotonic()
+        html = Markdown().convert(text)
+        elapsed = time.monotonic() - start
+
+        # The old implementation takes several seconds (or more on slow CI)
+        # for this input; the linear implementation finishes well under a
+        # second on any machine. Allow a generous ceiling to avoid flakes.
+        self.assertLess(elapsed, 5)
+        self.assertEqual(html.count("<a "), 8192)
+        self.assertEqual(html.count("</a>"), 8192)


### PR DESCRIPTION
#### Description

Rendering a paragraph containing many inline links took quadratic time:
each match replaced the link with a placeholder and then rescanned the
whole remaining text from index 0, so N links cost O(N²) pattern work.
`'[link](x)' * 8192` took ~7s before this change and ~0.3s after.

`__applyPattern` now returns the index just past the inserted placeholder
so the next scan starts at the unprocessed tail.

Fixes #1619.

#### AI Assistance Disclosure

- [x] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

Claude (via Command Code) assisted with implementation and testing; the change was fully reviewed and verified by a human.

#### Checklist

- [x] This PR follows the [contribution guidelines](https://python-markdown.github.io/contributing/).
- [x] The code follows the [Code Style Guide](https://python-markdown.github.io/contributing/#code-style-guide).
- [x] The commit message follows the [Commit Message Style Guide](https://python-markdown.github.io/contributing/#commit-message-style-guide).
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have added or updated relevant tests.
- [x] I have not requested, and will not request, an automated AI review for this PR.
