### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,6 +32,8 @@ jobs:
             python-version: '3.13'
           - tox-env: py314
             python-version: '3.14'
+          - tox-env: py315
+            python-version: '3.15'
           - tox-env: pypy310
             python-version: pypy-3.10
           - tox-env: pypy311

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,10 +20,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        tox-env: [py310, py311, py312, py313, py314, pypy310, pypy311, pygments]
+        tox-env: [py311, py312, py313, py314, pypy311, pygments]
         include:
-          - tox-env: py310
-            python-version: '3.10'
           - tox-env: py311
             python-version: '3.11'
           - tox-env: py312
@@ -34,8 +32,6 @@ jobs:
             python-version: '3.14'
           - tox-env: py315
             python-version: '3.15'
-          - tox-env: pypy310
-            python-version: pypy-3.10
           - tox-env: pypy311
             python-version: pypy-3.11
           - tox-env: pygments

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 * Inline processors now resume searching after the previous match, improving
   performance for repeated inline patterns (#1619).
+* Officially support Python 3.15
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,7 @@ See the [Contributing Guide](contributing.md) for details.
 
 * Inline processors now resume searching after the previous match, improving
   performance for repeated inline patterns (#1619).
-* Officially support Python 3.15
+* Officially support Python 3.15 and drop support for Python 3.10
 
 ### Fixed
 

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -103,10 +103,7 @@ RTL_BIDI_RANGES = (
 @lru_cache(maxsize=None)
 def get_installed_extensions():
     """ Return all entry_points in the `markdown.extensions` group. """
-    if sys.version_info >= (3, 10):
-        from importlib import metadata
-    else:  # `<PY310` use backport
-        import importlib_metadata as metadata
+    from importlib import metadata
     # Only load extension entry_points once.
     return metadata.entry_points(group='markdown.extensions')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,13 @@ maintainers = [
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE.md"]
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 keywords = ['markdown', 'markdown-parser', 'python-markdown', 'markdown-to-html']
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: 3.15',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{310, 311, 312, 313, 314, 315}, pypy{310, 311}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{311, 312, 313, 314, 315}, pypy{311}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{310, 311, 312, 313, 314}, pypy{310, 311}, pygments, flake8, checkspelling, pep517check, checklinks
+envlist = py{310, 311, 312, 313, 314, 315}, pypy{310, 311}, pygments, flake8, checkspelling, pep517check, checklinks
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
#### Description
Python 3.15.0 rc1 is out. "release candidate" means that there will be no more ABI changes, and the API over all is now stable. It is now pretty much safe to test against and to specify support for it.

This PR adds Python 3.15 support to `Markdown` by enabling testing on it and adding a PyPI classifier.

#### AI Assistance Disclosure
<!-- Please select exactly ONE of the following: -->
- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.

#### Checklist
- [x] This PR follows the [contribution guidelines](https://python-markdown.github.io/contributing/).
- [x] The code follows the [Code Style Guide](https://python-markdown.github.io/contributing/#code-style-guide).
- [x] The commit message follows the [Commit Message Style Guide](https://python-markdown.github.io/contributing/#commit-message-style-guide).
- [x] I have added or updated relevant docs, including release notes if applicable which follow the [Documentation Style Guide](Documentation Style Guide).
- [ ] I have added or updated relevant tests. — not applicable
- [x] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->
